### PR TITLE
feat(homeserver): fallback missing pubky-host header to query param

### DIFF
--- a/e2e/src/tests/public.rs
+++ b/e2e/src/tests/public.rs
@@ -29,7 +29,30 @@ async fn put_get_delete() {
         .error_for_status()
         .unwrap();
 
+    // Use Pubky native method to get data from homeserver
     let response = client.get(url).send().await.unwrap().bytes().await.unwrap();
+
+    assert_eq!(response, bytes::Bytes::from(vec![0, 1, 2, 3, 4]));
+
+    // Use regular web method to get data from homeserver (with query pubky-host)
+    let regular_url = format!(
+        "{}pub/foo.txt?pubky-host={}",
+        server.url(),
+        keypair.public_key()
+    );
+
+    // We set `non.pubky.host` header as otherwise he client will use by default
+    // the homeserver pubky as host and this request will resolve the `/pub/foo.txt` of
+    // the wrong tenant user
+    let response = client
+        .get(regular_url)
+        .header("Host", "non.pubky.host")
+        .send()
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
 
     assert_eq!(response, bytes::Bytes::from(vec![0, 1, 2, 3, 4]));
 


### PR DESCRIPTION
A simple fix so the `pubky-host` header, if missing, can be extracted from the URL. So in addition of this working
```bash
curl -H "pubky-host: b8pf41opxrtgwjox7a49u6d677snmutyukzdy5wdueet5sne4q8o" https://homeserver.pubky.app/pub/pubky.app/profile.json
```
this would also work
```
curl https://homeserver.pubky.app/pub/pubky.app/profile.json&pubky-host=b8pf41opxrtgwjox7a49u6d677snmutyukzdy5wdueet5sne4q8o
```
Useful for fetching data from contexts where headers cannot be set.