### PR TITLE
feat(homeserver): Admin delete entry + ban user endpoints

### DIFF
--- a/e2e/src/tests/auth.rs
+++ b/e2e/src/tests/auth.rs
@@ -52,6 +52,66 @@ async fn basic_authn() {
 }
 
 #[tokio::test]
+async fn disabled_user() {
+    let testnet = EphemeralTestnet::start().await.unwrap();
+    let server = testnet.homeserver_suite();
+
+    let client = testnet.pubky_client_builder().build().unwrap();
+
+    let keypair = Keypair::random();
+    let pubky = keypair.public_key();
+
+    // Create a new user
+    client
+        .signup(&keypair, &server.public_key(), None)
+        .await
+        .unwrap();
+
+    // Create a test file to make sure the user can write to their account
+    let file_url = format!("pubky://{pubky}/pub/pubky.app/foo");
+    client
+        .put(file_url.clone())
+        .body(vec![])
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+
+    // Make sure the user can read their own file
+    let response = client.get(file_url.clone()).send().await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let admin_socket = server.admin().listen_socket();
+    let admin_client = reqwest::Client::new();
+
+    // Disable the user
+    let response = admin_client
+        .post(format!("http://{admin_socket}/users/{pubky}/disable"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Make sure the user cannot read their own file
+    let response = client.get(file_url.clone()).send().await.unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    // Make sure the user cannot write to their own file
+    let response = client
+        .put(file_url.clone())
+        .body(vec![])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+
+    // Make sure the user cannot sign in
+    let session = client.signin(&keypair).await;
+    assert!(session.is_err());
+}
+
+#[tokio::test]
 async fn authz() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();

--- a/pubky-homeserver/src/admin/app.rs
+++ b/pubky-homeserver/src/admin/app.rs
@@ -2,11 +2,13 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use super::routes::{generate_signup_token, root};
+use super::routes::disable_users::{disable_tenant, enable_tenant};
+use super::routes::{delete_entry, generate_signup_token, root};
 use super::trace::with_trace_layer;
 use super::{app_state::AppState, auth_middleware::AdminAuthLayer};
 use crate::app_context::AppContext;
 use crate::{AppContextConversionError, MockDataDir, PersistentDataDir};
+use axum::routing::{delete, post};
 use axum::{routing::get, Router};
 use axum_server::Handle;
 use tokio::task::JoinHandle;
@@ -31,6 +33,12 @@ fn create_app(state: AppState, password: &str) -> axum::routing::IntoMakeService
     let app = Router::new()
         .nest("/admin", admin_router)
         .route("/", get(root::root))
+        .route(
+            "/drive/pub/{pubkey}/{*path}",
+            delete(delete_entry::delete_entry),
+        )
+        .route("/users/{pubkey}/disable", post(disable_tenant))
+        .route("/users/{pubkey}/enable", post(enable_tenant))
         .with_state(state)
         .layer(CorsLayer::very_permissive());
 

--- a/pubky-homeserver/src/admin/app.rs
+++ b/pubky-homeserver/src/admin/app.rs
@@ -2,7 +2,7 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use super::routes::disable_users::{disable_tenant, enable_tenant};
+use super::routes::disable_users::{disable_user, enable_user};
 use super::routes::{delete_entry, generate_signup_token, root};
 use super::trace::with_trace_layer;
 use super::{app_state::AppState, auth_middleware::AdminAuthLayer};
@@ -37,8 +37,8 @@ fn create_app(state: AppState, password: &str) -> axum::routing::IntoMakeService
             "/webdav/{pubkey}/pub/{*path}",
             delete(delete_entry::delete_entry),
         )
-        .route("/users/{pubkey}/disable", post(disable_tenant))
-        .route("/users/{pubkey}/enable", post(enable_tenant))
+        .route("/users/{pubkey}/disable", post(disable_user))
+        .route("/users/{pubkey}/enable", post(enable_user))
         .with_state(state)
         .layer(CorsLayer::very_permissive());
 

--- a/pubky-homeserver/src/admin/app.rs
+++ b/pubky-homeserver/src/admin/app.rs
@@ -34,7 +34,7 @@ fn create_app(state: AppState, password: &str) -> axum::routing::IntoMakeService
         .nest("/admin", admin_router)
         .route("/", get(root::root))
         .route(
-            "/webdav/{pubkey}/pub/{*path}",
+            "/webdav/{pubkey}/{*path}",
             delete(delete_entry::delete_entry),
         )
         .route("/users/{pubkey}/disable", post(disable_user))

--- a/pubky-homeserver/src/admin/app.rs
+++ b/pubky-homeserver/src/admin/app.rs
@@ -34,7 +34,7 @@ fn create_app(state: AppState, password: &str) -> axum::routing::IntoMakeService
         .nest("/admin", admin_router)
         .route("/", get(root::root))
         .route(
-            "/drive/pub/{pubkey}/{*path}",
+            "/webdav/{pubkey}/pub/{*path}",
             delete(delete_entry::delete_entry),
         )
         .route("/users/{pubkey}/disable", post(disable_tenant))

--- a/pubky-homeserver/src/admin/routes/delete_entry.rs
+++ b/pubky-homeserver/src/admin/routes/delete_entry.rs
@@ -64,7 +64,7 @@ mod tests {
         // Delete the file
         let server = axum_test::TestServer::new(router).unwrap();
         let response = server
-            .delete(format!("/webdav/{}/pub/{}", pubkey, file_path).as_str())
+            .delete(format!("/webdav/{}{}", pubkey, entry_path).as_str())
             .await;
         assert_eq!(response.status_code(), StatusCode::NO_CONTENT);
 
@@ -92,7 +92,7 @@ mod tests {
         let file_path = "my_file.txt";
         let app_state = AppState::new(LmDB::test());
         let router = Router::new()
-            .route("/webdav/{pubkey}/pub/{*path}", delete(delete_entry))
+            .route("/webdav/{pubkey}/{*path}", delete(delete_entry))
             .with_state(app_state);
 
         // Delete the file
@@ -109,7 +109,7 @@ mod tests {
         let db = LmDB::test();
         let app_state = AppState::new(db.clone());
         let router = Router::new()
-            .route("/webdav/{pubkey}/pub/{*path}", delete(delete_entry))
+            .route("/webdav/{pubkey}/{*path}", delete(delete_entry))
             .with_state(app_state);
 
         // Delete with invalid pubkey

--- a/pubky-homeserver/src/admin/routes/delete_entry.rs
+++ b/pubky-homeserver/src/admin/routes/delete_entry.rs
@@ -14,7 +14,7 @@ pub async fn delete_entry(
     let full_path = format!("/pub/{}", path);
     let deleted = state.db.delete_entry(&pubkey.0, &full_path)?;
     if deleted {
-        Ok((StatusCode::OK, "Ok"))
+        Ok((StatusCode::NO_CONTENT, ()))
     } else {
         Err(HttpError::new(
             StatusCode::NOT_FOUND,

--- a/pubky-homeserver/src/admin/routes/delete_entry.rs
+++ b/pubky-homeserver/src/admin/routes/delete_entry.rs
@@ -1,0 +1,106 @@
+use super::super::app_state::AppState;
+use crate::shared::{HttpError, HttpResult, Z32Pubkey};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+
+/// Delete a single entry from the database.
+pub async fn delete_entry(
+    State(mut state): State<AppState>,
+    Path((pubkey, path)): Path<(Z32Pubkey, String)>,
+) -> HttpResult<impl IntoResponse> {
+    let full_path = format!("/pub/{}", path);
+    let deleted = state.db.delete_entry(&pubkey.0, &full_path)?;
+    if deleted {
+        Ok((StatusCode::OK, "Ok"))
+    } else {
+        Err(HttpError::new(
+            StatusCode::NOT_FOUND,
+            Some("Entry not found"),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::app_state::AppState;
+    use super::*;
+    use crate::persistence::lmdb::LmDB;
+    use axum::{routing::delete, Router};
+    use pkarr::{Keypair, PublicKey};
+    use std::io::Write;
+
+    async fn write_test_file(db: &mut LmDB, pubkey: &PublicKey, path: &str) {
+        let mut entry_writer = db.write_entry(pubkey, path).unwrap();
+        let content = b"Hello, world!";
+        entry_writer.write_all(content).unwrap();
+        let _entry = entry_writer.commit().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_delete_entry() {
+        // Set everything up
+        let keypair = Keypair::from_secret_key(&[0; 32]);
+        let pubkey = keypair.public_key();
+        let file_path = "my_file.txt";
+        let mut db = LmDB::test();
+        let app_state = AppState::new(db.clone());
+        let router = Router::new()
+            .route("/drive/{pubkey}/pub/{*path}", delete(delete_entry))
+            .with_state(app_state);
+
+        // Write a test file
+        let entry_path = format!("/pub/{}", file_path);
+        write_test_file(&mut db, &pubkey, &entry_path).await;
+
+        // Delete the file
+        let server = axum_test::TestServer::new(router).unwrap();
+        let response = server
+            .delete(format!("/drive/{}/pub/{}", pubkey, file_path).as_str())
+            .await;
+        assert_eq!(response.status_code(), StatusCode::OK);
+
+        // Check that the file is deleted
+        let rtx = db.env.read_txn().unwrap();
+        let entry = db.get_entry(&rtx, &pubkey, &file_path).unwrap();
+        assert!(entry.is_none(), "Entry should be deleted");
+    }
+
+    #[tokio::test]
+    async fn test_file_not_found() {
+        // Set everything up
+        let keypair = Keypair::from_secret_key(&[0; 32]);
+        let pubkey = keypair.public_key();
+        let file_path = "my_file.txt";
+        let app_state = AppState::new(LmDB::test());
+        let router = Router::new()
+            .route("/drive/{pubkey}/pub/{*path}", delete(delete_entry))
+            .with_state(app_state);
+
+        // Delete the file
+        let server = axum_test::TestServer::new(router).unwrap();
+        let response = server
+            .delete(format!("/drive/{}/pub/{}", pubkey, file_path).as_str())
+            .await;
+        assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_invalid_pubkey() {
+        // Set everything up
+        let db = LmDB::test();
+        let app_state = AppState::new(db.clone());
+        let router = Router::new()
+            .route("/drive/{pubkey}/pub/{*path}", delete(delete_entry))
+            .with_state(app_state);
+
+        // Delete with invalid pubkey
+        let server = axum_test::TestServer::new(router).unwrap();
+        let response = server
+            .delete(format!("/drive/1234/pub/test.txt").as_str())
+            .await;
+        assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
+    }
+}

--- a/pubky-homeserver/src/admin/routes/delete_entry.rs
+++ b/pubky-homeserver/src/admin/routes/delete_entry.rs
@@ -48,7 +48,7 @@ mod tests {
         let mut db = LmDB::test();
         let app_state = AppState::new(db.clone());
         let router = Router::new()
-            .route("/drive/{pubkey}/pub/{*path}", delete(delete_entry))
+            .route("/webdav/{pubkey}/pub/{*path}", delete(delete_entry))
             .with_state(app_state);
 
         // Write a test file
@@ -58,7 +58,7 @@ mod tests {
         // Delete the file
         let server = axum_test::TestServer::new(router).unwrap();
         let response = server
-            .delete(format!("/drive/{}/pub/{}", pubkey, file_path).as_str())
+            .delete(format!("/webdav/{}/pub/{}", pubkey, file_path).as_str())
             .await;
         assert_eq!(response.status_code(), StatusCode::OK);
 
@@ -76,13 +76,13 @@ mod tests {
         let file_path = "my_file.txt";
         let app_state = AppState::new(LmDB::test());
         let router = Router::new()
-            .route("/drive/{pubkey}/pub/{*path}", delete(delete_entry))
+            .route("/webdav/{pubkey}/pub/{*path}", delete(delete_entry))
             .with_state(app_state);
 
         // Delete the file
         let server = axum_test::TestServer::new(router).unwrap();
         let response = server
-            .delete(format!("/drive/{}/pub/{}", pubkey, file_path).as_str())
+            .delete(format!("/webdav/{}/pub/{}", pubkey, file_path).as_str())
             .await;
         assert_eq!(response.status_code(), StatusCode::NOT_FOUND);
     }
@@ -93,13 +93,13 @@ mod tests {
         let db = LmDB::test();
         let app_state = AppState::new(db.clone());
         let router = Router::new()
-            .route("/drive/{pubkey}/pub/{*path}", delete(delete_entry))
+            .route("/webdav/{pubkey}/pub/{*path}", delete(delete_entry))
             .with_state(app_state);
 
         // Delete with invalid pubkey
         let server = axum_test::TestServer::new(router).unwrap();
         let response = server
-            .delete(format!("/drive/1234/pub/test.txt").as_str())
+            .delete(format!("/webdav/1234/pub/test.txt").as_str())
             .await;
         assert_eq!(response.status_code(), StatusCode::BAD_REQUEST);
     }

--- a/pubky-homeserver/src/admin/routes/delete_entry.rs
+++ b/pubky-homeserver/src/admin/routes/delete_entry.rs
@@ -69,7 +69,11 @@ mod tests {
         rtx.commit().unwrap();
 
         let events = db.list_events(None, None).unwrap();
-        assert_eq!(events.len(), 3, "One PUT and one DEL event should be created. Last entry is the cursor.");
+        assert_eq!(
+            events.len(),
+            3,
+            "One PUT and one DEL event should be created. Last entry is the cursor."
+        );
         assert!(events[0].contains("PUT"));
         assert!(events[1].contains("DEL"));
     }

--- a/pubky-homeserver/src/admin/routes/disable_users.rs
+++ b/pubky-homeserver/src/admin/routes/disable_users.rs
@@ -1,0 +1,133 @@
+use super::super::app_state::AppState;
+use crate::{
+    persistence::lmdb::tables::users::UserQueryError,
+    shared::{HttpError, HttpResult, Z32Pubkey},
+};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+};
+
+/// Delete a single entry from the database.
+///
+/// # Errors
+///
+/// - `400` if the pubkey is invalid.
+/// - `404` if the entry does not exist.
+///
+pub async fn disable_tenant(
+    State(state): State<AppState>,
+    Path(pubkey): Path<Z32Pubkey>,
+) -> HttpResult<impl IntoResponse> {
+    let mut tx = state.db.env.write_txn()?;
+    if let Err(e) = state.db.disable_user(&pubkey.0, &mut tx) {
+        match e {
+            UserQueryError::UserNotFound => {
+                return Err(HttpError::new(
+                    StatusCode::NOT_FOUND,
+                    Some("User not found"),
+                ))
+            }
+            UserQueryError::DatabaseError(_) => {
+                return Err(HttpError::new(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Some("Database error"),
+                ))
+            }
+        };
+    }
+    tx.commit()?;
+    Ok((StatusCode::OK, "Ok"))
+}
+
+/// Delete a single entry from the database.
+///
+/// # Errors
+///
+/// - `400` if the pubkey is invalid.
+/// - `404` if the entry does not exist.
+///
+pub async fn enable_tenant(
+    State(state): State<AppState>,
+    Path(pubkey): Path<Z32Pubkey>,
+) -> HttpResult<impl IntoResponse> {
+    let mut tx = state.db.env.write_txn()?;
+    if let Err(e) = state.db.enable_user(&pubkey.0, &mut tx) {
+        match e {
+            UserQueryError::UserNotFound => {
+                return Err(HttpError::new(
+                    StatusCode::NOT_FOUND,
+                    Some("User not found"),
+                ))
+            }
+            UserQueryError::DatabaseError(_) => {
+                return Err(HttpError::new(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Some("Database error"),
+                ))
+            }
+        };
+    }
+    tx.commit()?;
+    Ok((StatusCode::OK, "Ok"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::super::app_state::AppState;
+    use super::*;
+    use crate::persistence::lmdb::LmDB;
+    use axum::routing::post;
+    use axum::Router;
+    use pkarr::Keypair;
+
+    #[tokio::test]
+    async fn test_disable_enable_tenant() {
+        let pubkey = Keypair::random().public_key();
+
+        // Create new user
+        let db = LmDB::test();
+        let mut tx = db.env.write_txn().unwrap();
+        db.create_user(&pubkey, &mut tx).unwrap();
+        tx.commit().unwrap();
+
+        // Check that the tenant is enabled
+        let user = db
+            .get_user(&pubkey, &mut db.env.read_txn().unwrap())
+            .unwrap();
+        assert!(!user.disabled);
+
+        // Setup server
+        let app_state = AppState::new(db.clone());
+        let router = Router::new()
+            .route("/users/{pubkey}/disable", post(disable_tenant))
+            .route("/users/{pubkey}/enable", post(enable_tenant))
+            .with_state(app_state);
+
+        // Disable the tenant
+        let server = axum_test::TestServer::new(router).unwrap();
+        let response = server
+            .post(format!("/users/{}/disable", pubkey).as_str())
+            .await;
+        assert_eq!(response.status_code(), StatusCode::OK);
+
+        // Check that the tenant is disabled
+        let user = db
+            .get_user(&pubkey, &mut db.env.read_txn().unwrap())
+            .unwrap();
+        assert!(user.disabled);
+
+        // Enable the tenant again
+        let response = server
+            .post(format!("/users/{}/enable", pubkey).as_str())
+            .await;
+        assert_eq!(response.status_code(), StatusCode::OK);
+
+        // Check that the tenant is enabled
+        let user = db
+            .get_user(&pubkey, &mut db.env.read_txn().unwrap())
+            .unwrap();
+        assert!(!user.disabled);
+    }
+}

--- a/pubky-homeserver/src/admin/routes/disable_users.rs
+++ b/pubky-homeserver/src/admin/routes/disable_users.rs
@@ -16,7 +16,7 @@ use axum::{
 /// - `400` if the pubkey is invalid.
 /// - `404` if the entry does not exist.
 ///
-pub async fn disable_tenant(
+pub async fn disable_user(
     State(state): State<AppState>,
     Path(pubkey): Path<Z32Pubkey>,
 ) -> HttpResult<impl IntoResponse> {
@@ -48,7 +48,7 @@ pub async fn disable_tenant(
 /// - `400` if the pubkey is invalid.
 /// - `404` if the entry does not exist.
 ///
-pub async fn enable_tenant(
+pub async fn enable_user(
     State(state): State<AppState>,
     Path(pubkey): Path<Z32Pubkey>,
 ) -> HttpResult<impl IntoResponse> {
@@ -83,7 +83,7 @@ mod tests {
     use pkarr::Keypair;
 
     #[tokio::test]
-    async fn test_disable_enable_tenant() {
+    async fn test_disable_enable_user() {
         let pubkey = Keypair::random().public_key();
 
         // Create new user
@@ -101,8 +101,8 @@ mod tests {
         // Setup server
         let app_state = AppState::new(db.clone());
         let router = Router::new()
-            .route("/users/{pubkey}/disable", post(disable_tenant))
-            .route("/users/{pubkey}/enable", post(enable_tenant))
+            .route("/users/{pubkey}/disable", post(disable_user))
+            .route("/users/{pubkey}/enable", post(enable_user))
             .with_state(app_state);
 
         // Disable the tenant

--- a/pubky-homeserver/src/admin/routes/mod.rs
+++ b/pubky-homeserver/src/admin/routes/mod.rs
@@ -1,2 +1,4 @@
+pub(crate) mod delete_entry;
+pub(crate) mod disable_users;
 pub(crate) mod generate_signup_token;
 pub(crate) mod root;

--- a/pubky-homeserver/src/core/err_if_user_is_invalid.rs
+++ b/pubky-homeserver/src/core/err_if_user_is_invalid.rs
@@ -1,0 +1,25 @@
+use pkarr::PublicKey;
+use reqwest::StatusCode;
+
+use crate::persistence::lmdb::{tables::users::UserQueryError, LmDB};
+
+use super::Error;
+
+/// Returns an error if the user doesn't exist or is disabled.
+pub fn err_if_user_is_invalid(pubkey: &PublicKey, db: &LmDB) -> super::error::Result<()> {
+    match db.get_user(pubkey, &mut db.env.read_txn()?) {
+        Ok(user) => {
+            if user.disabled {
+                return Err(Error::with_status(StatusCode::FORBIDDEN));
+            }
+        }
+        Err(UserQueryError::UserNotFound) => {
+            return Err(Error::with_status(StatusCode::NOT_FOUND));
+        }
+        Err(UserQueryError::DatabaseError(e)) => {
+            return Err(e.into());
+        }
+    };
+
+    Ok(())
+}

--- a/pubky-homeserver/src/core/err_if_user_is_invalid.rs
+++ b/pubky-homeserver/src/core/err_if_user_is_invalid.rs
@@ -1,5 +1,5 @@
 use pkarr::PublicKey;
-use reqwest::StatusCode;
+use axum::http::StatusCode;
 
 use crate::persistence::lmdb::{tables::users::UserQueryError, LmDB};
 

--- a/pubky-homeserver/src/core/err_if_user_is_invalid.rs
+++ b/pubky-homeserver/src/core/err_if_user_is_invalid.rs
@@ -1,5 +1,5 @@
-use pkarr::PublicKey;
 use axum::http::StatusCode;
+use pkarr::PublicKey;
 
 use crate::persistence::lmdb::{tables::users::UserQueryError, LmDB};
 

--- a/pubky-homeserver/src/core/mod.rs
+++ b/pubky-homeserver/src/core/mod.rs
@@ -1,3 +1,4 @@
+mod err_if_user_is_invalid;
 mod error;
 mod extractors;
 mod homeserver_core;

--- a/pubky-homeserver/src/core/routes/auth.rs
+++ b/pubky-homeserver/src/core/routes/auth.rs
@@ -15,9 +15,7 @@ use axum_extra::{extract::Host, headers::UserAgent, TypedHeader};
 use base32::{encode, Alphabet};
 use bytes::Bytes;
 use pkarr::PublicKey;
-use pubky_common::{
-    capabilities::Capability, crypto::random_bytes, session::Session, timestamp::Timestamp,
-};
+use pubky_common::{capabilities::Capability, crypto::random_bytes, session::Session};
 use std::collections::HashMap;
 use tower_cookies::{cookie::SameSite, Cookie, Cookies};
 
@@ -62,13 +60,7 @@ pub async fn signup(
 
     // 4) Create the new user record
     let mut wtxn = state.db.env.write_txn()?;
-    users.put(
-        &mut wtxn,
-        public_key,
-        &User {
-            created_at: Timestamp::now().as_u64(),
-        },
-    )?;
+    users.put(&mut wtxn, public_key, &User::default())?;
     wtxn.commit()?;
 
     // 5) Create session & set cookie

--- a/pubky-homeserver/src/core/routes/auth.rs
+++ b/pubky-homeserver/src/core/routes/auth.rs
@@ -1,3 +1,4 @@
+use crate::core::err_if_user_is_invalid::err_if_user_is_invalid;
 use crate::persistence::lmdb::tables::users::User;
 use crate::{
     core::{
@@ -118,6 +119,8 @@ fn create_session_and_cookie(
     capabilities: &[Capability],
     user_agent: Option<TypedHeader<UserAgent>>,
 ) -> Result<impl IntoResponse> {
+    err_if_user_is_invalid(public_key, &state.db)?;
+
     // 1) Create session
     let session_secret = encode(Alphabet::Crockford, &random_bytes::<16>());
     let session = Session::new(

--- a/pubky-homeserver/src/core/routes/tenants/session.rs
+++ b/pubky-homeserver/src/core/routes/tenants/session.rs
@@ -2,6 +2,7 @@ use axum::{extract::State, http::StatusCode, response::IntoResponse};
 use tower_cookies::Cookies;
 
 use crate::core::{
+    err_if_user_is_invalid::err_if_user_is_invalid,
     error::{Error, Result},
     extractors::PubkyHost,
     layers::authz::session_secret_from_cookies,
@@ -13,6 +14,7 @@ pub async fn session(
     cookies: Cookies,
     pubky: PubkyHost,
 ) -> Result<impl IntoResponse> {
+    err_if_user_is_invalid(pubky.public_key(), &state.db)?;
     if let Some(secret) = session_secret_from_cookies(&cookies, pubky.public_key()) {
         if let Some(session) = state.db.get_session(&secret)? {
             // TODO: add content-type

--- a/pubky-homeserver/src/core/routes/tenants/write.rs
+++ b/pubky-homeserver/src/core/routes/tenants/write.rs
@@ -10,6 +10,7 @@ use axum::{
 };
 
 use crate::core::{
+    err_if_user_is_invalid::err_if_user_is_invalid,
     error::{Error, Result},
     extractors::PubkyHost,
     AppState,
@@ -20,6 +21,7 @@ pub async fn delete(
     pubky: PubkyHost,
     path: OriginalUri,
 ) -> Result<impl IntoResponse> {
+    err_if_user_is_invalid(pubky.public_key(), &state.db)?;
     let public_key = pubky.public_key().clone();
 
     // TODO: should we wrap this with `tokio::task::spawn_blocking` in case it takes too long?
@@ -39,6 +41,7 @@ pub async fn put(
     path: OriginalUri,
     body: Body,
 ) -> Result<impl IntoResponse> {
+    err_if_user_is_invalid(pubky.public_key(), &state.db)?;
     let public_key = pubky.public_key().clone();
 
     let mut entry_writer = state.db.write_entry(&public_key, path.0.path())?;

--- a/pubky-homeserver/src/core/user_keys_republisher.rs
+++ b/pubky-homeserver/src/core/user_keys_republisher.rs
@@ -167,7 +167,7 @@ mod tests {
         let db = LmDB::test();
         let mut wtxn = db.env.write_txn().unwrap();
         for _ in 0..count {
-            let user = User::new();
+            let user = User::default();
             let public_key = Keypair::random().public_key();
             db.tables.users.put(&mut wtxn, &public_key, &user).unwrap();
         }

--- a/pubky-homeserver/src/lib.rs
+++ b/pubky-homeserver/src/lib.rs
@@ -18,6 +18,7 @@ mod core;
 mod data_directory;
 mod homeserver_suite;
 mod persistence;
+mod shared;
 
 pub use admin::{AdminServer, AdminServerBuildError};
 pub use app_context::{AppContext, AppContextConversionError};

--- a/pubky-homeserver/src/persistence/lmdb/db.rs
+++ b/pubky-homeserver/src/persistence/lmdb/db.rs
@@ -36,7 +36,10 @@ impl LmDB {
                 .open(&main_dir)
         }?;
 
-        let tables = migrations::run(&env)?;
+        migrations::run(&env)?;
+        let mut wtxn = env.write_txn()?;
+        let tables = Tables::new(&env, &mut wtxn)?;
+        wtxn.commit()?;
 
         let db = LmDB {
             env,

--- a/pubky-homeserver/src/persistence/lmdb/migrations/m220420251247_add_user_disabled.rs
+++ b/pubky-homeserver/src/persistence/lmdb/migrations/m220420251247_add_user_disabled.rs
@@ -1,0 +1,271 @@
+use super::super::tables::users;
+use crate::persistence::lmdb::tables::users::PublicKeyCodec;
+use heed::{BoxedError, BytesDecode, BytesEncode, Database, Env, RwTxn};
+use pkarr::PublicKey;
+use postcard::{from_bytes, to_allocvec};
+use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
+
+/// Adds the `disabled` field to the `users` table.
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+struct OldUser {
+    pub created_at: u64,
+}
+
+impl BytesEncode<'_> for OldUser {
+    type EItem = Self;
+
+    fn bytes_encode(user: &Self::EItem) -> Result<Cow<[u8]>, BoxedError> {
+        let vec = to_allocvec(user).unwrap();
+
+        Ok(Cow::Owned(vec))
+    }
+}
+
+impl<'a> BytesDecode<'a> for OldUser {
+    type DItem = Self;
+
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, BoxedError> {
+        let user: OldUser = from_bytes(bytes).unwrap();
+
+        Ok(user)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+struct NewUser {
+    pub created_at: u64,
+    pub disabled: bool,
+}
+
+impl BytesEncode<'_> for NewUser {
+    type EItem = Self;
+
+    fn bytes_encode(user: &Self::EItem) -> Result<Cow<[u8]>, BoxedError> {
+        let vec = to_allocvec(user)?;
+
+        Ok(Cow::Owned(vec))
+    }
+}
+
+impl From<OldUser> for NewUser {
+    fn from(user: OldUser) -> Self {
+        Self {
+            created_at: user.created_at,
+            disabled: false,
+        }
+    }
+}
+
+impl<'a> BytesDecode<'a> for NewUser {
+    type DItem = Self;
+
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, BoxedError> {
+        let user: NewUser = from_bytes(bytes)?;
+
+        Ok(user)
+    }
+}
+
+/// Checks if the migration is needed.
+/// Tries to read users with the new schema. If it succeeds, the migration is not needed.
+/// If it fails, the migration is needed.
+fn is_migration_needed(env: &Env, wtxn: &mut RwTxn) -> anyhow::Result<bool> {
+    let new_table: Database<PublicKeyCodec, NewUser> = env
+        .open_database(wtxn, Some(users::USERS_TABLE))?
+        .expect("User database is not available");
+
+    match new_table.first(wtxn) {
+        Ok(Some(_user)) => {
+            // User found. The old schema is valid.
+            // We need to migrate the users to the new schema.
+            Ok(false)
+        }
+        Ok(None) => {
+            // No users found. No need to run the migration.
+            Ok(false)
+        }
+        Err(_e) => {
+            // Failed to deserialize. The migrations has already been run.
+            Ok(true)
+        }
+    }
+}
+
+fn read_old_users_table(env: &Env, wtxn: &mut RwTxn) -> anyhow::Result<Vec<(PublicKey, OldUser)>> {
+    let table: Database<PublicKeyCodec, OldUser> = env
+        .open_database(wtxn, Some(users::USERS_TABLE))?
+        .expect("User database is not available");
+
+    let mut new_users: Vec<(PublicKey, OldUser)> = vec![];
+    for entry in table.iter(wtxn)? {
+        let (key, old_user) = entry?;
+        new_users.push((key, old_user));
+    }
+
+    Ok(new_users)
+}
+
+fn write_new_users_table(
+    env: &Env,
+    wtxn: &mut RwTxn,
+    users: Vec<(PublicKey, NewUser)>,
+) -> anyhow::Result<()> {
+    let table: Database<PublicKeyCodec, NewUser> = env
+        .open_database(wtxn, Some(users::USERS_TABLE))?
+        .expect("User database is not available");
+
+    for (key, new_user) in users {
+        table.put(wtxn, &key, &new_user)?;
+    }
+
+    Ok(())
+}
+
+pub fn run(env: &Env, wtxn: &mut RwTxn) -> anyhow::Result<()> {
+    if !is_migration_needed(env, wtxn)? {
+        return Ok(());
+    }
+
+    let old_users = read_old_users_table(env, wtxn)
+        .map_err(|e| anyhow::anyhow!("Failed to read old users table: {}", e))?;
+
+    // Migrate the users to the new schema.
+    // Save into a temporary table.
+    let new_users: Vec<(PublicKey, NewUser)> = old_users
+        .into_iter()
+        .map(|(key, old_user)| (key, old_user.into()))
+        .collect();
+
+    write_new_users_table(env, wtxn, new_users)
+        .map_err(|e| anyhow::anyhow!("Failed to write new users table: {}", e))?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use heed::EnvOpenOptions;
+    use pkarr::Keypair;
+
+    use crate::persistence::lmdb::{db::DEFAULT_MAP_SIZE, migrations::m0};
+
+    use super::*;
+
+    #[test]
+    fn test_is_migration_needed_yes() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let env = unsafe {
+            EnvOpenOptions::new()
+                .max_dbs(20)
+                .map_size(DEFAULT_MAP_SIZE)
+                .open(&tmp_dir.path())
+        }
+        .unwrap();
+        m0::run(&env, &mut env.write_txn().unwrap()).unwrap();
+        let mut wtxn = env.write_txn().unwrap();
+
+        // Write a user to the old table.
+        let table: Database<PublicKeyCodec, OldUser> = env
+            .create_database(&mut wtxn, Some(users::USERS_TABLE))
+            .unwrap();
+        table
+            .put(
+                &mut wtxn,
+                &Keypair::random().public_key(),
+                &OldUser { created_at: 1 },
+            )
+            .unwrap();
+
+        assert!(is_migration_needed(&env, &mut wtxn).unwrap());
+    }
+
+    #[test]
+    fn test_is_migration_needed_no_users() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let env = unsafe {
+            EnvOpenOptions::new()
+                .max_dbs(20)
+                .map_size(DEFAULT_MAP_SIZE)
+                .open(&tmp_dir.path())
+        }
+        .unwrap();
+        m0::run(&env, &mut env.write_txn().unwrap()).unwrap();
+        let mut wtxn = env.write_txn().unwrap();
+
+        // Write a user to the old table.
+        let _: Database<PublicKeyCodec, OldUser> = env
+            .create_database(&mut wtxn, Some(users::USERS_TABLE))
+            .unwrap();
+
+        assert!(!is_migration_needed(&env, &mut wtxn).unwrap());
+    }
+
+    #[test]
+    fn test_is_migration_needed_already_migrated() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let env = unsafe {
+            EnvOpenOptions::new()
+                .max_dbs(20)
+                .map_size(DEFAULT_MAP_SIZE)
+                .open(&tmp_dir.path())
+        }
+        .unwrap();
+        m0::run(&env, &mut env.write_txn().unwrap()).unwrap();
+        let mut wtxn = env.write_txn().unwrap();
+
+        // Write a user to the new table.
+        let table: Database<PublicKeyCodec, NewUser> = env
+            .create_database(&mut wtxn, Some(users::USERS_TABLE))
+            .unwrap();
+        table
+            .put(
+                &mut wtxn,
+                &Keypair::random().public_key(),
+                &NewUser {
+                    created_at: 1,
+                    disabled: false,
+                },
+            )
+            .unwrap();
+
+        assert!(
+            !is_migration_needed(&env, &mut wtxn).unwrap(),
+            "The migration should not be needed anymore because it's already been run."
+        );
+    }
+
+    #[test]
+    fn test_migrate() {
+        let tmp_dir = tempfile::tempdir().unwrap();
+        let env = unsafe {
+            EnvOpenOptions::new()
+                .max_dbs(20)
+                .map_size(DEFAULT_MAP_SIZE)
+                .open(&tmp_dir.path())
+        }
+        .unwrap();
+        m0::run(&env, &mut env.write_txn().unwrap()).unwrap();
+        let mut wtxn = env.write_txn().unwrap();
+
+        // Write a user to the old table.
+        let pubkey = Keypair::random().public_key();
+        let table: Database<PublicKeyCodec, OldUser> = env
+            .create_database(&mut wtxn, Some(users::USERS_TABLE))
+            .unwrap();
+        table
+            .put(&mut wtxn, &pubkey, &OldUser { created_at: 1 })
+            .unwrap();
+
+        // Migrate the users to the new schema.
+        run(&env, &mut wtxn).unwrap();
+
+        // Check that the user has been migrated to the new schema.
+        let table: Database<PublicKeyCodec, NewUser> = env
+            .open_database(&mut wtxn, Some(users::USERS_TABLE))
+            .unwrap()
+            .unwrap();
+        let user = table.get(&mut wtxn, &pubkey).unwrap().unwrap();
+        assert_eq!(user.disabled, false, "The user should not be disabled.");
+    }
+}

--- a/pubky-homeserver/src/persistence/lmdb/migrations/m220420251247_add_user_disabled.rs
+++ b/pubky-homeserver/src/persistence/lmdb/migrations/m220420251247_add_user_disabled.rs
@@ -77,8 +77,8 @@ fn is_migration_needed(env: &Env, wtxn: &mut RwTxn) -> anyhow::Result<bool> {
 
     match new_table.first(wtxn) {
         Ok(Some(_user)) => {
-            // User found. The old schema is valid.
-            // We need to migrate the users to the new schema.
+            // User found. The new schema is valid.
+            // Migrations has already been run.
             Ok(false)
         }
         Ok(None) => {
@@ -86,7 +86,8 @@ fn is_migration_needed(env: &Env, wtxn: &mut RwTxn) -> anyhow::Result<bool> {
             Ok(false)
         }
         Err(_e) => {
-            // Failed to deserialize. The migrations has already been run.
+            // Failed to deserialize. It's the old schema.
+            // Migrations is needed.
             Ok(true)
         }
     }
@@ -131,7 +132,6 @@ pub fn run(env: &Env, wtxn: &mut RwTxn) -> anyhow::Result<()> {
         .map_err(|e| anyhow::anyhow!("Failed to read old users table: {}", e))?;
 
     // Migrate the users to the new schema.
-    // Save into a temporary table.
     let new_users: Vec<(PublicKey, NewUser)> = old_users
         .into_iter()
         .map(|(key, old_user)| (key, old_user.into()))

--- a/pubky-homeserver/src/persistence/lmdb/migrations/m220420251247_add_user_disabled_used_bytes.rs
+++ b/pubky-homeserver/src/persistence/lmdb/migrations/m220420251247_add_user_disabled_used_bytes.rs
@@ -36,7 +36,7 @@ impl<'a> BytesDecode<'a> for OldUser {
 struct NewUser {
     pub created_at: u64,
     pub disabled: bool,
-    pub used_bytes: u64
+    pub used_bytes: u64,
 }
 
 impl BytesEncode<'_> for NewUser {

--- a/pubky-homeserver/src/persistence/lmdb/migrations/mod.rs
+++ b/pubky-homeserver/src/persistence/lmdb/migrations/mod.rs
@@ -1,17 +1,16 @@
-use super::tables::Tables;
 use heed::Env;
 
 mod m0;
+mod m220420251247_add_user_disabled;
 
 /// Run the migrations.
-pub fn run(env: &Env) -> anyhow::Result<Tables> {
+pub fn run(env: &Env) -> anyhow::Result<()> {
     let mut wtxn = env.write_txn()?;
 
     m0::run(env, &mut wtxn)?;
-
-    let tables = Tables::new(env, &mut wtxn)?;
+    m220420251247_add_user_disabled::run(env, &mut wtxn)?;
 
     wtxn.commit()?;
 
-    Ok(tables)
+    Ok(())
 }

--- a/pubky-homeserver/src/persistence/lmdb/migrations/mod.rs
+++ b/pubky-homeserver/src/persistence/lmdb/migrations/mod.rs
@@ -1,14 +1,14 @@
 use heed::Env;
 
 mod m0;
-mod m220420251247_add_user_disabled;
+mod m220420251247_add_user_disabled_used_bytes;
 
 /// Run the migrations.
 pub fn run(env: &Env) -> anyhow::Result<()> {
     let mut wtxn = env.write_txn()?;
 
     m0::run(env, &mut wtxn)?;
-    m220420251247_add_user_disabled::run(env, &mut wtxn)?;
+    m220420251247_add_user_disabled_used_bytes::run(env, &mut wtxn)?;
 
     wtxn.commit()?;
 

--- a/pubky-homeserver/src/persistence/lmdb/tables/users.rs
+++ b/pubky-homeserver/src/persistence/lmdb/tables/users.rs
@@ -20,6 +20,7 @@ pub const USERS_TABLE: &str = "users";
 pub struct User {
     pub created_at: u64,
     pub disabled: bool,
+    pub used_bytes: u64,
 }
 
 impl Default for User {
@@ -27,6 +28,7 @@ impl Default for User {
         Self {
             created_at: Timestamp::now().as_u64(),
             disabled: false,
+            used_bytes: 0,
         }
     }
 }

--- a/pubky-homeserver/src/persistence/lmdb/tables/users.rs
+++ b/pubky-homeserver/src/persistence/lmdb/tables/users.rs
@@ -3,8 +3,10 @@ use std::borrow::Cow;
 use postcard::{from_bytes, to_allocvec};
 use serde::{Deserialize, Serialize};
 
-use heed::{BoxedError, BytesDecode, BytesEncode, Database};
+use heed::{BoxedError, BytesDecode, BytesEncode, Database, RoTxn, RwTxn};
 use pkarr::{PublicKey, Timestamp};
+
+use crate::persistence::lmdb::LmDB;
 
 extern crate alloc;
 
@@ -17,13 +19,14 @@ pub const USERS_TABLE: &str = "users";
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct User {
     pub created_at: u64,
+    pub disabled: bool,
 }
 
-impl User {
-    #[allow(dead_code)]
-    pub fn new() -> Self {
+impl Default for User {
+    fn default() -> Self {
         Self {
             created_at: Timestamp::now().as_u64(),
+            disabled: false,
         }
     }
 }
@@ -63,5 +66,76 @@ impl<'a> BytesDecode<'a> for PublicKeyCodec {
 
     fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, BoxedError> {
         Ok(PublicKey::try_from(bytes)?)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum UserQueryError {
+    #[error("User not found")]
+    UserNotFound,
+    #[error("transparent")]
+    DatabaseError(#[from] heed::Error),
+}
+
+impl LmDB {
+    /// Disable a user.
+    ///
+    /// # Errors
+    ///
+    /// - `UserQueryError::UserNotFound` if the user does not exist.
+    /// - `UserQueryError::DatabaseError` if the database operation fails.
+    pub fn disable_user(&self, pubkey: &PublicKey, wtxn: &mut RwTxn) -> Result<(), UserQueryError> {
+        let mut user = match self.tables.users.get(wtxn, pubkey)? {
+            Some(user) => user,
+            None => return Err(UserQueryError::UserNotFound),
+        };
+
+        user.disabled = true;
+        self.tables.users.put(wtxn, pubkey, &user)?;
+
+        Ok(())
+    }
+
+    /// Enable a user.
+    ///
+    /// # Errors
+    ///
+    /// - `UserQueryError::UserNotFound` if the user does not exist.
+    /// - `UserQueryError::DatabaseError` if the database operation fails.
+    pub fn enable_user(&self, pubkey: &PublicKey, wtxn: &mut RwTxn) -> Result<(), UserQueryError> {
+        let mut user = match self.tables.users.get(wtxn, pubkey)? {
+            Some(user) => user,
+            None => return Err(UserQueryError::UserNotFound),
+        };
+
+        user.disabled = false;
+        self.tables.users.put(wtxn, pubkey, &user)?;
+
+        Ok(())
+    }
+
+    /// Create a user.
+    ///
+    /// # Errors
+    ///
+    /// - `UserQueryError::DatabaseError` if the database operation fails.
+    pub fn create_user(&self, pubkey: &PublicKey, wtxn: &mut RwTxn) -> anyhow::Result<()> {
+        let user = User::default();
+        self.tables.users.put(wtxn, pubkey, &user)?;
+        Ok(())
+    }
+
+    /// Get a user.
+    ///
+    /// # Errors
+    ///
+    /// - `UserQueryError::UserNotFound` if the user does not exist.
+    /// - `UserQueryError::DatabaseError` if the database operation fails.
+    pub fn get_user(&self, pubkey: &PublicKey, wtxn: &mut RoTxn) -> Result<User, UserQueryError> {
+        let user = match self.tables.users.get(wtxn, pubkey)? {
+            Some(user) => user,
+            None => return Err(UserQueryError::UserNotFound),
+        };
+        Ok(user)
     }
 }

--- a/pubky-homeserver/src/shared/http_error.rs
+++ b/pubky-homeserver/src/shared/http_error.rs
@@ -1,0 +1,87 @@
+//! Server error
+use axum::{http::StatusCode, response::IntoResponse};
+
+pub(crate) type HttpResult<T, E = HttpError> = core::result::Result<T, E>;
+
+#[derive(Debug, Clone)]
+pub(crate) struct HttpError {
+    // #[serde(with = "serde_status_code")]
+    status: StatusCode,
+    detail: Option<String>,
+}
+
+impl Default for HttpError {
+    fn default() -> Self {
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            detail: None,
+        }
+    }
+}
+
+impl HttpError {
+    /// Create a new [`Error`].
+    pub fn new(status_code: StatusCode, message: Option<impl ToString>) -> HttpError {
+        Self {
+            status: status_code,
+            detail: message.map(|m| m.to_string()),
+        }
+    }
+}
+
+impl IntoResponse for HttpError {
+    fn into_response(self) -> axum::response::Response {
+        match self.detail {
+            Some(detail) => (self.status, detail).into_response(),
+            _ => (self.status,).into_response(),
+        }
+    }
+}
+
+// === INTERNAL_SERVER_ERROR ===
+// Very common errors that we can just convert to a Internal Server Error.
+// This way, we can use `?` to propagate errors without having to handle them.
+
+impl From<std::io::Error> for HttpError {
+    fn from(error: std::io::Error) -> Self {
+        tracing::debug!(?error);
+        Self::new(StatusCode::INTERNAL_SERVER_ERROR, error.into())
+    }
+}
+
+// LMDB errors
+impl From<heed::Error> for HttpError {
+    fn from(error: heed::Error) -> Self {
+        tracing::debug!(?error);
+        Self::new(StatusCode::INTERNAL_SERVER_ERROR, error.into())
+    }
+}
+
+// Anyhow errors
+impl From<anyhow::Error> for HttpError {
+    fn from(error: anyhow::Error) -> Self {
+        tracing::debug!(?error);
+        Self::new(StatusCode::INTERNAL_SERVER_ERROR, error.into())
+    }
+}
+
+impl From<postcard::Error> for HttpError {
+    fn from(error: postcard::Error) -> Self {
+        tracing::debug!(?error);
+        Self::new(StatusCode::INTERNAL_SERVER_ERROR, error.into())
+    }
+}
+
+impl From<axum::Error> for HttpError {
+    fn from(error: axum::Error) -> Self {
+        tracing::debug!(?error);
+        Self::new(StatusCode::INTERNAL_SERVER_ERROR, error.into())
+    }
+}
+
+impl From<axum::http::Error> for HttpError {
+    fn from(error: axum::http::Error) -> Self {
+        tracing::debug!(?error);
+        Self::new(StatusCode::INTERNAL_SERVER_ERROR, error.into())
+    }
+}

--- a/pubky-homeserver/src/shared/mod.rs
+++ b/pubky-homeserver/src/shared/mod.rs
@@ -1,0 +1,5 @@
+mod http_error;
+mod pubkey_path_validator;
+
+pub(crate) use http_error::{HttpError, HttpResult};
+pub(crate) use pubkey_path_validator::Z32Pubkey;

--- a/pubky-homeserver/src/shared/pubkey_path_validator.rs
+++ b/pubky-homeserver/src/shared/pubkey_path_validator.rs
@@ -1,0 +1,33 @@
+use pkarr::PublicKey;
+
+/// Custom validator for the zbase32 pubkey in the route path.
+/// Usage:
+/// ```ignore
+/// use axum::response::IntoResponse;
+/// use reqwest::StatusCode;
+/// use axum::extract::Path;
+/// use crate::shared::pubkey_path_validator::Z32Pubkey;
+/// use crate::shared::http_error::HttpResult;
+///
+/// pub(crate) async fn my_handler(
+///     Path(pubkey): Path<Z32Pubkey>,
+/// ) -> HttpResult<impl IntoResponse> {
+///     println!("Pubkey: {}", pubkey.0);
+///     Ok((StatusCode::OK, "Ok"))
+/// }
+/// ```
+///
+/// TODO: Add serde deserialization to pkarr::PublicKey itself
+#[derive(Debug)]
+pub(crate) struct Z32Pubkey(pub PublicKey);
+
+impl<'de> serde::Deserialize<'de> for Z32Pubkey {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s: String = serde::Deserialize::deserialize(deserializer)?;
+        let pubkey = PublicKey::try_from(s.as_str()).map_err(serde::de::Error::custom)?;
+        Ok(Z32Pubkey(pubkey))
+    }
+}

--- a/pubky-homeserver/src/shared/pubkey_path_validator.rs
+++ b/pubky-homeserver/src/shared/pubkey_path_validator.rs
@@ -4,7 +4,7 @@ use pkarr::PublicKey;
 /// Usage:
 /// ```ignore
 /// use axum::response::IntoResponse;
-/// use reqwest::StatusCode;
+/// use axum::http::StatusCode;
 /// use axum::extract::Path;
 /// use crate::shared::pubkey_path_validator::Z32Pubkey;
 /// use crate::shared::http_error::HttpResult;


### PR DESCRIPTION
Adds the following endpoints to the admin interface:
- `Delete entry` - Deletes a specific file. Adds a delete event
- `Disable user` - Disables a user. Prevents them from sign in and to read/write any files from this specific user.
- `Enable user` - Enables a disabled user.

Migrates the `User` entity, adds the `disabled` field.

I had to suppress an inner urge to refactor the core web server and lmdb. So most of this code is structured as good as it gets in consideration of the surrounding environment.

Adds `used_bytes` to the user migration for #108.