### PR TITLE
fix: improve testnet start up times in some environments

### DIFF
--- a/pubky-testnet/src/lib.rs
+++ b/pubky-testnet/src/lib.rs
@@ -23,7 +23,7 @@ pub struct Testnet {
 impl Testnet {
     /// Run a new testnet.
     pub async fn run() -> Result<Self> {
-        let dht = mainline::Testnet::new(10)?;
+        let dht = mainline::Testnet::new(3)?;
 
         let mut testnet = Self {
             dht,
@@ -42,7 +42,7 @@ impl Testnet {
     /// 2. A Homeserver with address is hardcoded to `8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo`
     /// 4. An HTTP relay running on port [15412](pubky_common::constants::testnet_ports::HTTP_RELAY)
     pub async fn run_with_hardcoded_configurations() -> Result<Self> {
-        let dht = mainline::Testnet::new(10)?;
+        let dht = mainline::Testnet::new(3)?;
 
         dht.leak();
 


### PR DESCRIPTION
This PR reduces the number of Dht testnet nodes from 10 to 3. 

Both should suffice for testing. But 3 might improve start up times in some specific environments where `mainline::Testnet` after the `5.3.1` fix still takes a considerable amount of time to start for some unknown reason. More context in https://github.com/pubky/mainline/issues/52#issuecomment-2676219391