### PR TITLE
feat: signup tokens

### DIFF
--- a/examples/authn/README.md
+++ b/examples/authn/README.md
@@ -3,11 +3,10 @@
 You can use these examples to test Signup or Signin to a provided homeserver using a keypair,
 as opposed to using a the 3rd party [authorization flow](../authz).
 
-
-## Usage 
+## Usage
 
 ### Signup
 
 ```bash
-cargo run --bin signup <homeserver pubky> </path/to/recovery file>
+cargo run --bin signup <homeserver pubky> </path/to/recovery file> <signup_token>
 ```

--- a/examples/authn/signup.rs
+++ b/examples/authn/signup.rs
@@ -32,7 +32,7 @@ async fn main() -> Result<()> {
     println!("Successfully decrypted the recovery file, signing up to the homeserver:");
 
     client
-        .signup(&keypair, &PublicKey::try_from(homeserver).unwrap())
+        .signup(&keypair, &PublicKey::try_from(homeserver).unwrap(), None)
         .await?;
 
     println!("Successfully signed up. Checking session:");

--- a/examples/authn/signup.rs
+++ b/examples/authn/signup.rs
@@ -11,6 +11,9 @@ struct Cli {
 
     /// Path to a recovery_file of the Pubky you want to sign in with
     recovery_file: PathBuf,
+
+    /// Signup code (optional)
+    signup_code: Option<String>,
 }
 
 #[tokio::main]
@@ -32,7 +35,11 @@ async fn main() -> Result<()> {
     println!("Successfully decrypted the recovery file, signing up to the homeserver:");
 
     client
-        .signup(&keypair, &PublicKey::try_from(homeserver).unwrap(), None)
+        .signup(
+            &keypair,
+            &PublicKey::try_from(homeserver).unwrap(),
+            cli.signup_code.as_deref(),
+        )
         .await?;
 
     println!("Successfully signed up. Checking session:");

--- a/examples/authz/authenticator.rs
+++ b/examples/authz/authenticator.rs
@@ -74,7 +74,7 @@ async fn main() -> Result<()> {
         // the user has an account on the local homeserver.
         if client.signin(&keypair).await.is_err() {
             client
-                .signup(&keypair, &PublicKey::try_from(HOMESERVER).unwrap())
+                .signup(&keypair, &PublicKey::try_from(HOMESERVER).unwrap(), None)
                 .await?;
         };
 

--- a/pubky-homeserver/README.md
+++ b/pubky-homeserver/README.md
@@ -24,6 +24,26 @@ async fn main() {
 }
 ```
 
+If homeserver is set to require signup tokens, you can create a new signup token using the admin endpoint:
+
+```rust
+let admin_response = pubky_client
+    .get(&format!("https://{homeserver_pubkey}/admin/generate_signup_token"))
+    .header("X-Admin-Password", "admin") // Use your admin password. This is testnet default pwd.
+    .send()
+    .await
+    .unwrap();
+let signup_token = admin_response.text().await.unwrap();
+```
+
+or via CLI with `curl`
+
+```bash
+curl -X GET "https://<homeserver_ip:port>/admin/generate_signup_token" \
+     -H "X-Admin-Password: admin"
+     # Use your admin password. This is testnet default pwd.
+```
+
 ### Binary
 
 Use `cargo run`

--- a/pubky-homeserver/README.md
+++ b/pubky-homeserver/README.md
@@ -26,22 +26,35 @@ async fn main() {
 
 If homeserver is set to require signup tokens, you can create a new signup token using the admin endpoint:
 
-```rust
-let admin_response = pubky_client
+```rust,ignore
+let response = pubky_client
     .get(&format!("https://{homeserver_pubkey}/admin/generate_signup_token"))
     .header("X-Admin-Password", "admin") // Use your admin password. This is testnet default pwd.
     .send()
     .await
     .unwrap();
-let signup_token = admin_response.text().await.unwrap();
+let signup_token = response.text().await.unwrap();
 ```
 
-or via CLI with `curl`
+via CLI with `curl`
 
 ```bash
 curl -X GET "https://<homeserver_ip:port>/admin/generate_signup_token" \
      -H "X-Admin-Password: admin"
      # Use your admin password. This is testnet default pwd.
+```
+
+or from JS
+
+```js
+const url = "http://${homeserver_address}/admin/generate_signup_token";
+const response = await client.fetch(url, {
+  method: "GET",
+  headers: {
+    "X-Admin-Password": "admin", // use your admin password, defaults to testnet password.
+  },
+});
+const signupToken = await response.text();
 ```
 
 ### Binary

--- a/pubky-homeserver/src/config.example.toml
+++ b/pubky-homeserver/src/config.example.toml
@@ -1,6 +1,14 @@
 # Secret key (in hex) to generate the Homeserver's Keypair
 # secret_key = "0000000000000000000000000000000000000000000000000000000000000000"
 
+[admin]
+# Set an admin password to protect admin endpoints.
+# WARNING: if no password is set, the admin endpoints will be unprotected.
+password = "mySecretAdminPassword"
+# Set signup_mode to "open" to allow anyone to signup a new user,
+# otherwise, "closed" (the default) to require a valid invite token on signup;
+signup_mode = "closed"
+
 [database]
 # Storage directory Defaults to <System's Data Directory>
 #

--- a/pubky-homeserver/src/config.example.toml
+++ b/pubky-homeserver/src/config.example.toml
@@ -3,7 +3,7 @@
 
 [admin]
 # Set an admin password to protect admin endpoints.
-# WARNING: if no password is set, the admin endpoints will be unprotected.
+# If no password is set, the admin endpoints will not be accessible. 
 password = "mySecretAdminPassword"
 # Set signup_mode to "open" to allow anyone to signup a new user,
 # otherwise, "closed" (the default) to require a valid invite token on signup;

--- a/pubky-homeserver/src/config.example.toml
+++ b/pubky-homeserver/src/config.example.toml
@@ -4,10 +4,10 @@
 [admin]
 # Set an admin password to protect admin endpoints.
 # If no password is set, the admin endpoints will not be accessible. 
-password = "mySecretAdminPassword"
+password = "admin"
 # Set signup_mode to "open" to allow anyone to signup a new user,
-# otherwise, "closed" (the default) to require a valid invite token on signup;
-signup_mode = "closed"
+# otherwise, "token_required" (the default) to require a valid invite token on signup;
+signup_mode = "token_required"
 
 [database]
 # Storage directory Defaults to <System's Data Directory>

--- a/pubky-homeserver/src/config.rs
+++ b/pubky-homeserver/src/config.rs
@@ -41,7 +41,6 @@ struct LegacyBrowsersTompl {
     pub domain: Option<String>,
 }
 
-// Add these new types near the top:
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 struct AdminToml {
     pub password: Option<String>,

--- a/pubky-homeserver/src/config.rs
+++ b/pubky-homeserver/src/config.rs
@@ -44,7 +44,7 @@ struct LegacyBrowsersTompl {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 struct AdminToml {
     pub password: Option<String>,
-    /// "open" or "closed" (defaults to "closed", i.e., a signup token is required)
+    /// "open" or "token_required" (defaults to "token_required", i.e., a signup token is required)
     pub signup_mode: Option<String>,
 }
 
@@ -192,7 +192,7 @@ impl TryFrom<ConfigToml> for Config {
                 password: admin_toml.password.clone(),
                 signup_mode: match admin_toml.signup_mode.as_deref() {
                     Some("open") => SignupMode::Open,
-                    _ => SignupMode::Closed,
+                    _ => SignupMode::TokenRequired,
                 },
             }
         } else {
@@ -283,7 +283,7 @@ mod tests {
                     ..Default::default()
                 },
                 admin: AdminConfig {
-                    password: Some("test_admin_password".to_string()),
+                    password: Some("admin".to_string()),
                     signup_mode: SignupMode::Open
                 }
             }

--- a/pubky-homeserver/src/config.rs
+++ b/pubky-homeserver/src/config.rs
@@ -283,7 +283,7 @@ mod tests {
                     ..Default::default()
                 },
                 admin: AdminConfig {
-                    password: None,
+                    password: Some("test_admin_password".to_string()),
                     signup_mode: SignupMode::Open
                 }
             }

--- a/pubky-homeserver/src/config.rs
+++ b/pubky-homeserver/src/config.rs
@@ -10,7 +10,10 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use crate::{core::CoreConfig, io::IoConfig};
+use crate::{
+    core::{AdminConfig, CoreConfig, SignupMode},
+    io::IoConfig,
+};
 
 // === Core ==
 pub const DEFAULT_STORAGE_DIR: &str = "pubky";
@@ -46,29 +49,6 @@ struct AdminToml {
     pub signup_mode: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub enum SignupMode {
-    Open,
-    #[default]
-    Closed,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub struct AdminConfig {
-    /// The password used to authorize admin endpoints.
-    pub password: Option<String>,
-    /// Determines whether new signups require a valid token.
-    pub signup_mode: SignupMode,
-}
-
-impl AdminConfig {
-    pub fn test() -> Self {
-        AdminConfig {
-            password: None,
-            signup_mode: SignupMode::Open,
-        }
-    }
-}
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq)]
 struct IoToml {
     pub http_port: Option<u16>,

--- a/pubky-homeserver/src/config.rs
+++ b/pubky-homeserver/src/config.rs
@@ -38,6 +38,37 @@ struct LegacyBrowsersTompl {
     pub domain: Option<String>,
 }
 
+// Add these new types near the top:
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+struct AdminToml {
+    pub password: Option<String>,
+    /// "open" or "closed" (defaults to "closed", i.e., a signup token is required)
+    pub signup_mode: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum SignupMode {
+    Open,
+    #[default]
+    Closed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct AdminConfig {
+    /// The password used to authorize admin endpoints.
+    pub password: Option<String>,
+    /// Determines whether new signups require a valid token.
+    pub signup_mode: SignupMode,
+}
+
+impl AdminConfig {
+    pub fn test() -> Self {
+        AdminConfig {
+            password: None,
+            signup_mode: SignupMode::Open,
+        }
+    }
+}
 #[derive(Debug, Default, Serialize, Deserialize, Clone, PartialEq)]
 struct IoToml {
     pub http_port: Option<u16>,
@@ -51,9 +82,9 @@ struct IoToml {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 struct ConfigToml {
     secret_key: Option<String>,
-
     database: Option<DatabaseToml>,
     io: Option<IoToml>,
+    admin: Option<AdminToml>,
 }
 
 /// Server configuration
@@ -63,9 +94,20 @@ pub struct Config {
     ///
     /// Defaults to a random keypair.
     pub keypair: Keypair,
-
     pub io: IoConfig,
     pub core: CoreConfig,
+    pub admin: AdminConfig,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            keypair: Keypair::random(),
+            io: IoConfig::default(),
+            core: CoreConfig::default(),
+            admin: AdminConfig::default(),
+        }
+    }
 }
 
 impl Config {
@@ -112,17 +154,8 @@ impl Config {
                 ..Default::default()
             },
             core: CoreConfig::test(),
+            admin: AdminConfig::test(),
             ..Default::default()
-        }
-    }
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            keypair: Keypair::random(),
-            io: IoConfig::default(),
-            core: CoreConfig::default(),
         }
     }
 }
@@ -175,14 +208,26 @@ impl TryFrom<ConfigToml> for Config {
             }
         };
 
+        let admin = if let Some(admin_toml) = value.admin {
+            AdminConfig {
+                password: admin_toml.password.clone(),
+                signup_mode: match admin_toml.signup_mode.as_deref() {
+                    Some("open") => SignupMode::Open,
+                    _ => SignupMode::Closed,
+                },
+            }
+        } else {
+            AdminConfig::default()
+        };
+
         Ok(Config {
             keypair,
-
             io,
             core: CoreConfig {
                 storage,
                 ..Default::default()
             },
+            admin,
         })
     }
 }
