### PR TITLE
feat: Make config headers optional

### DIFF
--- a/pubky-homeserver/src/data_directory/config_toml.rs
+++ b/pubky-homeserver/src/data_directory/config_toml.rs
@@ -149,7 +149,7 @@ fn default_admin_listen_socket() -> SocketAddr {
 }
 
 /// All configuration related to the admin API
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 pub struct GeneralToml {
     /// The mode of the signup.
     #[serde(default)]
@@ -157,15 +157,6 @@ pub struct GeneralToml {
     /// LMDB backup interval in seconds. 0 means disabled.
     #[serde(default)]
     pub lmdb_backup_interval_s: u64,
-}
-
-impl Default for GeneralToml {
-    fn default() -> Self {
-        Self {
-            signup_mode: SignupMode::default(),
-            lmdb_backup_interval_s: u64::default(),
-        }
-    }
 }
 
 /// The error that can occur when reading the config file
@@ -320,12 +311,12 @@ mod tests {
         signup_mode = \"open\"
         ";
         let parsed: ConfigToml = s.parse().unwrap();
-        
+
         // Check that explicitly set values are preserved
         assert_eq!(
-            parsed.general.signup_mode, SignupMode::Open,
+            parsed.general.signup_mode,
+            SignupMode::Open,
             "signup_mode not set correctly"
         );
-        
     }
 }

--- a/pubky-homeserver/src/data_directory/config_toml.rs
+++ b/pubky-homeserver/src/data_directory/config_toml.rs
@@ -56,6 +56,21 @@ pub struct PkdnsToml {
     pub dht_request_timeout_ms: Option<NonZeroU64>,
 }
 
+impl Default for PkdnsToml {
+    fn default() -> Self {
+        Self {
+            public_ip: default_public_ip(),
+            public_pubky_tls_port: Option::default(),
+            public_icann_http_port: Option::default(),
+            icann_domain: Option::default(),
+            user_keys_republisher_interval: default_user_keys_republisher_interval(),
+            dht_bootstrap_nodes: default_dht_bootstrap_nodes(),
+            dht_relay_nodes: default_dht_relay_nodes(),
+            dht_request_timeout_ms: default_dht_request_timeout(),
+        }
+    }
+}
+
 fn default_public_ip() -> IpAddr {
     IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))
 }
@@ -88,6 +103,15 @@ pub struct DriveToml {
     pub icann_listen_socket: SocketAddr,
 }
 
+impl Default for DriveToml {
+    fn default() -> Self {
+        Self {
+            pubky_listen_socket: default_pubky_drive_listen_socket(),
+            icann_listen_socket: default_icann_drive_listen_socket(),
+        }
+    }
+}
+
 fn default_pubky_drive_listen_socket() -> SocketAddr {
     SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::new(127, 0, 0, 1), 6287))
 }
@@ -105,6 +129,15 @@ pub struct AdminToml {
     /// The password for the admin API.
     #[serde(default = "default_admin_password")]
     pub admin_password: String,
+}
+
+impl Default for AdminToml {
+    fn default() -> Self {
+        Self {
+            listen_socket: default_admin_listen_socket(),
+            admin_password: default_admin_password(),
+        }
+    }
 }
 
 fn default_admin_password() -> String {
@@ -126,6 +159,15 @@ pub struct GeneralToml {
     pub lmdb_backup_interval_s: u64,
 }
 
+impl Default for GeneralToml {
+    fn default() -> Self {
+        Self {
+            signup_mode: SignupMode::default(),
+            lmdb_backup_interval_s: u64::default(),
+        }
+    }
+}
+
 /// The error that can occur when reading the config file
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigReadError {
@@ -141,12 +183,16 @@ pub enum ConfigReadError {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct ConfigToml {
     /// The configuration for the general settings.
+    #[serde(default)]
     pub general: GeneralToml,
     /// The configuration for the drive files.
+    #[serde(default)]
     pub drive: DriveToml,
     /// The configuration for the admin API.
+    #[serde(default)]
     pub admin: AdminToml,
     /// The configuration for the pkdns.
+    #[serde(default)]
     pub pkdns: PkdnsToml,
 }
 
@@ -265,5 +311,21 @@ mod tests {
             parsed.pkdns.dht_bootstrap_nodes, None,
             "dht_bootstrap_nodes not commented out"
         );
+    }
+
+    #[test]
+    fn test_empty_config() {
+        // Test that a minimal config with only the general section works
+        let s = "[general]
+        signup_mode = \"open\"
+        ";
+        let parsed: ConfigToml = s.parse().unwrap();
+        
+        // Check that explicitly set values are preserved
+        assert_eq!(
+            parsed.general.signup_mode, SignupMode::Open,
+            "signup_mode not set correctly"
+        );
+        
     }
 }


### PR DESCRIPTION
All config values are optional but the headers (`[general]`) aren't. This PR makes them optional too. This way, an empty config file is a valid config too.