### PR TITLE
fix(tests): update apis on docs

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -20,7 +20,7 @@ anyhow = "1.0.95"
 base64 = "0.22.1"
 clap = { version = "4.5.29", features = ["derive"] }
 pubky = { path = "../pubky" }
-pubky-common = { version = "0.3.0", path = "../pubky-common" }
+pubky-common = { path = "../pubky-common" }
 reqwest = "0.12.12"
 rpassword = "7.3.1"
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }

--- a/pubky-homeserver/README.md
+++ b/pubky-homeserver/README.md
@@ -9,18 +9,18 @@ A pubky-core homeserver that acts as users' agent on the Internet, providing dat
 You can use the Homeserver as a library in other crates/binaries or for testing purposes.
 
 ```rust
+use anyhow::Result;
+use pubky_homeserver::Homeserver;
 
 #[tokio::main]
-async fn main() -> Result<()> {
-    Homeserver::builder().run().await?
+async fn main() {
+    let homeserver = unsafe {
+        Homeserver::builder().run().await.unwrap()
+    };
 
-    tokio::signal::ctrl_c().await?;
+    println!("Shutting down Homeserver");
 
-    tracing::info!("Shutting down Homeserver");
-
-    server.shutdown();
-
-    Ok(())
+    homeserver.shutdown();
 }
 ```
 

--- a/pubky/README.md
+++ b/pubky/README.md
@@ -5,46 +5,48 @@ Rust implementation implementation of [Pubky](https://github.com/pubky/pubky-cor
 ## Quick Start
 
 ```rust
-use pkarr::mainline::Testnet;
-use pkarr::Keypair;
-use pubky_homeserver::Homeserver;
-use pubky::Client;
+use pubky_testnet::Testnet;
+use pubky::{Client, Keypair};
 
 #[tokio::main]
 async fn main () {
   // Mainline Dht testnet and a temporary homeserver for unit testing.
-  let testnet = Testnet::new(10);
-  let server = Homeserver::run_test(&testnet).await.unwrap();
+  let testnet = Testnet::run_with_hardcoded_configurations().await.unwrap();
+  let homeserver = testnet.run_homeserver().await.unwrap();
 
-  let client = Client::test(&testnet);
+  let client = Client::builder().testnet().build().unwrap();
 
   // Uncomment the following line instead if you are not just testing.
-  // let client Client::new().unwrap(); 
+  // let client Client::builder().build().unwrap();
 
   // Generate a keypair
   let keypair = Keypair::random();
 
   // Signup to a Homeserver
   let keypair = Keypair::random();
-  client.signup(&keypair, &server.public_key()).await.unwrap();
+  client.signup(&keypair, &homeserver.public_key()).await.unwrap();
 
   // Write data.
   let url = format!("pubky://{}/pub/foo.txt", keypair.public_key());
   let url = url.as_str();
 
-  client.put(url, &[0, 1, 2, 3, 4]).await.unwrap();
+  let data = [0, 1, 2, 3, 4].to_vec();
+
+  // The client has the same familiar API of a reqwest client
+  client.put(url).body(data.clone()).send().await.unwrap();
 
   // Read using a Public key based link
-  let response = client.get(url).await.unwrap().unwrap();
+  let response = client.get(url).send().await.unwrap();
+  let response_data = response.bytes().await.unwrap();
 
-  assert_eq!(response, bytes::Bytes::from(vec![0, 1, 2, 3, 4]));
+  assert_eq!(response_data, data);
 
   // Delete an entry.
-  client.delete(url).await.unwrap();
+  client.delete(url).send().await.unwrap();
 
-  let response = client.get(url).await.unwrap();
+  let response = client.get(url).send().await.unwrap();
 
-  assert_eq!(response, None);
+  assert_eq!(response.status(), 404);
 }
 ```
 


### PR DESCRIPTION
As we mostly use `cargo nextest run` , we stoped testing our readmes, as it seems only `cargo test` is now running those snippets. As consequence, the readmes have been outdated/untested for some time.

This fixes `cargo test` . Therefore it seems introducing `tokio-shared-rt` is not necessary as seen in https://github.com/pubky/pubky-core/pull/71