### PR TITLE
fix: return an error for non-2xx responses using error_for_status()

### DIFF
--- a/pubky/src/shared/auth.rs
+++ b/pubky/src/shared/auth.rs
@@ -143,10 +143,12 @@ impl PubkyClient {
         path_segments.push(&channel_id);
         drop(path_segments);
 
-        self.request(Method::POST, callback)
+        let response = self.request(Method::POST, callback)
             .body(encrypted_token)
             .send()
             .await?;
+
+        response.error_for_status()?;
 
         Ok(())
     }

--- a/pubky/src/shared/auth.rs
+++ b/pubky/src/shared/auth.rs
@@ -143,7 +143,8 @@ impl PubkyClient {
         path_segments.push(&channel_id);
         drop(path_segments);
 
-        let response = self.request(Method::POST, callback)
+        let response = self
+            .request(Method::POST, callback)
             .body(encrypted_token)
             .send()
             .await?;


### PR DESCRIPTION
- Previously, the request function returned `Ok(())` even if the HTTP response status was an error (4xx/5xx). By adding `response.error_for_status()?`, we correctly propagate HTTP errors rather than masking them, ensuring that timeouts and other non-2xx status codes produce an error as expected.