### PR TITLE
feat(homeserver): add a subscribe query param to /events/ endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1741,6 +1741,7 @@ dependencies = [
  "reqwest",
  "serde",
  "tokio",
+ "tokio-stream",
  "toml",
  "tower-cookies",
  "tower-http",
@@ -2554,6 +2555,18 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1730,6 +1730,7 @@ dependencies = [
  "clap",
  "dirs-next",
  "flume",
+ "futures",
  "futures-util",
  "heed",
  "hex",

--- a/pubky-homeserver/Cargo.toml
+++ b/pubky-homeserver/Cargo.toml
@@ -29,6 +29,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 url = "2.5.2"
 tokio-stream = { version = "0.1.16", features = ["sync"] }
+futures = "0.3.31"
 
 [dev-dependencies]
 reqwest = "0.12.8"

--- a/pubky-homeserver/Cargo.toml
+++ b/pubky-homeserver/Cargo.toml
@@ -28,6 +28,7 @@ tower-http = { version = "0.5.2", features = ["cors", "trace"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 url = "2.5.2"
+tokio-stream = { version = "0.1.16", features = ["sync"] }
 
 [dev-dependencies]
 reqwest = "0.12.8"

--- a/pubky-homeserver/src/database/tables/events.rs
+++ b/pubky-homeserver/src/database/tables/events.rs
@@ -33,7 +33,7 @@ impl Event {
     }
 
     pub fn serialize(&self) -> Vec<u8> {
-        to_allocvec(self).expect("Session::serialize")
+        to_allocvec(self).expect("Event::serialize")
     }
 
     pub fn deserialize(bytes: &[u8]) -> core::result::Result<Self, postcard::Error> {
@@ -56,6 +56,10 @@ impl Event {
             Event::Put(_) => "PUT",
             Event::Delete(_) => "DEL",
         }
+    }
+
+    pub fn into_event_line(self) -> String {
+        format!("{} {}", self.operation(), self.url())
     }
 }
 
@@ -85,10 +89,9 @@ impl DB {
                 Some((timestamp, event_bytes)) => {
                     let event = Event::deserialize(event_bytes)?;
 
-                    let line = format!("{} {}", event.operation(), event.url());
                     next_cursor = timestamp.to_string();
 
-                    result.push(line);
+                    result.push(event.into_event_line());
                 }
                 None => break,
             };

--- a/pubky-homeserver/src/extractors.rs
+++ b/pubky-homeserver/src/extractors.rs
@@ -81,6 +81,7 @@ pub struct ListQueryParams {
     pub cursor: Option<String>,
     pub reverse: bool,
     pub shallow: bool,
+    pub subscribe: bool,
 }
 
 #[async_trait]
@@ -112,12 +113,14 @@ where
                     Some(c.to_string())
                 }
             });
+        let subscribe = params.contains_key("subscribe");
 
         Ok(ListQueryParams {
             reverse,
             shallow,
             limit,
             cursor,
+            subscribe,
         })
     }
 }

--- a/pubky-homeserver/src/routes/feed.rs
+++ b/pubky-homeserver/src/routes/feed.rs
@@ -1,12 +1,13 @@
 use axum::{
     body::Body,
     extract::State,
-    http::{header, Response, StatusCode},
+    http::{header, HeaderMap, Response, StatusCode},
     response::{
         sse::{Event, Sse},
         IntoResponse,
     },
 };
+use futures::stream;
 use tokio_stream::{wrappers::BroadcastStream, StreamExt};
 
 use pubky_common::timestamp::Timestamp;
