### PR TITLE
fix: ARM (Apple Silicon) build support in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,10 @@
 # ========================
 FROM rust:1.82.0-alpine3.20 AS builder
 
+# Build platform argument (x86_64 or aarch64) (default: x86_64)
+ARG TARGETARCH=x86_64
+RUN echo "TARGETARCH: $TARGETARCH"
+
 # Install build dependencies, including static OpenSSL libraries
 RUN apk add --no-cache \
     musl-dev \
@@ -12,13 +16,24 @@ RUN apk add --no-cache \
     build-base \
     curl
 
+# Install cross-compiler toolchain only for ARM (Apple Silicon)
+RUN if [ "$TARGETARCH" = "aarch64" ]; then \
+        wget -qO- https://musl.cc/aarch64-linux-musl-cross.tgz | tar -xz -C /usr/local && \
+        echo "/usr/local/aarch64-linux-musl-cross/bin" > /tmp/musl_cross_path; \
+    else \
+        echo "" > /tmp/musl_cross_path; \
+    fi
+
+# Set PATH only if we installed the cross compiler (will be empty string for x86)
+ENV PATH="$(cat /tmp/musl_cross_path):$PATH"
+
 # Set environment variables for static linking with OpenSSL
 ENV OPENSSL_STATIC=yes
 ENV OPENSSL_LIB_DIR=/usr/lib
 ENV OPENSSL_INCLUDE_DIR=/usr/include
 
 # Add the MUSL target for static linking
-RUN rustup target add x86_64-unknown-linux-musl
+RUN rustup target add $TARGETARCH-unknown-linux-musl
 
 # Set the working directory
 WORKDIR /usr/src/app
@@ -30,21 +45,23 @@ COPY Cargo.toml Cargo.lock ./
 COPY . .
 
 # Build the project in release mode for the MUSL target
-RUN cargo build --release --bin pubky-homeserver --target x86_64-unknown-linux-musl
+RUN cargo build --release --bin pubky-homeserver --target $TARGETARCH-unknown-linux-musl
 
 # Strip the binary to reduce size
-RUN strip target/x86_64-unknown-linux-musl/release/pubky-homeserver
+RUN strip target/$TARGETARCH-unknown-linux-musl/release/pubky-homeserver
 
 # ========================
 # Runtime Stage
 # ========================
 FROM alpine:3.20
 
+ARG TARGETARCH=x86_64
+
 # Install runtime dependencies (only ca-certificates)
 RUN apk add --no-cache ca-certificates
 
 # Copy the compiled binary from the builder stage
-COPY --from=builder /usr/src/app/target/x86_64-unknown-linux-musl/release/pubky-homeserver /usr/local/bin/homeserver
+COPY --from=builder /usr/src/app/target/$TARGETARCH-unknown-linux-musl/release/pubky-homeserver /usr/local/bin/homeserver
 
 # Set the working directory
 WORKDIR /usr/local/bin

--- a/examples/authz/3rd-party-app/src/pubky-auth-widget.js
+++ b/examples/authz/3rd-party-app/src/pubky-auth-widget.js
@@ -2,7 +2,7 @@ import { LitElement, css, html } from 'lit'
 import { createRef, ref } from 'lit/directives/ref.js';
 import QRCode from 'qrcode'
 
-const DEFAULT_HTTP_RELAY = "https://demo.httprelay.io/link"
+const DEFAULT_HTTP_RELAY = "https://httprelay.staging.pubky.app/link/"
 
 /**
  */
@@ -19,7 +19,7 @@ export class PubkyAuthWidget extends LitElement {
        * GET request made for `${realy url}/${channelID}`
        *
        * If no relay is passed, the widget will use a default relay:
-       * https://demo.httprelay.io/link
+       * https://httprelay.staging.pubky.app/link/
        */
       relay: { type: String },
       /**

--- a/pubky/pkg/test/auth.js
+++ b/pubky/pkg/test/auth.js
@@ -38,7 +38,7 @@ test("3rd party signin", async (t) => {
   let capabilities = "/pub/pubky.app/:rw,/pub/foo.bar/file:r";
   let client = PubkyClient.testnet();
   let [pubkyauth_url, pubkyauthResponse] = client
-    .authRequest("https://demo.httprelay.io/link", capabilities);
+    .authRequest("https://httprelay.staging.pubky.app/link/", capabilities);
 
   if (globalThis.document) {
     // Skip `sendAuthToken` in browser

--- a/pubky/src/shared/auth.rs
+++ b/pubky/src/shared/auth.rs
@@ -280,7 +280,7 @@ mod tests {
             "/pub/pubky.app/:rw,/pub/foo.bar/file:r".try_into().unwrap();
         let client = PubkyClient::test(&testnet);
         let (pubkyauth_url, pubkyauth_response) = client
-            .auth_request("https://demo.httprelay.io/link", &capabilities)
+            .auth_request("https://httprelay.staging.pubky.app/link/", &capabilities)
             .unwrap();
 
         // Authenticator side


### PR DESCRIPTION
Still defaults to x86. Pass build arg when using ARM architecture: `docker build --build-arg TARGETARCH=aarch64 .`