### PR TITLE
feat: add --homeserver-config arg to testnet binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.30"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b7b18d71fad5313a1e320fa9897994228ce274b60faa4d694fe0ea89cd9e6d"
+checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -489,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.30"
+version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35db2071778a7344791a4fb4f95308b5673d219dee3ae348b86642574ecc90c"
+checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
 dependencies = [
  "anstream",
  "anstyle",
@@ -501,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2361,6 +2361,8 @@ name = "pubky-testnet"
 version = "0.2.0-rc.1"
 dependencies = [
  "anyhow",
+ "clap",
+ "dirs",
  "http-relay",
  "mainline",
  "pkarr",

--- a/pubky-homeserver/src/core/homeserver_core.rs
+++ b/pubky-homeserver/src/core/homeserver_core.rs
@@ -103,6 +103,7 @@ impl HomeserverCore {
     /// - Creates the web server (router) for testing. Use `listen` to start the server.
     pub async fn new(context: AppContext) -> std::result::Result<Self, HomeserverBuildError> {
         let router = Self::create_router(&context);
+
         let (icann_http_handle, icann_http_socket) =
             Self::start_icann_http_server(&context, router.clone())
                 .await

--- a/pubky-testnet/Cargo.toml
+++ b/pubky-testnet/Cargo.toml
@@ -25,3 +25,5 @@ tempfile = "3.19.1"
 tracing = "0.1.41"
 pkarr = { workspace = true }
 mainline = { workspace = true }
+clap = "4.5.36"
+dirs = "6.0.0"

--- a/pubky-testnet/src/ephemeral_testnet.rs
+++ b/pubky-testnet/src/ephemeral_testnet.rs
@@ -10,35 +10,35 @@ use crate::Testnet;
 /// - An admin server for the homeserver.
 pub struct EphemeralTestnet {
     /// Inner flexible testnet.
-    pub flexible_testnet: Testnet,
+    pub testnet: Testnet,
 }
 
 impl EphemeralTestnet {
     /// Run a new simple testnet.
     pub async fn start() -> anyhow::Result<Self> {
         let mut me = Self {
-            flexible_testnet: Testnet::new().await?,
+            testnet: Testnet::new().await?,
         };
 
-        me.flexible_testnet.create_http_relay().await?;
-        me.flexible_testnet.create_homeserver_suite().await?;
+        me.testnet.create_http_relay().await?;
+        me.testnet.create_homeserver_suite().await?;
 
         Ok(me)
     }
 
     /// Create a new pubky client builder.
     pub fn pubky_client_builder(&self) -> pubky::ClientBuilder {
-        self.flexible_testnet.pubky_client_builder()
+        self.testnet.pubky_client_builder()
     }
 
     /// Create a new pkarr client builder.
     pub fn pkarr_client_builder(&self) -> pkarr::ClientBuilder {
-        self.flexible_testnet.pkarr_client_builder()
+        self.testnet.pkarr_client_builder()
     }
 
     /// Get the homeserver in the testnet.
     pub fn homeserver_suite(&self) -> &pubky_homeserver::HomeserverSuite {
-        self.flexible_testnet
+        self.testnet
             .homeservers
             .first()
             .expect("homeservers should be non-empty")
@@ -46,7 +46,7 @@ impl EphemeralTestnet {
 
     /// Get the http relay in the testnet.
     pub fn http_relay(&self) -> &HttpRelay {
-        self.flexible_testnet
+        self.testnet
             .http_relays
             .first()
             .expect("http relays should be non-empty")


### PR DESCRIPTION
Adds the ability to run the `StaticTestnet` binary with a custom homeserver config

```bash
cargo run -- --homeserver-config=config.toml  
```

The old way still works too

```bash
cargo run
```

In both ways, the data is not persisted after the binary is stopped.