@@ -19,26 +20,9 @@ use crate::{
 
 pub async fn feed(
     State(state): State<AppState>,
+    headers: HeaderMap,
     params: ListQueryParams,
 ) -> Result<impl IntoResponse> {
-    if params.subscribe {
-        let rx = state.events.subscribe();
-
-        let stream = BroadcastStream::new(rx).filter_map(|result| match result {
-            Ok((timestamp, event)) => Some(Ok::<Event, String>(
-                Event::default()
-                    .id(timestamp.to_string())
-                    .event(event.operation())
-                    .data(event.url()),
-            )),
-            Err(_) => None,
-        });
-
-        return Ok(Sse::new(stream)
-            .keep_alive(Default::default())
-            .into_response());
-    }
-
     if let Some(ref cursor) = params.cursor {
         if Timestamp::try_from(cursor.to_string()).is_err() {
             Err(Error::new(
@@ -48,7 +32,57 @@ pub async fn feed(
         }
     }
 
-    let result = state.db.list_events(params.limit, params.cursor)?;
+    if params.subscribe {
+        // Get the cursor from the last-event-id header or cursor param.
+        let cursor = headers
+            .get("last-event-id")
+            .and_then(|h| h.to_str().ok().map(|s| s.to_string()))
+            .or(params.cursor);
+
+        let initial_events = stream::iter(if let Some(cursor) = cursor {
+            state
+                .db
+                .list_events(params.limit, Some(cursor))?
+                .iter()
+                .map(|(timestamp, event)| {
+                    Ok(Event::default()
+                        .id(timestamp)
+                        .event(event.operation())
+                        .data(event.url()))
+                })
+                .collect::<Vec<_>>()
+        } else {
+            vec![]
+        });
+
+        let live_events =
+            BroadcastStream::new(state.events.subscribe()).filter_map(|result| match result {
+                Ok((timestamp, event)) => Some(Ok::<Event, String>(
+                    Event::default()
+                        .id(timestamp.to_string())
+                        .event(event.operation())
+                        .data(event.url()),
+                )),
+                Err(_) => None,
+            });
+
+        let combined_stream = initial_events.chain(live_events);
+
+        return Ok(Sse::new(combined_stream)
+            .keep_alive(Default::default())
+            .into_response());
+    }
+
+    let events = state.db.list_events(params.limit, params.cursor)?;
+
+    let mut result = events
+        .iter()
+        .map(|(_, e)| e.to_event_line())
+        .collect::<Vec<_>>();
+
+    if let Some(last) = events.last() {
+        result.push(format!("cursor: {}", last.0))
+    };
 
     Ok(Response::builder()
         .status(StatusCode::OK)

--- a/pubky-homeserver/src/routes/feed.rs
+++ b/pubky-homeserver/src/routes/feed.rs
@@ -2,8 +2,13 @@ use axum::{
     body::Body,
     extract::State,
     http::{header, Response, StatusCode},
-    response::IntoResponse,
+    response::{
+        sse::{Event, Sse},
+        IntoResponse,
+    },
 };
+use tokio_stream::{wrappers::BroadcastStream, StreamExt};
+
 use pubky_common::timestamp::Timestamp;
 
 use crate::{
@@ -16,6 +21,24 @@ pub async fn feed(
     State(state): State<AppState>,
     params: ListQueryParams,
 ) -> Result<impl IntoResponse> {
+    if params.subscribe {
+        let rx = state.events.subscribe();
+
+        let stream = BroadcastStream::new(rx).filter_map(|result| match result {
+            Ok((timestamp, event)) => Some(Ok::<Event, String>(
+                Event::default()
+                    .id(timestamp.to_string())
+                    .event(event.operation())
+                    .data(event.url()),
+            )),
+            Err(_) => None,
+        });
+
+        return Ok(Sse::new(stream)
+            .keep_alive(Default::default())
+            .into_response());
+    }
+
     if let Some(ref cursor) = params.cursor {
         if Timestamp::try_from(cursor.to_string()).is_err() {
             Err(Error::new(

--- a/pubky-homeserver/src/routes/feed.rs
+++ b/pubky-homeserver/src/routes/feed.rs
@@ -39,6 +39,8 @@ pub async fn feed(
             .and_then(|h| h.to_str().ok().map(|s| s.to_string()))
             .or(params.cursor);
 
+        let keep_alive = stream::once(async { Ok(Event::default().comment("keep-alive")) });
+
         let initial_events = stream::iter(if let Some(cursor) = cursor {
             state
                 .db
@@ -66,7 +68,7 @@ pub async fn feed(
                 Err(_) => None,
             });
 
-        let combined_stream = initial_events.chain(live_events);
+        let combined_stream = keep_alive.chain(initial_events).chain(live_events);
 
         return Ok(Sse::new(combined_stream)
             .keep_alive(Default::default())


### PR DESCRIPTION
This PR adds a [Server-sent events](https://html.spec.whatwg.org/multipage/server-sent-events.html) for the `/events/` endpoint, accessible by adding the query param `?subscribe`. 

This is a replacement for short polling that Nexus is currently hammering the Homeserver with. After it is used successfully, we can start add rate limits.

The idea here is that at the beginning of sync, Nexus should keep making cursor pagination requests, until it gets no more responses.

Once you run out of events if you have a `cursor` from last events, you can pass it into the [EventSource](https://developer.mozilla.org/en-US/docs/Web/API/EventSource) URL as a query param as usual, that will help the server catch you up with any events that happened between the last GET request and the start of this events live feed.

If you put the testnet url in browser, you should see something like this:  `http://localhost:15411/events/?subscribe&cursor=0032C29SSF87E` after running some tests to populate the testnet homeserver, you should see something like this:

```
:

id: 0032C22KNFFFP
event: PUT
data: pubky://tiz8of9w7hgk3ikxfrf9i6x73u36jrxq8z1rgjo3m4outm4syfny/pub/example.com/arbitrary

id: 0032C22KNGGFY
event: DEL
data: pubky://tiz8of9w7hgk3ikxfrf9i6x73u36jrxq8z1rgjo3m4outm4syfny/pub/example.com/arbitrary
```

The empty `:` is a keep alive message, every 15 seconds, which you shouldn't worry about.

The `id` will help the `EventSource` class/struct to reconnect and start from after that event.

The `event` is the operation.

And finally the `data` is the URL.

## Test status
I tested both commits manually, but there is no unit tests for now.

## Rust Usage

Haven't tested this, but check this implementation, or implement it from scratch with Reqwest (not really use good client with proper reconnects).

```rust
use eventsource_client::Client;
use futures_util::StreamExt;
use tokio;

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let client = Client::for_url("http://localhost:15411/events/?subscribe&cursor=0032C29SSF87E")?;
    let mut stream = client.stream();

    while let Some(event) = stream.next().await {
        match event {
            Ok(event) => println!("Received SSE event: {:?}", event),
            Err(e) => eprintln!("Error receiving SSE: {:?}", e),
        }
    }
    Ok(())
}
```