@@ -258,6 +303,10 @@ mod tests {
 
                     ..Default::default()
                 },
+                admin: AdminConfig {
+                    password: None,
+                    signup_mode: SignupMode::Open
+                }
             }
         )
     }

--- a/pubky-homeserver/src/core/database/migrations/m0.rs
+++ b/pubky-homeserver/src/core/database/migrations/m0.rs
@@ -1,6 +1,6 @@
 use heed::{Env, RwTxn};
 
-use crate::core::database::tables::{blobs, entries, events, sessions, users};
+use crate::core::database::tables::{blobs, entries, events, sessions, signup_tokens, users};
 
 pub fn run(env: &Env, wtxn: &mut RwTxn) -> anyhow::Result<()> {
     let _: users::UsersTable = env.create_database(wtxn, Some(users::USERS_TABLE))?;
@@ -12,6 +12,9 @@ pub fn run(env: &Env, wtxn: &mut RwTxn) -> anyhow::Result<()> {
     let _: entries::EntriesTable = env.create_database(wtxn, Some(entries::ENTRIES_TABLE))?;
 
     let _: events::EventsTable = env.create_database(wtxn, Some(events::EVENTS_TABLE))?;
+
+    let _: signup_tokens::SignupTokensTable =
+        env.create_database(wtxn, Some(signup_tokens::SIGNUP_TOKENS_TABLE))?;
 
     Ok(())
 }

--- a/pubky-homeserver/src/core/database/tables.rs
+++ b/pubky-homeserver/src/core/database/tables.rs
@@ -2,6 +2,7 @@ pub mod blobs;
 pub mod entries;
 pub mod events;
 pub mod sessions;
+pub mod signup_tokens;
 pub mod users;
 
 use heed::{Env, RwTxn};
@@ -12,10 +13,11 @@ use entries::{EntriesTable, ENTRIES_TABLE};
 use self::{
     events::{EventsTable, EVENTS_TABLE},
     sessions::{SessionsTable, SESSIONS_TABLE},
+    signup_tokens::{SignupTokensTable, SIGNUP_TOKENS_TABLE},
     users::{UsersTable, USERS_TABLE},
 };
 
-pub const TABLES_COUNT: u32 = 5;
+pub const TABLES_COUNT: u32 = 6;
 
 #[derive(Debug, Clone)]
 pub struct Tables {
@@ -24,6 +26,7 @@ pub struct Tables {
     pub blobs: BlobsTable,
     pub entries: EntriesTable,
     pub events: EventsTable,
+    pub signup_tokens: SignupTokensTable,
 }
 
 impl Tables {
@@ -44,6 +47,9 @@ impl Tables {
             events: env
                 .open_database(wtxn, Some(EVENTS_TABLE))?
                 .expect("Events table already created"),
+            signup_tokens: env
+                .open_database(wtxn, Some(SIGNUP_TOKENS_TABLE))?
+                .expect("Signup tokens table already created"),
         })
     }
 }

--- a/pubky-homeserver/src/core/database/tables/entries.rs
+++ b/pubky-homeserver/src/core/database/tables/entries.rs
@@ -431,7 +431,7 @@ impl<'db> EntryWriter<'db> {
     }
 }
 
