### PR TITLE
fix(homeserver): simplified config with serde(default)

### DIFF
--- a/pubky-homeserver/src/data_directory/config_toml.rs
+++ b/pubky-homeserver/src/data_directory/config_toml.rs
@@ -30,11 +30,11 @@ pub struct PkdnsToml {
     pub user_keys_republisher_interval: NonZeroU64,
 
     /// The list of bootstrap nodes for the DHT. If None, the default pkarr bootstrap nodes will be used.
-    #[serde(default = "default_dht_bootstrap_nodes")]
+    #[serde(default)]
     pub dht_bootstrap_nodes: Option<Vec<DomainPort>>,
 
     /// The list of relay nodes for the DHT. If None, the default pkarr relay nodes will be used.
-    #[serde(default = "default_dht_relay_nodes")]
+    #[serde(default)]
     pub dht_relay_nodes: Option<Vec<Url>>,
 }
 
@@ -42,14 +42,6 @@ fn default_public_socket() -> SocketAddr {
     let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let port = 6286;
     SocketAddr::from((ip, port))
-}
-
-fn default_dht_bootstrap_nodes() -> Option<Vec<DomainPort>> {
-    None
-}
-
-fn default_dht_relay_nodes() -> Option<Vec<Url>> {
-    None
 }
 
 fn default_user_keys_republisher_interval() -> NonZeroU64 {
@@ -73,7 +65,7 @@ pub struct DriveToml {
     #[serde(default = "default_icann_drive_listen_socket")]
     pub icann_listen_socket: SocketAddr,
     /// Optional domain name of the regular http API.
-    #[serde(default = "default_icann_drive_domain")]
+    #[serde(default)]
     pub icann_domain: Option<String>,
 }
 
@@ -81,10 +73,6 @@ fn default_icann_drive_listen_socket() -> SocketAddr {
     let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
     let port = 6286;
     SocketAddr::from((ip, port))
-}
-
-fn default_icann_drive_domain() -> Option<String> {
-    None
 }
 
 /// All configuration related to the admin API
@@ -112,19 +100,11 @@ fn default_admin_listen_socket() -> SocketAddr {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct GeneralToml {
     /// The mode of the signup.
-    #[serde(default = "default_signup_mode")]
+    #[serde(default)]
     pub signup_mode: SignupMode,
     /// LMDB backup interval in seconds. 0 means disabled.
-    #[serde(default = "default_lmdb_backup_interval_s")]
+    #[serde(default)]
     pub lmdb_backup_interval_s: u64,
-}
-
-fn default_signup_mode() -> SignupMode {
-    SignupMode::TokenRequired
-}
-
-fn default_lmdb_backup_interval_s() -> u64 {
-    0
 }
 
 /// The error that can occur when reading the config file

--- a/pubky-homeserver/src/data_directory/signup_mode.rs
+++ b/pubky-homeserver/src/data_directory/signup_mode.rs
@@ -1,10 +1,10 @@
 use core::fmt;
-use std::{fmt::Display, str::FromStr};
-
 use serde::{Deserialize, Serialize};
+use std::fmt::Display;
 
 /// The mode of signup.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum SignupMode {
     /// Everybody can signup.
     Open,
@@ -22,53 +22,34 @@ impl Display for SignupMode {
     }
 }
 
-impl FromStr for SignupMode {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(match s {
-            "open" => Self::Open,
-            "token_required" => Self::TokenRequired,
-            _ => return Err(anyhow::anyhow!("Invalid signup mode: {}", s)),
-        })
-    }
-}
-
-impl Serialize for SignupMode {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(self.to_string().as_str())
-    }
-}
-
-impl<'de> Deserialize<'de> for SignupMode {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        Ok(Self::from_str(&s).unwrap())
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_signup_mode_from_str() {
-        assert_eq!(SignupMode::from_str("open").unwrap(), SignupMode::Open);
-        assert_eq!(
-            SignupMode::from_str("token_required").unwrap(),
-            SignupMode::TokenRequired
-        );
-    }
-
-    #[test]
     fn test_signup_mode_display() {
         assert_eq!(SignupMode::Open.to_string(), "open");
         assert_eq!(SignupMode::TokenRequired.to_string(), "token_required");
+    }
+
+    #[derive(Default, Serialize, Deserialize)]
+    struct TestToml {
+        #[serde(default)]
+        signup_mode: SignupMode,
+    }
+
+    #[test]
+    fn test_signup_mode_serde() {
+        let test_toml = TestToml::default();
+        assert_eq!(test_toml.signup_mode, SignupMode::TokenRequired);
+
+        let test_toml_str = toml::to_string(&test_toml).unwrap();
+        assert_eq!(test_toml_str, "signup_mode = \"token_required\"\n");
+
+        let test_toml_2: TestToml = toml::from_str(&test_toml_str).unwrap();
+        assert_eq!(test_toml_2.signup_mode, SignupMode::TokenRequired);
+
+        let test_toml_3: TestToml = toml::from_str("\n").unwrap();
+        assert_eq!(test_toml_3.signup_mode, SignupMode::TokenRequired);
     }
 }

--- a/pubky-homeserver/src/data_directory/signup_mode.rs
+++ b/pubky-homeserver/src/data_directory/signup_mode.rs
@@ -1,6 +1,4 @@
-use core::fmt;
 use serde::{Deserialize, Serialize};
-use std::fmt::Display;
 
 /// The mode of signup.
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -13,24 +11,9 @@ pub enum SignupMode {
     TokenRequired,
 }
 
-impl Display for SignupMode {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Open => write!(f, "open"),
-            Self::TokenRequired => write!(f, "token_required"),
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_signup_mode_display() {
-        assert_eq!(SignupMode::Open.to_string(), "open");
-        assert_eq!(SignupMode::TokenRequired.to_string(), "token_required");
-    }
 
     #[derive(Default, Serialize, Deserialize)]
     struct TestToml {


### PR DESCRIPTION
Remove `unwrap()` in SignupMode and uses more serde(default) macros to simplify the code.

`Display` is still there for debug/optic purposes.