### PR TITLE
fix (pkarr-republisher): Include in Github workflow

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         crate:
-          [pubky, pubky-common, pubky-homeserver, pubky-testnet, http-relay]
+          [pubky, pubky-common, pubky-homeserver, pubky-testnet, http-relay, pkarr-republisher]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
`pkarr-republisher` tests were not run on Github. This adds the tests.