-impl<'db> std::io::Write for EntryWriter<'db> {
+impl std::io::Write for EntryWriter<'_> {
     /// Write a chunk to a Filesystem based buffer.
     #[inline]
     fn write(&mut self, chunk: &[u8]) -> std::io::Result<usize> {

--- a/pubky-homeserver/src/core/database/tables/signup_tokens.rs
+++ b/pubky-homeserver/src/core/database/tables/signup_tokens.rs
@@ -28,6 +28,10 @@ impl SignupToken {
         from_bytes(bytes).expect("deserialize signup token")
     }
 
+    pub fn is_used(&self) -> bool {
+        self.used.is_some()
+    }
+
     // Generate 7 random bytes and encode as BASE32, fully uppercase
     // with hyphens every 4 characters. Example, `QXV0-15V7-EXY0`
     pub fn random() -> Self {
@@ -68,7 +72,7 @@ impl DB {
         let mut wtxn = self.env.write_txn()?;
         if let Some(token_bytes) = self.tables.signup_tokens.get(&wtxn, token)? {
             let mut signup_token = SignupToken::deserialize(token_bytes);
-            if signup_token.used.is_some() {
+            if signup_token.is_used() {
                 anyhow::bail!("Token already used");
             }
             // Mark token as used.

--- a/pubky-homeserver/src/core/database/tables/signup_tokens.rs
+++ b/pubky-homeserver/src/core/database/tables/signup_tokens.rs
@@ -1,0 +1,87 @@
+use crate::core::database::DB;
+use base32::{encode, Alphabet};
+use heed::{
+    types::{Bytes, Str},
+    Database,
+};
+use pkarr::PublicKey;
+use postcard::{from_bytes, to_allocvec};
+use pubky_common::{crypto::random_bytes, timestamp::Timestamp};
+use serde::{Deserialize, Serialize};
+
+pub const SIGNUP_TOKENS_TABLE: &str = "signup_tokens";
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SignupToken {
+    pub token: String,
+    pub created_at: u64,
+    /// If Some(pubkey), the token has been used.
+    pub used: Option<PublicKey>,
+}
+
+impl SignupToken {
+    pub fn serialize(&self) -> Vec<u8> {
+        to_allocvec(self).expect("serialize signup token")
+    }
+
+    pub fn deserialize(bytes: &[u8]) -> Self {
+        from_bytes(bytes).expect("deserialize signup token")
+    }
+}
+
+// Generate 8 random bytes and encode as BASE32, fully uppercase
+// with hyphens every 4 characters.
+fn generate_random_token() -> String {
+    let bytes = random_bytes::<8>();
+    let encoded = encode(Alphabet::Crockford, &bytes).to_uppercase();
+    let mut with_hyphens = String::new();
+    for (i, ch) in encoded.chars().enumerate() {
+        if i > 0 && i % 4 == 0 {
+            with_hyphens.push('-');
+        }
+        with_hyphens.push(ch);
+    }
+    with_hyphens
+}
+
+impl DB {
+    pub fn generate_signup_token(&mut self) -> anyhow::Result<String> {
+        let token = generate_random_token();
+        let signup_token = SignupToken {
+            token: token.clone(),
+            created_at: Timestamp::now().as_u64(),
+            used: None,
+        };
+        let mut wtxn = self.env.write_txn()?;
+        self.tables
+            .signup_tokens
+            .put(&mut wtxn, &token, &signup_token.serialize())?;
+        wtxn.commit()?;
+        Ok(token)
+    }
+
+    pub fn validate_signup_token(
+        &self,
+        token: &str,
+        user_pubkey: &PublicKey,
+    ) -> anyhow::Result<()> {
+        let mut wtxn = self.env.write_txn()?;
+        if let Some(token_bytes) = self.tables.signup_tokens.get(&wtxn, token)? {
+            let mut signup_token = SignupToken::deserialize(&token_bytes);
+            if signup_token.used.is_some() {
+                anyhow::bail!("Token already used");
+            }
+            // Mark token as used.
+            signup_token.used = Some(user_pubkey.clone());
+            self.tables
+                .signup_tokens
+                .put(&mut wtxn, token, &signup_token.serialize())?;
+            wtxn.commit()?;
+            Ok(())
+        } else {
+            anyhow::bail!("Invalid token");
+        }
+    }
+}
+
+pub type SignupTokensTable = Database<Str, Bytes>;

--- a/pubky-homeserver/src/core/database/tables/signup_tokens.rs
+++ b/pubky-homeserver/src/core/database/tables/signup_tokens.rs
@@ -29,10 +29,10 @@ impl SignupToken {
     }
 }
 
-// Generate 8 random bytes and encode as BASE32, fully uppercase
-// with hyphens every 4 characters.
+// Generate 7 random bytes and encode as BASE32, fully uppercase
+// with hyphens every 4 characters. Example, `QXV0-15V7-EXY0`
 fn generate_random_token() -> String {
-    let bytes = random_bytes::<8>();
+    let bytes = random_bytes::<7>();
     let encoded = encode(Alphabet::Crockford, &bytes).to_uppercase();
     let mut with_hyphens = String::new();
     for (i, ch) in encoded.chars().enumerate() {

--- a/pubky-homeserver/src/core/database/tables/signup_tokens.rs
+++ b/pubky-homeserver/src/core/database/tables/signup_tokens.rs
@@ -67,7 +67,7 @@ impl DB {
     ) -> anyhow::Result<()> {
         let mut wtxn = self.env.write_txn()?;
         if let Some(token_bytes) = self.tables.signup_tokens.get(&wtxn, token)? {
-            let mut signup_token = SignupToken::deserialize(&token_bytes);
+            let mut signup_token = SignupToken::deserialize(token_bytes);
             if signup_token.used.is_some() {
                 anyhow::bail!("Token already used");
             }

--- a/pubky-homeserver/src/core/database/tables/users.rs
+++ b/pubky-homeserver/src/core/database/tables/users.rs
@@ -19,7 +19,7 @@ pub struct User {
     pub created_at: u64,
 }
 
-impl<'a> BytesEncode<'a> for User {
+impl BytesEncode<'_> for User {
     type EItem = Self;
 
     fn bytes_encode(user: &Self::EItem) -> Result<Cow<[u8]>, BoxedError> {
@@ -41,7 +41,7 @@ impl<'a> BytesDecode<'a> for User {
 
 pub struct PublicKeyCodec {}
 
-impl<'a> BytesEncode<'a> for PublicKeyCodec {
+impl BytesEncode<'_> for PublicKeyCodec {
     type EItem = PublicKey;
 
     fn bytes_encode(pubky: &Self::EItem) -> Result<Cow<[u8]>, BoxedError> {

--- a/pubky-homeserver/src/core/layers/admin.rs
+++ b/pubky-homeserver/src/core/layers/admin.rs
@@ -1,0 +1,87 @@
+// src/core/layers/admin_auth.rs
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    response::Response,
+};
+use futures_util::future::BoxFuture;
+use std::{convert::Infallible, task::Poll};
+use tower::{Layer, Service};
+
+/// A Tower Layer that checks the “X-Admin-Password” header against a configured password.
+#[derive(Clone)]
+pub struct AdminAuthLayer {
+    password: String,
+}
+
+impl AdminAuthLayer {
+    /// Create a new AdminAuthLayer with the given admin password.
+    pub fn new(password: String) -> Self {
+        Self { password }
+    }
+}
+
+impl<S> Layer<S> for AdminAuthLayer {
+    type Service = AdminAuthMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AdminAuthMiddleware {
+            inner,
+            password: self.password.clone(),
+        }
+    }
+}
+
+/// Middleware that performs the admin password check.
+#[derive(Clone)]
+pub struct AdminAuthMiddleware<S> {
+    inner: S,
+    password: String,
+}
+
+impl<S, ReqBody> Service<Request<ReqBody>> for AdminAuthMiddleware<S>
+where
+    S: Service<Request<ReqBody>, Response = Response, Error = Infallible> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    ReqBody: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<ReqBody>) -> Self::Future {
+        let password = self.password.clone();
+        let mut inner = self.inner.clone();
+
+        Box::pin(async move {
+            match req.headers().get("X-Admin-Password") {
+                Some(header_value) if header_value.to_str().unwrap_or("") == password => {
+                    // If the header is valid, proceed.
+                    inner.call(req).await
+                }
+                Some(_) => {
+                    // If header exists but password is incorrect,
+                    let msg = "Invalid admin password";
+                    let response = Response::builder()
+                        .status(StatusCode::UNAUTHORIZED)
+                        .body(Body::from(msg))
+                        .unwrap_or_else(|_| Response::new(Body::from(msg)));
+                    Ok(response)
+                }
+                None => {
+                    // If header is missing, do the same.
+                    let msg = "Missing admin password";
+                    let response = Response::builder()
+                        .status(StatusCode::UNAUTHORIZED)
+                        .body(Body::from(msg))
+                        .unwrap_or_else(|_| Response::new(Body::from(msg)));
+                    Ok(response)
+                }
+            }
+        })
+    }
+}

--- a/pubky-homeserver/src/core/layers/mod.rs
+++ b/pubky-homeserver/src/core/layers/mod.rs
@@ -1,3 +1,4 @@
+pub mod admin;
 pub mod authz;
 pub mod pubky_host;
 pub mod trace;

--- a/pubky-homeserver/src/core/mod.rs
+++ b/pubky-homeserver/src/core/mod.rs
@@ -108,7 +108,7 @@ mod tests {
 pub enum SignupMode {
     Open,
     #[default]
-    Closed,
+    TokenRequired,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -122,7 +122,7 @@ pub struct AdminConfig {
 impl AdminConfig {
     pub fn test() -> Self {
         AdminConfig {
-            password: Some("test_admin_password".to_string()),
+            password: Some("admin".to_string()),
             signup_mode: SignupMode::Open,
         }
     }

--- a/pubky-homeserver/src/core/mod.rs
+++ b/pubky-homeserver/src/core/mod.rs
@@ -122,7 +122,7 @@ pub struct AdminConfig {
 impl AdminConfig {
     pub fn test() -> Self {
         AdminConfig {
-            password: None,
+            password: Some("test_admin_password".to_string()),
             signup_mode: SignupMode::Open,
         }
     }

--- a/pubky-homeserver/src/core/routes/admin.rs
+++ b/pubky-homeserver/src/core/routes/admin.rs
@@ -12,22 +12,37 @@ pub async fn generate_signup_token(
     State(mut state): State<AppState>,
     headers: HeaderMap,
 ) -> Result<impl IntoResponse> {
-    // Check for the admin password in a custom header "X-Admin-Password"
-    let admin_password = state.admin.password.as_deref().unwrap_or("");
-    if let Some(value) = headers.get("X-Admin-Password") {
-        if value.to_str().unwrap_or("") != admin_password {
+    // 1) If no admin password is configured, block entirely the admin endpoints.
+    let admin_password = match &state.admin.password {
+        Some(pw) => pw,
+        None => {
+            return Err(Error::new(
+                StatusCode::FORBIDDEN,
+                Some("No admin password set. Admin endpoints are disabled."),
+            ));
+        }
+    };
+
+    // 2) If a password is set, require "X-Admin-Password" to match.
+    match headers.get("X-Admin-Password") {
+        Some(value) if value.to_str().unwrap_or_default() == admin_password => {
+            // OK, proceed
+        }
+        Some(_) => {
             return Err(Error::new(
                 StatusCode::UNAUTHORIZED,
                 Some("Invalid admin password"),
             ));
         }
-    } else {
-        return Err(Error::new(
-            StatusCode::UNAUTHORIZED,
-            Some("Missing admin password"),
-        ));
+        None => {
+            return Err(Error::new(
+                StatusCode::UNAUTHORIZED,
+                Some("Missing admin password"),
+            ));
+        }
     }
-    // Generate a new signup token.
+
+    // 3) Generate a new signup token
     let token = state.db.generate_signup_token()?;
     Ok((StatusCode::OK, token))
 }

--- a/pubky-homeserver/src/core/routes/admin.rs
+++ b/pubky-homeserver/src/core/routes/admin.rs
@@ -1,48 +1,14 @@
-use crate::core::{
-    error::{Error, Result},
-    AppState,
-};
-use axum::{
-    extract::State,
-    http::{HeaderMap, StatusCode},
-    response::IntoResponse,
-};
+use crate::core::{error::Result, layers::admin::AdminAuthLayer, AppState};
+use axum::{extract::State, http::StatusCode, response::IntoResponse, routing::get, Router};
 
-pub async fn generate_signup_token(
-    State(mut state): State<AppState>,
-    headers: HeaderMap,
-) -> Result<impl IntoResponse> {
-    // 1) If no admin password is configured, block entirely the admin endpoints.
-    let admin_password = match &state.admin.password {
-        Some(pw) => pw,
-        None => {
-            return Err(Error::new(
-                StatusCode::FORBIDDEN,
-                Some("No admin password set. Admin endpoints are disabled."),
-            ));
-        }
-    };
-
-    // 2) If a password is set, require "X-Admin-Password" to match.
-    match headers.get("X-Admin-Password") {
-        Some(value) if value.to_str().unwrap_or_default() == admin_password => {
-            // OK, proceed
-        }
-        Some(_) => {
-            return Err(Error::new(
-                StatusCode::UNAUTHORIZED,
-                Some("Invalid admin password"),
-            ));
-        }
-        None => {
-            return Err(Error::new(
-                StatusCode::UNAUTHORIZED,
-                Some("Missing admin password"),
-            ));
-        }
-    }
-
-    // 3) Generate a new signup token
+pub async fn generate_signup_token(State(mut state): State<AppState>) -> Result<impl IntoResponse> {
     let token = state.db.generate_signup_token()?;
     Ok((StatusCode::OK, token))
+}
+
+pub fn router(state: AppState) -> Router<AppState> {
+    let admin_password = state.admin.password.unwrap_or_default();
+    Router::new()
+        .route("/generate_signup_token", get(generate_signup_token))
+        .layer(AdminAuthLayer::new(admin_password))
 }

--- a/pubky-homeserver/src/core/routes/admin.rs
+++ b/pubky-homeserver/src/core/routes/admin.rs
@@ -1,0 +1,33 @@
+use crate::core::{
+    error::{Error, Result},
+    AppState,
+};
+use axum::{
+    extract::State,
+    http::{HeaderMap, StatusCode},
+    response::IntoResponse,
+};
+
+pub async fn generate_signup_token(
+    State(mut state): State<AppState>,
+    headers: HeaderMap,
+) -> Result<impl IntoResponse> {
+    // Check for the admin password in a custom header "X-Admin-Password"
+    let admin_password = state.admin.password.as_deref().unwrap_or("");
+    if let Some(value) = headers.get("X-Admin-Password") {
+        if value.to_str().unwrap_or("") != admin_password {
+            return Err(Error::new(
+                StatusCode::UNAUTHORIZED,
+                Some("Invalid admin password"),
+            ));
+        }
+    } else {
+        return Err(Error::new(
+            StatusCode::UNAUTHORIZED,
+            Some("Missing admin password"),
+        ));
+    }
+    // Generate a new signup token.
+    let token = state.db.generate_signup_token()?;
+    Ok((StatusCode::OK, token))
+}

--- a/pubky-homeserver/src/core/routes/auth.rs
+++ b/pubky-homeserver/src/core/routes/auth.rs
@@ -46,7 +46,7 @@ pub async fn signup(
     }
     txn.commit()?;
 
-    // 3) If signup_mode == closed, require & validate a `signup_token` param.
+    // 3) If signup_mode == token_required, require & validate a `signup_token` param.
     if state.admin.signup_mode == SignupMode::TokenRequired {
         let signup_token_param = params
             .get("signup_token")

--- a/pubky-homeserver/src/core/routes/auth.rs
+++ b/pubky-homeserver/src/core/routes/auth.rs
@@ -1,24 +1,83 @@
-use axum::{extract::State, response::IntoResponse};
+use crate::core::{
+    database::tables::users::User,
+    error::{Error, Result},
+    AppState, SignupMode,
+};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
 use axum_extra::{extract::Host, headers::UserAgent, TypedHeader};
+use base32::{encode, Alphabet};
 use bytes::Bytes;
+use pkarr::PublicKey;
+use pubky_common::{
+    capabilities::Capability, crypto::random_bytes, session::Session, timestamp::Timestamp,
+};
+use std::collections::HashMap;
 use tower_cookies::{cookie::SameSite, Cookie, Cookies};
 
-use pubky_common::{crypto::random_bytes, session::Session, timestamp::Timestamp};
-
-use crate::core::{database::tables::users::User, error::Result, AppState};
-
+/// Creates a brand-new user if they do not exist, then logs them in by creating a session.
+/// 1) Check if signup tokens are required (signup mode is Closed).
+/// 2) Ensure the user *does not* already exist.
+/// 3) Create new user if needed.
+/// 4) Create a session and set the cookie (using the shared helper).
 pub async fn signup(
     State(state): State<AppState>,
     user_agent: Option<TypedHeader<UserAgent>>,
     cookies: Cookies,
-    host: Host,
+    Host(host): Host,
+    Query(params): Query<HashMap<String, String>>, // for extracting `signup_token` if needed
     body: Bytes,
 ) -> Result<impl IntoResponse> {
-    // TODO: Verify invitation link.
-    // TODO: add errors in case of already axisting user.
-    signin(State(state), user_agent, cookies, host, body).await
+    // 1) Verify AuthToken from request body
+    let token = state.verifier.verify(&body)?;
+    let public_key = token.pubky();
+
+    // 2) If signup_mode == closed, require & validate a `signup_token` param.
+    if state.admin.signup_mode == SignupMode::Closed {
+        let signup_token_param = params
+            .get("signup_token")
+            .ok_or_else(|| Error::new(StatusCode::BAD_REQUEST, Some("signup_token required")))?;
+        // Validate it in the DB (marks it used)
+        state
+            .db
+            .validate_signup_token(signup_token_param, public_key)?;
+    }
+
+    // 3) Ensure the user does *not* already exist
+    let mut wtxn = state.db.env.write_txn()?;
+    let users = state.db.tables.users;
+    if users.get(&wtxn, public_key)?.is_some() {
+        return Err(Error::new(
+            StatusCode::CONFLICT,
+            Some("User already exists"),
+        ));
+    }
+
+    // 4) Create the new user record
+    users.put(
+        &mut wtxn,
+        public_key,
+        &User {
+            created_at: Timestamp::now().as_u64(),
+        },
+    )?;
+    wtxn.commit()?;
+
+    // 5) Create session & set cookie
+    create_session_and_cookie(
+        &state,
+        cookies,
+        &host,
+        public_key,
+        token.capabilities(),
+        user_agent,
+    )
 }
 
+/// Fails if user doesn’t exist, otherwise logs them in by creating a session.
 pub async fn signin(
     State(state): State<AppState>,
     user_agent: Option<TypedHeader<UserAgent>>,
@@ -26,54 +85,68 @@ pub async fn signin(
     Host(host): Host,
     body: Bytes,
 ) -> Result<impl IntoResponse> {
+    // 1) Verify the AuthToken in the request body
     let token = state.verifier.verify(&body)?;
-
     let public_key = token.pubky();
 
-    let mut wtxn = state.db.env.write_txn()?;
-
+    // 2) Ensure user *does* exist
+    let rtxn = state.db.env.read_txn()?;
     let users = state.db.tables.users;
-    if let Some(existing) = users.get(&wtxn, public_key)? {
-        // TODO: why do we need this?
-        users.put(&mut wtxn, public_key, &existing)?;
-    } else {
-        users.put(
-            &mut wtxn,
-            public_key,
-            &User {
-                created_at: Timestamp::now().as_u64(),
-            },
-        )?;
+    let user_exists = users.get(&rtxn, public_key)?.is_some();
+    rtxn.commit()?;
+    if !user_exists {
+        return Err(Error::new(
+            StatusCode::NOT_FOUND,
+            Some("User does not exist"),
+        ));
     }
 
-    let session_secret = base32::encode(base32::Alphabet::Crockford, &random_bytes::<16>());
-
-    let session = Session::new(
-        token.pubky(),
+    // 3) Create the session & set cookie
+    create_session_and_cookie(
+        &state,
+        cookies,
+        &host,
+        public_key,
         token.capabilities(),
+        user_agent,
+    )
+}
+
+/// Creates and stores a session, sets the cookie, returns session as JSON/string.
+fn create_session_and_cookie(
+    state: &AppState,
+    cookies: Cookies,
+    host: &str,
+    public_key: &PublicKey,
+    capabilities: &[Capability],
+    user_agent: Option<TypedHeader<UserAgent>>,
+) -> Result<impl IntoResponse> {
+    // 1) Create session
+    let session_secret = encode(Alphabet::Crockford, &random_bytes::<16>());
+    let session = Session::new(
+        &public_key,
+        capabilities,
         user_agent.map(|ua| ua.to_string()),
     )
     .serialize();
 
+    // 2) Insert session into DB
+    let mut wtxn = state.db.env.write_txn()?;
     state
         .db
         .tables
         .sessions
         .put(&mut wtxn, &session_secret, &session)?;
-
     wtxn.commit()?;
 
+    // 3) Build and set cookie
     let mut cookie = Cookie::new(public_key.to_string(), session_secret);
-
     cookie.set_path("/");
-
-    // TODO: do we even have insecure anymore?
-    if is_secure(&host) {
+    if is_secure(host) {
         cookie.set_secure(true);
         cookie.set_same_site(SameSite::None);
     }
     cookie.set_http_only(true);
-
     cookies.add(cookie);
 
     Ok(session)

--- a/pubky-homeserver/src/core/routes/auth.rs
+++ b/pubky-homeserver/src/core/routes/auth.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use tower_cookies::{cookie::SameSite, Cookie, Cookies};
 
 /// Creates a brand-new user if they do not exist, then logs them in by creating a session.
-/// 1) Check if signup tokens are required (signup mode is Closed).
+/// 1) Check if signup tokens are required (signup mode is token_required).
 /// 2) Ensure the user *does not* already exist.
 /// 3) Create new user if needed.
 /// 4) Create a session and set the cookie (using the shared helper).

--- a/pubky-homeserver/src/core/routes/auth.rs
+++ b/pubky-homeserver/src/core/routes/auth.rs
@@ -124,7 +124,7 @@ fn create_session_and_cookie(
     // 1) Create session
     let session_secret = encode(Alphabet::Crockford, &random_bytes::<16>());
     let session = Session::new(
-        &public_key,
+        public_key,
         capabilities,
         user_agent.map(|ua| ua.to_string()),
     )

--- a/pubky-homeserver/src/core/routes/mod.rs
+++ b/pubky-homeserver/src/core/routes/mod.rs
@@ -33,11 +33,6 @@ fn base() -> Router<AppState> {
         .route("/session", post(auth::signin))
         // Events
         .route("/events/", get(feed::feed))
-        // Admin endpoints
-        .route(
-            "/admin/generate_signup_token",
-            get(admin::generate_signup_token),
-        )
     // TODO: add size limit
     // TODO: revisit if we enable streaming big payloads
     // TODO: maybe add to a separate router (drive router?).
@@ -46,11 +41,13 @@ fn base() -> Router<AppState> {
 pub fn create_app(state: AppState) -> Router {
     let app = base()
         .merge(tenants::router(state.clone()))
+        .nest("/admin", admin::router(state.clone()))
         .layer(CookieManagerLayer::new())
         .layer(CorsLayer::very_permissive())
         .layer(ServiceBuilder::new().layer(middleware::from_fn(add_server_header)))
         .with_state(state);
 
+    // Apply trace and pubky host layers to the complete router.
     with_trace_layer(app, &TRACING_EXCLUDED_PATHS).layer(PubkyHostLayer)
 }
 

--- a/pubky-homeserver/src/core/routes/mod.rs
+++ b/pubky-homeserver/src/core/routes/mod.rs
@@ -17,6 +17,7 @@ use crate::core::AppState;
 
 use super::layers::{pubky_host::PubkyHostLayer, trace::with_trace_layer};
 
+mod admin;
 mod auth;
 mod feed;
 mod root;
@@ -32,6 +33,11 @@ fn base() -> Router<AppState> {
         .route("/session", post(auth::signin))
         // Events
         .route("/events/", get(feed::feed))
+        // Admin endpoints
+        .route(
+            "/admin/generate_signup_token",
+            get(admin::generate_signup_token),
+        )
     // TODO: add size limit
     // TODO: revisit if we enable streaming big payloads
     // TODO: maybe add to a separate router (drive router?).

--- a/pubky-homeserver/src/io/mod.rs
+++ b/pubky-homeserver/src/io/mod.rs
@@ -12,7 +12,7 @@ use tracing::info;
 
 use crate::{
     config::{Config, DEFAULT_HTTPS_PORT, DEFAULT_HTTP_PORT},
-    core::HomeserverCore,
+    core::{HomeserverCore, SignupMode},
 };
 
 mod http;
@@ -54,6 +54,15 @@ impl HomeserverBuilder {
     /// Set the public domain of this Homeserver
     pub fn domain(&mut self, domain: &str) -> &mut Self {
         self.0.io.domain = Some(domain.to_string());
+
+        self
+    }
+
+    /// Set the signup mode to "close" (require signup token to new user)
+    /// Only to be used on ::test() homeserver for the specific case of
+    /// testing signup token flow.
+    pub fn close_signups(&mut self) -> &mut Self {
+        self.0.admin.signup_mode = SignupMode::Closed;
 
         self
     }
@@ -107,7 +116,7 @@ impl Homeserver {
 
         let keypair = config.keypair;
 
-        let core = unsafe { HomeserverCore::new(config.core)? };
+        let core = unsafe { HomeserverCore::new(config.core, config.admin)? };
 
         let http_servers = HttpServers::run(&keypair, &config.io, &core.router).await?;
 

--- a/pubky-homeserver/src/io/mod.rs
+++ b/pubky-homeserver/src/io/mod.rs
@@ -61,8 +61,15 @@ impl HomeserverBuilder {
     /// Set the signup mode to "close" (require signup token to new user)
     /// Only to be used on ::test() homeserver for the specific case of
     /// testing signup token flow.
-    pub fn close_signups(&mut self) -> &mut Self {
+    pub fn close_signups(mut self) -> Self {
         self.0.admin.signup_mode = SignupMode::Closed;
+
+        self
+    }
+
+    /// Set a password to protect admin endpoints
+    pub fn admin_password(mut self, password: String) -> Self {
+        self.0.admin.password = Some(password);
 
         self
     }

--- a/pubky-homeserver/src/io/mod.rs
+++ b/pubky-homeserver/src/io/mod.rs
@@ -58,17 +58,16 @@ impl HomeserverBuilder {
         self
     }
 
-    /// Set the signup mode to "close" (require signup token to new user)
-    /// Only to be used on ::test() homeserver for the specific case of
-    /// testing signup token flow.
-    pub fn close_signups(mut self) -> Self {
-        self.0.admin.signup_mode = SignupMode::Closed;
+    /// Set the signup mode to "token_required". Only to be used on ::test()
+    /// homeserver for the specific case of testing signup token flow.
+    pub fn close_signups(&mut self) -> &mut Self {
+        self.0.admin.signup_mode = SignupMode::TokenRequired;
 
         self
     }
 
     /// Set a password to protect admin endpoints
-    pub fn admin_password(mut self, password: String) -> Self {
+    pub fn admin_password(&mut self, password: String) -> &mut Self {
         self.0.admin.password = Some(password);
 
         self
@@ -109,6 +108,15 @@ impl Homeserver {
     /// Run a Homeserver with configurations suitable for ephemeral tests.
     pub async fn run_test(bootstrap: &[String]) -> Result<Self> {
         let config = Config::test(bootstrap);
+
+        unsafe { Self::run(config) }.await
+    }
+
+    /// Run a Homeserver with configurations suitable for ephemeral tests.
+    /// That requires signup tokens.
+    pub async fn run_test_with_signup_tokens(bootstrap: &[String]) -> Result<Self> {
+        let mut config = Config::test(bootstrap);
+        config.admin.signup_mode = SignupMode::TokenRequired;
 
         unsafe { Self::run(config) }.await
     }

--- a/pubky-testnet/src/lib.rs
+++ b/pubky-testnet/src/lib.rs
@@ -109,7 +109,8 @@ impl Testnet {
 
     /// Returns a [HomeserverBuilder] preconfigured with this testnet's DHT bootstrap nodes.
     pub fn homeserver_builder(&self) -> HomeserverBuilder {
-        let mut builder = Homeserver::builder();
+        // Use the same test admin password as the run_test() homeserver.
+        let mut builder = Homeserver::builder().admin_password("test_admin_password".to_string());
         // Set the DHT bootstrap nodes so the homeserver can join this local testnet
         builder.bootstrap(&self.dht.bootstrap);
 

--- a/pubky-testnet/src/lib.rs
+++ b/pubky-testnet/src/lib.rs
@@ -11,7 +11,7 @@ use anyhow::Result;
 use http_relay::HttpRelay;
 use pubky::{ClientBuilder, Keypair};
 use pubky_common::timestamp::Timestamp;
-use pubky_homeserver::Homeserver;
+use pubky_homeserver::{Homeserver, HomeserverBuilder};
 use url::Url;
 
 /// A local test network for Pubky Core development.
@@ -105,6 +105,15 @@ impl Testnet {
     /// Run a Pubky Homeserver
     pub async fn run_homeserver(&self) -> Result<Homeserver> {
         Homeserver::run_test(&self.dht.bootstrap).await
+    }
+
+    /// Returns a [HomeserverBuilder] preconfigured with this testnet's DHT bootstrap nodes.
+    pub fn homeserver_builder(&self) -> HomeserverBuilder {
+        let mut builder = Homeserver::builder();
+        // Set the DHT bootstrap nodes so the homeserver can join this local testnet
+        builder.bootstrap(&self.dht.bootstrap);
+
+        builder
     }
 
     /// Run an HTTP Relay

--- a/pubky/README.md
+++ b/pubky/README.md
@@ -24,7 +24,7 @@ async fn main () {
 
   // Signup to a Homeserver
   let keypair = Keypair::random();
-  client.signup(&keypair, &homeserver.public_key()).await.unwrap();
+  client.signup(&keypair, &homeserver.public_key(), None).await.unwrap();
 
   // Write data.
   let url = format!("pubky://{}/pub/foo.txt", keypair.public_key());

--- a/pubky/pkg/README.md
+++ b/pubky/pkg/README.md
@@ -3,6 +3,7 @@
 JavaScript implementation of [Pubky](https://github.com/pubky/pubky-core) client.
 
 ## Table of Contents
+
 - [Install](#install)
 - [Getting Started](#getting-started)
 - [API](#api)
@@ -21,7 +22,7 @@ For Nodejs, you need Node v20 or later.
 ## Getting started
 
 ```js
-import { Client, Keypair, PublicKey } from '../index.js'
+import { Client, Keypair, PublicKey } from "../index.js";
 
 // Initialize Client with Pkarr relay(s).
 let client = new Client();
@@ -30,9 +31,11 @@ let client = new Client();
 let keypair = Keypair.random();
 
 // Create a new account
-let homeserver = PublicKey.from("8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo");
+let homeserver = PublicKey.from(
+  "8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo"
+);
 
-await client.signup(keypair, homeserver)
+await client.signup(keypair, homeserver, signup_token);
 
 const publicKey = keypair.publicKey();
 
@@ -40,24 +43,24 @@ const publicKey = keypair.publicKey();
 let url = `pubky://${publicKey.z32()}/pub/example.com/arbitrary`;
 
 // Verify that you are signed in.
-const session = await client.session(publicKey)
+const session = await client.session(publicKey);
 
 // PUT public data, by authorized client
-await client.fetch(url, { 
-    method: "PUT",
-    body: JSON.stringify({foo: "bar"}),
-    credentials: "include"
+await client.fetch(url, {
+  method: "PUT",
+  body: JSON.stringify({ foo: "bar" }),
+  credentials: "include",
 });
 
 // GET public data without signup or signin
 {
-    const client = new Client();
+  const client = new Client();
 
-    let response = await client.fetch(url);
+  let response = await client.fetch(url);
 }
 
 // Delete public data, by authorized client
-await client.fetch(url, { method: "DELETE", credentials: "include "});
+await client.fetch(url, { method: "DELETE", credentials: "include " });
 ```
 
 ## API
@@ -65,11 +68,13 @@ await client.fetch(url, { method: "DELETE", credentials: "include "});
 ### Client
 
 #### constructor
+
 ```js
-let client = new Client()
+let client = new Client();
 ```
 
 #### fetch
+
 ```js
 let response = await client.fetch(url, opts);
 ```
@@ -77,35 +82,45 @@ let response = await client.fetch(url, opts);
 Just like normal Fetch API, but it can handle `pubky://` urls and `http(s)://` urls with Pkarr domains.
 
 #### signup
+
 ```js
-await client.signup(keypair, homeserver)
+await client.signup(keypair, homeserver, signup_token);
 ```
+
 - keypair: An instance of [Keypair](#keypair).
 - homeserver: An instance of [PublicKey](#publickey) representing the homeserver.
+- signup_token: A homeserver could optionally ask for a valid signup token (aka, invitation code).
 
 Returns:
+
 - session: An instance of [Session](#session).
 
 #### signin
+
 ```js
-let session = await client.signin(keypair)
+let session = await client.signin(keypair);
 ```
+
 - keypair: An instance of [Keypair](#keypair).
 
 Returns:
+
 - An instance of [Session](#session).
 
 #### signout
+
 ```js
-await client.signout(publicKey)
+await client.signout(publicKey);
 ```
+
 - publicKey: An instance of [PublicKey](#publicKey).
 
 #### authRequest
+
 ```js
 let pubkyAuthRequest = client.authRequest(relay, capabilities);
 
-let pubkyauthUrl= pubkyAuthRequest.url();
+let pubkyauthUrl = pubkyAuthRequest.url();
 
 showQr(pubkyauthUrl);
 
@@ -119,25 +134,31 @@ instead request permissions (showing the user pubkyauthUrl), and await a Session
 - capabilities: A list of capabilities required for the app for example `/pub/pubky.app/:rw,/pub/example.com/:r`.
 
 #### sendAuthToken
+
 ```js
 await client.sendAuthToken(keypair, pubkyauthUrl);
 ```
+
 Consenting to authentication or authorization according to the required capabilities in the `pubkyauthUrl` , and sign and send an auth token to the requester.
 
 - keypair: An instance of [KeyPair](#keypair)
 - pubkyauthUrl: A string `pubkyauth://` url
 
 #### session {#session-method}
+
 ```js
-let session = await client.session(publicKey)
+let session = await client.session(publicKey);
 ```
+
 - publicKey: An instance of [PublicKey](#publickey).
 - Returns: A [Session](#session) object if signed in, or undefined if not.
 
 ### list
+
 ```js
-let response = await client.list(url, cursor, reverse, limit)
+let response = await client.list(url, cursor, reverse, limit);
 ```
+
 - url: A string representing the Pubky URL. The path in that url is the prefix that you want to list files within.
 - cursor: Usually the last URL from previous calls. List urls after/before (depending on `reverse`) the cursor.
 - reverse: Whether or not return urls in reverse order.
@@ -147,29 +168,36 @@ let response = await client.list(url, cursor, reverse, limit)
 ### Keypair
 
 #### random
+
 ```js
-let keypair = Keypair.random()
+let keypair = Keypair.random();
 ```
+
 - Returns: A new random Keypair.
 
 #### fromSecretKey
+
 ```js
-let keypair = Keypair.fromSecretKey(secretKey)
+let keypair = Keypair.fromSecretKey(secretKey);
 ```
+
 - secretKey: A 32 bytes Uint8array.
 - Returns: A new Keypair.
 
-
 #### publicKey {#publickey-method}
+
 ```js
-let publicKey = keypair.publicKey()
+let publicKey = keypair.publicKey();
 ```
+
 - Returns: The [PublicKey](#publickey) associated with the Keypair.
 
 #### secretKey
+
 ```js
-let secretKey = keypair.secretKey()
+let secretKey = keypair.secretKey();
 ```
+
 - Returns: The Uint8array secret key associated with the Keypair.
 
 ### PublicKey
@@ -179,43 +207,54 @@ let secretKey = keypair.secretKey()
 ```js
 let publicKey = PublicKey.from(string);
 ```
+
 - string: A string representing the public key.
 - Returns: A new PublicKey instance.
 
 #### z32
+
 ```js
 let pubky = publicKey.z32();
 ```
+
 Returns: The z-base-32 encoded string representation of the PublicKey.
 
-### Session 
+### Session
 
 #### pubky
+
 ```js
 let pubky = session.pubky();
 ```
+
 Returns an instance of [PublicKey](#publickey)
 
 #### capabilities
+
 ```js
 let capabilities = session.capabilities();
 ```
+
 Returns an array of capabilities, for example `["/pub/pubky.app/:rw"]`
 
 ### Helper functions
 
 #### createRecoveryFile
+
 ```js
-let recoveryFile = createRecoveryFile(keypair, passphrase)
+let recoveryFile = createRecoveryFile(keypair, passphrase);
 ```
+
 - keypair: An instance of [Keypair](#keypair).
 - passphrase: A utf-8 string [passphrase](https://www.useapassphrase.com/).
 - Returns: A recovery file with a spec line and an encrypted secret key.
 
 #### createRecoveryFile
+
 ```js
-let keypair = decryptRecoveryfile(recoveryFile, passphrase)
+let keypair = decryptRecoveryfile(recoveryFile, passphrase);
 ```
+
 - recoveryFile: An instance of Uint8Array containing the recovery file blob.
 - passphrase: A utf-8 string [passphrase](https://www.useapassphrase.com/).
 - Returns: An instance of [Keypair](#keypair).
@@ -246,7 +285,7 @@ npm run testnet
 Use the logged addresses as inputs to `Client`
 
 ```js
-import { Client } from '../index.js'
+import { Client } from "../index.js";
 
 const client = Client().testnet();
 ```

--- a/pubky/pkg/package.json
+++ b/pubky/pkg/package.json
@@ -2,7 +2,7 @@
   "name": "@synonymdev/pubky",
   "type": "module",
   "description": "Pubky client",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/pubky/pkg/test/auth.js
+++ b/pubky/pkg/test/auth.js
@@ -1,7 +1,7 @@
 import test from 'tape'
 
 import { Client, Keypair, PublicKey, setLogLevel } from '../index.cjs'
-import { getSignupToken } from './utils.js';
+import { createSignupToken } from './utils.js';
 
 const HOMESERVER_PUBLICKEY = PublicKey.from('8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo')
 const TESTNET_HTTP_RELAY = "http://localhost:15412/link";
@@ -12,7 +12,7 @@ test('Auth: basic', async (t) => {
   const keypair = Keypair.random()
   const publicKey = keypair.publicKey()
 
-  const signupToken = await getSignupToken(client)
+  const signupToken = await createSignupToken(client)
 
   // Use the received token to sign up.
   await client.signup(keypair, HOMESERVER_PUBLICKEY, signupToken)
@@ -41,8 +41,8 @@ test("Auth: multi-user (cookies)", async (t) => {
   const alice = Keypair.random()
   const bob = Keypair.random()
 
-  const aliceSignupToken = await getSignupToken(client)
-  const bobSignupToken = await getSignupToken(client)
+  const aliceSignupToken = await createSignupToken(client)
+  const bobSignupToken = await createSignupToken(client)
 
   await client.signup(alice, HOMESERVER_PUBLICKEY , aliceSignupToken)
 
@@ -89,7 +89,7 @@ test("Auth: 3rd party signin", async (t) => {
   {
     let client = Client.testnet();
 
-    const signupToken = await getSignupToken(client)
+    const signupToken = await createSignupToken(client)
 
     await client.signup(keypair, HOMESERVER_PUBLICKEY, signupToken);
 

--- a/pubky/pkg/test/auth.js
+++ b/pubky/pkg/test/auth.js
@@ -11,7 +11,7 @@ test('Auth: basic', async (t) => {
   const keypair = Keypair.random()
   const publicKey = keypair.publicKey()
 
-  await client.signup(keypair, HOMESERVER_PUBLICKEY )
+  await client.signup(keypair, HOMESERVER_PUBLICKEY, null)
 
   const session = await client.session(publicKey)
   t.ok(session, "signup")
@@ -37,7 +37,7 @@ test("Auth: multi-user (cookies)", async (t) => {
   const alice = Keypair.random()
   const bob = Keypair.random()
 
-  await client.signup(alice, HOMESERVER_PUBLICKEY )
+  await client.signup(alice, HOMESERVER_PUBLICKEY , null)
 
   let session = await client.session(alice.publicKey())
   t.ok(session, "signup")
@@ -82,7 +82,7 @@ test("Auth: 3rd party signin", async (t) => {
   {
     let client = Client.testnet();
 
-    await client.signup(keypair, HOMESERVER_PUBLICKEY);
+    await client.signup(keypair, HOMESERVER_PUBLICKEY, null);
 
     await client.sendAuthToken(keypair, pubkyauthUrl)
   }

--- a/pubky/pkg/test/public.js
+++ b/pubky/pkg/test/public.js
@@ -1,6 +1,7 @@
 import test from 'tape'
 
 import { Client, Keypair, PublicKey, setLogLevel } from '../index.cjs'
+import { getSignupToken } from './utils.js';
 
 const HOMESERVER_PUBLICKEY = PublicKey.from('8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo')
 
@@ -9,7 +10,9 @@ test('public: put/get', async (t) => {
 
   const keypair = Keypair.random();
 
-  await client.signup(keypair, HOMESERVER_PUBLICKEY, null);
+  const signupToken = await getSignupToken(client)
+
+  await client.signup(keypair, HOMESERVER_PUBLICKEY, signupToken);
 
   const publicKey = keypair.publicKey();
 
@@ -57,7 +60,9 @@ test("not found", async (t) => {
 
   const keypair = Keypair.random();
 
-  await client.signup(keypair, HOMESERVER_PUBLICKEY, null);
+  const signupToken = await getSignupToken(client)
+
+  await client.signup(keypair, HOMESERVER_PUBLICKEY, signupToken);
 
   const publicKey = keypair.publicKey();
 
@@ -74,7 +79,9 @@ test("unauthorized", async (t) => {
   const keypair = Keypair.random()
   const publicKey = keypair.publicKey()
 
-  await client.signup(keypair, HOMESERVER_PUBLICKEY, null)
+  const signupToken = await getSignupToken(client)
+
+  await client.signup(keypair, HOMESERVER_PUBLICKEY, signupToken)
 
   const session = await client.session(publicKey)
   t.ok(session, "signup")
@@ -100,7 +107,9 @@ test("forbidden", async (t) => {
   const keypair = Keypair.random()
   const publicKey = keypair.publicKey()
 
-  await client.signup(keypair, HOMESERVER_PUBLICKEY, null)
+  const signupToken = await getSignupToken(client)
+
+  await client.signup(keypair, HOMESERVER_PUBLICKEY, signupToken)
 
   const session = await client.session(publicKey)
   t.ok(session, "signup")
@@ -127,7 +136,9 @@ test("list", async (t) => {
   const publicKey = keypair.publicKey()
   const pubky = publicKey.z32()
 
-  await client.signup(keypair, HOMESERVER_PUBLICKEY, null)
+  const signupToken = await getSignupToken(client)
+
+  await client.signup(keypair, HOMESERVER_PUBLICKEY, signupToken)
 
   let urls = [
     `pubky://${pubky}/pub/a.wrong/a.txt`,
@@ -260,7 +271,9 @@ test('list shallow', async (t) => {
   const publicKey = keypair.publicKey()
   const pubky = publicKey.z32()
 
-  await client.signup(keypair, HOMESERVER_PUBLICKEY, null)
+  const signupToken = await getSignupToken(client)
+
+  await client.signup(keypair, HOMESERVER_PUBLICKEY, signupToken)
 
   let urls = [
     `pubky://${pubky}/pub/a.com/a.txt`,

--- a/pubky/pkg/test/public.js
+++ b/pubky/pkg/test/public.js
@@ -1,7 +1,7 @@
 import test from 'tape'
 
 import { Client, Keypair, PublicKey, setLogLevel } from '../index.cjs'
-import { getSignupToken } from './utils.js';
+import { createSignupToken } from './utils.js';
 
 const HOMESERVER_PUBLICKEY = PublicKey.from('8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo')
 
@@ -10,7 +10,7 @@ test('public: put/get', async (t) => {
 
   const keypair = Keypair.random();
 
-  const signupToken = await getSignupToken(client)
+  const signupToken = await createSignupToken(client)
 
   await client.signup(keypair, HOMESERVER_PUBLICKEY, signupToken);
 
@@ -60,7 +60,7 @@ test("not found", async (t) => {
 
   const keypair = Keypair.random();
 
-  const signupToken = await getSignupToken(client)
+  const signupToken = await createSignupToken(client)
 
   await client.signup(keypair, HOMESERVER_PUBLICKEY, signupToken);
 
@@ -79,7 +79,7 @@ test("unauthorized", async (t) => {
   const keypair = Keypair.random()
   const publicKey = keypair.publicKey()
 
-  const signupToken = await getSignupToken(client)
+  const signupToken = await createSignupToken(client)
 
   await client.signup(keypair, HOMESERVER_PUBLICKEY, signupToken)
 
@@ -107,7 +107,7 @@ test("forbidden", async (t) => {
   const keypair = Keypair.random()
   const publicKey = keypair.publicKey()
 
-  const signupToken = await getSignupToken(client)
+  const signupToken = await createSignupToken(client)
 
   await client.signup(keypair, HOMESERVER_PUBLICKEY, signupToken)
 
@@ -136,7 +136,7 @@ test("list", async (t) => {
   const publicKey = keypair.publicKey()
   const pubky = publicKey.z32()
 
-  const signupToken = await getSignupToken(client)
+  const signupToken = await createSignupToken(client)
 
   await client.signup(keypair, HOMESERVER_PUBLICKEY, signupToken)
 
@@ -271,7 +271,7 @@ test('list shallow', async (t) => {
   const publicKey = keypair.publicKey()
   const pubky = publicKey.z32()
 
-  const signupToken = await getSignupToken(client)
+  const signupToken = await createSignupToken(client)
 
   await client.signup(keypair, HOMESERVER_PUBLICKEY, signupToken)
 

--- a/pubky/pkg/test/public.js
+++ b/pubky/pkg/test/public.js
@@ -9,7 +9,7 @@ test('public: put/get', async (t) => {
 
   const keypair = Keypair.random();
 
-  await client.signup(keypair, HOMESERVER_PUBLICKEY);
+  await client.signup(keypair, HOMESERVER_PUBLICKEY, null);
 
   const publicKey = keypair.publicKey();
 
@@ -57,7 +57,7 @@ test("not found", async (t) => {
 
   const keypair = Keypair.random();
 
-  await client.signup(keypair, HOMESERVER_PUBLICKEY);
+  await client.signup(keypair, HOMESERVER_PUBLICKEY, null);
 
   const publicKey = keypair.publicKey();
 
@@ -74,7 +74,7 @@ test("unauthorized", async (t) => {
   const keypair = Keypair.random()
   const publicKey = keypair.publicKey()
 
-  await client.signup(keypair, HOMESERVER_PUBLICKEY)
+  await client.signup(keypair, HOMESERVER_PUBLICKEY, null)
 
   const session = await client.session(publicKey)
   t.ok(session, "signup")
@@ -100,7 +100,7 @@ test("forbidden", async (t) => {
   const keypair = Keypair.random()
   const publicKey = keypair.publicKey()
 
-  await client.signup(keypair, HOMESERVER_PUBLICKEY)
+  await client.signup(keypair, HOMESERVER_PUBLICKEY, null)
 
   const session = await client.session(publicKey)
   t.ok(session, "signup")
@@ -127,7 +127,7 @@ test("list", async (t) => {
   const publicKey = keypair.publicKey()
   const pubky = publicKey.z32()
 
-  await client.signup(keypair, HOMESERVER_PUBLICKEY)
+  await client.signup(keypair, HOMESERVER_PUBLICKEY, null)
 
   let urls = [
     `pubky://${pubky}/pub/a.wrong/a.txt`,
@@ -260,7 +260,7 @@ test('list shallow', async (t) => {
   const publicKey = keypair.publicKey()
   const pubky = publicKey.z32()
 
-  await client.signup(keypair, HOMESERVER_PUBLICKEY)
+  await client.signup(keypair, HOMESERVER_PUBLICKEY, null)
 
   let urls = [
     `pubky://${pubky}/pub/a.com/a.txt`,

--- a/pubky/pkg/test/utils.js
+++ b/pubky/pkg/test/utils.js
@@ -1,0 +1,25 @@
+
+/**
+ * Util to request a signup token from the given homeserver as admin.
+ *
+ * @param {Client} client - An instance of your client.
+ * @param {string} homeserver_address - The homeserver's public key (as a domain-like string).
+ * @param {string} [adminPassword="admin"] - The admin password (defaults to "admin").
+ * @returns {Promise<string>} - The signup token.
+ * @throws Will throw an error if the request fails.
+ */
+export async function getSignupToken(client, homeserver_address ="localhost:6286", adminPassword = "admin") {
+  const adminUrl = `http://${homeserver_address}/admin/generate_signup_token`;
+  const response = await client.fetch(adminUrl, {
+    method: "GET",
+    headers: {
+      "X-Admin-Password": adminPassword,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to get signup token: ${response.statusText}`);
+  }
+
+  return response.text();
+}

--- a/pubky/pkg/test/utils.js
+++ b/pubky/pkg/test/utils.js
@@ -8,7 +8,7 @@
  * @returns {Promise<string>} - The signup token.
  * @throws Will throw an error if the request fails.
  */
-export async function getSignupToken(client, homeserver_address ="localhost:6286", adminPassword = "admin") {
+export async function createSignupToken(client, homeserver_address ="localhost:6286", adminPassword = "admin") {
   const adminUrl = `http://${homeserver_address}/admin/generate_signup_token`;
   const response = await client.fetch(adminUrl, {
     method: "GET",

--- a/pubky/src/native/api/auth.rs
+++ b/pubky/src/native/api/auth.rs
@@ -572,23 +572,16 @@ mod tests {
     async fn test_signup_with_token() {
         // 1. Start a test homeserver with closed signups (i.e. signup tokens required)
         let testnet = Testnet::run().await.unwrap();
-        let server = unsafe {
-            testnet
-                .homeserver_builder()
-                .close_signups() // configure this test homeserver to require signup tokens
-                .run()
-                .await
-                .unwrap()
-        };
+        let server = testnet.run_homeserver_with_signup_tokens().await.unwrap();
 
-        let admin_password = "test_admin_password";
+        let admin_password = "admin";
 
         let client = testnet.client_builder().build().unwrap();
         let keypair = Keypair::random();
 
         // 2. Try to signup with an invalid token "AAAAA" and expect failure.
         let invalid_signup = client
-            .signup(&keypair, &server.public_key(), Some("AAAAA"))
+            .signup(&keypair, &server.public_key(), Some("AAAA-BBBB-CCCC"))
             .await;
         assert!(
             invalid_signup.is_err(),

--- a/pubky/src/native/api/public.rs
+++ b/pubky/src/native/api/public.rs
@@ -138,7 +138,10 @@ mod tests {
 
         let keypair = Keypair::random();
 
-        client.signup(&keypair, &server.public_key()).await.unwrap();
+        client
+            .signup(&keypair, &server.public_key(), None)
+            .await
+            .unwrap();
 
         let url = format!("pubky://{}/pub/foo.txt", keypair.public_key());
         let url = url.as_str();
@@ -178,7 +181,10 @@ mod tests {
 
         let keypair = Keypair::random();
 
-        client.signup(&keypair, &server.public_key()).await.unwrap();
+        client
+            .signup(&keypair, &server.public_key(), None)
+            .await
+            .unwrap();
 
         let public_key = keypair.public_key();
 
@@ -191,7 +197,7 @@ mod tests {
 
             // TODO: remove extra client after switching to subdomains.
             other_client
-                .signup(&other, &server.public_key())
+                .signup(&other, &server.public_key(), None)
                 .await
                 .unwrap();
 
@@ -219,7 +225,7 @@ mod tests {
 
             // TODO: remove extra client after switching to subdomains.
             other_client
-                .signup(&other, &server.public_key())
+                .signup(&other, &server.public_key(), None)
                 .await
                 .unwrap();
 
@@ -243,7 +249,10 @@ mod tests {
 
         let keypair = Keypair::random();
 
-        client.signup(&keypair, &server.public_key()).await.unwrap();
+        client
+            .signup(&keypair, &server.public_key(), None)
+            .await
+            .unwrap();
 
         let pubky = keypair.public_key();
 
@@ -446,7 +455,10 @@ mod tests {
 
         let keypair = Keypair::random();
 
-        client.signup(&keypair, &server.public_key()).await.unwrap();
+        client
+            .signup(&keypair, &server.public_key(), None)
+            .await
+            .unwrap();
 
         let pubky = keypair.public_key();
 
@@ -656,7 +668,10 @@ mod tests {
 
         let keypair = Keypair::random();
 
-        client.signup(&keypair, &server.public_key()).await.unwrap();
+        client
+            .signup(&keypair, &server.public_key(), None)
+            .await
+            .unwrap();
 
         let pubky = keypair.public_key();
 
@@ -752,7 +767,10 @@ mod tests {
 
         let keypair = Keypair::random();
 
-        client.signup(&keypair, &server.public_key()).await.unwrap();
+        client
+            .signup(&keypair, &server.public_key(), None)
+            .await
+            .unwrap();
 
         let pubky = keypair.public_key();
 
@@ -805,8 +823,14 @@ mod tests {
         let user_1 = Keypair::random();
         let user_2 = Keypair::random();
 
-        client.signup(&user_1, &homeserver_pubky).await.unwrap();
-        client.signup(&user_2, &homeserver_pubky).await.unwrap();
+        client
+            .signup(&user_1, &homeserver_pubky, None)
+            .await
+            .unwrap();
+        client
+            .signup(&user_2, &homeserver_pubky, None)
+            .await
+            .unwrap();
 
         let user_1_id = user_1.public_key();
         let user_2_id = user_2.public_key();
@@ -872,7 +896,10 @@ mod tests {
 
         let keypair = Keypair::random();
 
-        client.signup(&keypair, &server.public_key()).await.unwrap();
+        client
+            .signup(&keypair, &server.public_key(), None)
+            .await
+            .unwrap();
 
         let url = format!("pubky://{}/pub/foo.txt", keypair.public_key());
         let url = url.as_str();

--- a/pubky/src/wasm/api/auth.rs
+++ b/pubky/src/wasm/api/auth.rs
@@ -24,14 +24,14 @@ impl Client {
         &self,
         keypair: &Keypair,
         homeserver: &PublicKey,
-        signup_token: &Option<&str>,
+        signup_token: Option<String>,
     ) -> Result<Session, JsValue> {
         Ok(Session(
             self.0
                 .signup(
                     keypair.as_inner(),
                     homeserver.as_inner(),
-                    signup_token.as_inner(),
+                    signup_token.as_deref(),
                 )
                 .await
                 .map_err(|e| JsValue::from_str(&e.to_string()))?,

--- a/pubky/src/wasm/api/auth.rs
+++ b/pubky/src/wasm/api/auth.rs
@@ -24,10 +24,15 @@ impl Client {
         &self,
         keypair: &Keypair,
         homeserver: &PublicKey,
+        signup_token: &Option<&str>,
     ) -> Result<Session, JsValue> {
         Ok(Session(
             self.0
-                .signup(keypair.as_inner(), homeserver.as_inner())
+                .signup(
+                    keypair.as_inner(),
+                    homeserver.as_inner(),
+                    signup_token.as_inner(),
+                )
                 .await
                 .map_err(|e| JsValue::from_str(&e.to_string()))?,
         ))


### PR DESCRIPTION
Fixes #74

- [x] admin password and new config
- [x] new table for signup_tokens
- [x] new `/admin/generate_signup_token` endpoint
- [x] homeserver can run with and without signup token requirements
- [x] client can signup with a valid token. Fails to signup with an invalid token. And can signup always when no token required.
- [x] signup is not a wrapper of signin anymore. Now, sign in does not create new users (lmao). Sign up will return an error if user existed already.
- [x] Client test for native signup flow with a signup token.
- [x] Wasm API updated and wasm building
- [x] Client test for wasm signup flow with a signup token.