### PR TITLE
feat(homeserver): nginx auth request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -252,6 +252,7 @@ dependencies = [
  "axum",
  "axum-core",
  "bytes",
+ "cookie",
  "futures-util",
  "headers",
  "http",

--- a/pubky-homeserver/Cargo.toml
+++ b/pubky-homeserver/Cargo.toml
@@ -51,7 +51,7 @@ hostname-validator = "1.1.1"
 axum-test = "17.2.0"
 tempfile = { version = "3.10.1" }
 dyn-clone = "1.0.19"
-reqwest = "0.12.15"
+reqwest = {version = "0.12.15", features = ["cookies"]}
 
 
 [dev-dependencies]

--- a/pubky-homeserver/Cargo.toml
+++ b/pubky-homeserver/Cargo.toml
@@ -56,3 +56,4 @@ reqwest = "0.12.15"
 
 [dev-dependencies]
 futures-lite = "2.6.0"
+axum-extra = { version = "0.10", features = ["cookie"] }

--- a/pubky-homeserver/src/admin/app.rs
+++ b/pubky-homeserver/src/admin/app.rs
@@ -7,6 +7,7 @@ use super::routes::{delete_entry, generate_signup_token, nginx_auth_request, roo
 use super::trace::with_trace_layer;
 use super::{app_state::AppState, auth_middleware::AdminAuthLayer};
 use crate::app_context::AppContext;
+use crate::shared::PubkyHostLayer;
 use crate::{AppContextConversionError, MockDataDir, PersistentDataDir};
 use axum::routing::{delete, post};
 use axum::{routing::get, Router};
@@ -37,7 +38,7 @@ fn create_public_router() -> Router<AppState> {
     .route("/", get(root::root))
     .route(
         "/nginx_auth_request",
-        get(nginx_auth_request::nginx_auth_request),
+        get(nginx_auth_request::nginx_auth_request).layer(PubkyHostLayer),
     )
 }
 

--- a/pubky-homeserver/src/admin/app.rs
+++ b/pubky-homeserver/src/admin/app.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use super::routes::disable_users::{disable_user, enable_user};
-use super::routes::{delete_entry, generate_signup_token, root};
+use super::routes::{delete_entry, generate_signup_token, nginx_auth_request, root};
 use super::trace::with_trace_layer;
 use super::{app_state::AppState, auth_middleware::AdminAuthLayer};
 use crate::app_context::AppContext;
@@ -33,6 +33,7 @@ fn create_app(state: AppState, password: &str) -> axum::routing::IntoMakeService
     let app = Router::new()
         .nest("/admin", admin_router)
         .route("/", get(root::root))
+        .route("/nginx_auth_request", get(nginx_auth_request::nginx_auth_request))
         .route(
             "/webdav/{pubkey}/{*path}",
             delete(delete_entry::delete_entry),

--- a/pubky-homeserver/src/admin/app.rs
+++ b/pubky-homeserver/src/admin/app.rs
@@ -22,10 +22,6 @@ fn create_protected_router(password: &str) -> Router<AppState> {
             get(generate_signup_token::generate_signup_token),
         )
         .route(
-            "/nginx_auth_request",
-            get(nginx_auth_request::nginx_auth_request),
-        )
-        .route(
             "/webdav/{pubkey}/{*path}",
             delete(delete_entry::delete_entry),
         )
@@ -37,7 +33,12 @@ fn create_protected_router(password: &str) -> Router<AppState> {
 /// Public router without any authentication.
 /// NO PASSWORD PROTECTION!
 fn create_public_router() -> Router<AppState> {
-    Router::new().route("/", get(root::root))
+    Router::new()
+    .route("/", get(root::root))
+    .route(
+        "/nginx_auth_request",
+        get(nginx_auth_request::nginx_auth_request),
+    )
 }
 
 /// Create the app

--- a/pubky-homeserver/src/admin/app.rs
+++ b/pubky-homeserver/src/admin/app.rs
@@ -13,6 +13,7 @@ use axum::routing::{delete, post};
 use axum::{routing::get, Router};
 use axum_server::Handle;
 use tokio::task::JoinHandle;
+use tower_cookies::CookieManagerLayer;
 use tower_http::cors::CorsLayer;
 
 /// Admin password protected router.
@@ -34,12 +35,13 @@ fn create_protected_router(password: &str) -> Router<AppState> {
 /// Public router without any authentication.
 /// NO PASSWORD PROTECTION!
 fn create_public_router() -> Router<AppState> {
+    let pubky_host_router = Router::new()
+        .route("/nginx_auth_request", get(nginx_auth_request::nginx_auth_request))
+        .layer(PubkyHostLayer).layer(CookieManagerLayer::new());
+
     Router::new()
     .route("/", get(root::root))
-    .route(
-        "/nginx_auth_request",
-        get(nginx_auth_request::nginx_auth_request).layer(PubkyHostLayer),
-    )
+    .merge(pubky_host_router)
 }
 
 /// Create the app

--- a/pubky-homeserver/src/admin/app.rs
+++ b/pubky-homeserver/src/admin/app.rs
@@ -33,7 +33,10 @@ fn create_app(state: AppState, password: &str) -> axum::routing::IntoMakeService
     let app = Router::new()
         .nest("/admin", admin_router)
         .route("/", get(root::root))
-        .route("/nginx_auth_request", get(nginx_auth_request::nginx_auth_request))
+        .route(
+            "/nginx_auth_request",
+            get(nginx_auth_request::nginx_auth_request),
+        )
         .route(
             "/webdav/{pubkey}/{*path}",
             delete(delete_entry::delete_entry),

--- a/pubky-homeserver/src/admin/routes/mod.rs
+++ b/pubky-homeserver/src/admin/routes/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod delete_entry;
 pub(crate) mod disable_users;
 pub(crate) mod generate_signup_token;
-pub(crate) mod root;
 pub(crate) mod nginx_auth_request;
+pub(crate) mod root;

--- a/pubky-homeserver/src/admin/routes/mod.rs
+++ b/pubky-homeserver/src/admin/routes/mod.rs
@@ -2,3 +2,4 @@ pub(crate) mod delete_entry;
 pub(crate) mod disable_users;
 pub(crate) mod generate_signup_token;
 pub(crate) mod root;
+pub(crate) mod nginx_auth_request;

--- a/pubky-homeserver/src/admin/routes/nginx_auth_request.rs
+++ b/pubky-homeserver/src/admin/routes/nginx_auth_request.rs
@@ -2,117 +2,189 @@ use super::super::app_state::AppState;
 use crate::shared::{HttpError, HttpResult, PubkyHost};
 use axum::{
     extract::State,
-    http::StatusCode,
+    http::{HeaderMap, HeaderValue, StatusCode},
     response::IntoResponse,
 };
+use tower_cookies::Cookies;
 
-
-
-/// Delete a single entry from the database.
+/// Auth endpoint for nginx to authenticate requests and extract the user pubkey.
+/// Using the `auth_request` directive, nginx will forward the request without the body
+/// to this endpoint. The homeserver will then extract the session cookie and validate it.
+/// If the session is valid, the homeserver will return the user pubkey in the `x-user-id` header.
+///
+/// Nginx will then use the `auth_request_set` directive to set the `$user_id` variable to the value
+/// of the `x-user-id` header.
+/// This way, nginx can use the user pubkey for rate limiting or other purposes.
+///
+/// Usage:
+/// ```nginx
+/// location /protected/ {
+///     auth_request /extract_pubky_from_session_cookie;
+///     # Set $user_id from the x-user-id header returned by the homeserver
+///     auth_request_set $user_id $upstream_http_x_user_id;
+///
+///     # Use $user_id for rate limiting
+///     limit_req_zone $user_id zone=user_limit:10m rate=1r/s;
+///     limit_req zone=user_limit burst=5 nodelay;
+/// }
+/// ```
 pub async fn nginx_auth_request(
-    State(mut state): State<AppState>,
+    State(state): State<AppState>,
     pubky: PubkyHost,
+    cookies: Cookies,
 ) -> HttpResult<impl IntoResponse> {
-    Ok((StatusCode::NO_CONTENT, ()))
+    // Extract and validate the session cookie
+    let cookie_name = pubky.public_key().to_z32();
+    let cookie_value = match cookies.get(&cookie_name) {
+        Some(cookie) => cookie.value().to_string(),
+        None => {
+            return Err(HttpError::new(
+                StatusCode::UNAUTHORIZED,
+                Some("Session cookie not found"),
+            ))
+        }
+    };
+    let session = match state.db.get_session(&cookie_value)? {
+        Some(session) => session,
+        None => {
+            return Err(HttpError::new(
+                StatusCode::UNAUTHORIZED,
+                Some("Session not found"),
+            ))
+        }
+    };
+
+    // Return the signed user pubkey as a response header
+    let user_pubkey = session.pubky();
+    let header_value = match HeaderValue::from_str(user_pubkey.to_z32().as_str()) {
+        Ok(header_value) => header_value,
+        Err(_) => {
+            return Err(HttpError::new(
+                StatusCode::UNAUTHORIZED,
+                Some("Invalid user pubkey"),
+            ))
+        }
+    };
+    let mut headers = HeaderMap::new();
+    headers.insert("x-user-id", header_value);
+    Ok((StatusCode::OK, headers))
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use crate::persistence::lmdb::LmDB;
+#[cfg(test)]
+mod tests {
+    use crate::{persistence::lmdb::LmDB, shared::PubkyHostLayer};
 
-//     use super::*;
-//     use axum::{Router, routing::get};
-//     use pkarr::{Keypair, PublicKey};
-//     use pubky_common::{capabilities::Capability, crypto::random_bytes, session::Session};
-//     use tokio::net::TcpListener;
-//     use std::{net::SocketAddr, sync::Arc};
-//     use base32::{encode as base32_encode, Alphabet};
-//     use reqwest::{Client, cookie::Jar, Url};
-//     use axum_extra::extract::cookie::CookieJar;
+    use super::*;
+    use axum::{routing::get, Router};
+    use base32::{encode as base32_encode, Alphabet};
+    use pkarr::{Keypair, PublicKey};
+    use pubky_common::{capabilities::Capability, crypto::random_bytes, session::Session};
+    use reqwest::{cookie::Jar, Client, Url};
+    use std::{net::SocketAddr, sync::Arc};
+    use tokio::net::TcpListener;
+    use tower_cookies::CookieManagerLayer;
 
-//     // Helper to spawn the app on a random port
-//     async fn spawn_app() -> (SocketAddr, LmDB) {
-//         let db = LmDB::test();
-//         let state = AppState::new(db.clone());
-//         let app = Router::new()
-//             .route("/nginx_auth_request", get(nginx_auth_request)).with_state(state);
-//         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
-//         let addr = listener.local_addr().unwrap();
-//         tokio::spawn(async move {
-//             axum::serve(listener, app).await.unwrap();
-//         });
-//         (addr, db)
-//     }
+    // Helper to spawn the app on a random port
+    async fn spawn_app() -> (SocketAddr, LmDB) {
+        let db = LmDB::test();
+        let state = AppState::new(db.clone());
+        let app = Router::new()
+            .route("/nginx_auth_request", get(nginx_auth_request))
+            .with_state(state)
+            .layer(PubkyHostLayer)
+            .layer(CookieManagerLayer::new());
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        (addr, db)
+    }
 
-//     fn create_session(db: &LmDB) -> (PublicKey, String) {
-//         let user_pubkey = Keypair::random().public_key();
-//         let session_secret = base32_encode(Alphabet::Crockford, &random_bytes::<16>());
-//         let session = Session::new(
-//             &user_pubkey,
-//             &vec![Capability::try_from("/pub/pubky.app/:rw").unwrap()],
-//             None,
-//         )
-//         .serialize();
-        
-//         let mut wtxn = db.env.write_txn().unwrap();
-//         db
-//             .tables
-//             .sessions
-//             .put(&mut wtxn, &session_secret, &session)
-//             .unwrap();
-//         wtxn.commit().unwrap();
+    fn create_session(db: &LmDB) -> (PublicKey, String) {
+        let user_pubkey = Keypair::random().public_key();
+        let session_secret = base32_encode(Alphabet::Crockford, &random_bytes::<16>());
+        let session = Session::new(
+            &user_pubkey,
+            &vec![Capability::try_from("/pub/pubky.app/:rw").unwrap()],
+            None,
+        )
+        .serialize();
 
-//         (user_pubkey, session_secret)
-//     }
+        let mut wtxn = db.env.write_txn().unwrap();
+        db.tables
+            .sessions
+            .put(&mut wtxn, &session_secret, &session)
+            .unwrap();
+        wtxn.commit().unwrap();
 
-//     #[tokio::test]
-//     async fn returns_200_for_valid_session() {
-//         let (addr, db)   = spawn_app().await;
-//         let url = format!("http://{}/extract_pubky_from_session_cookie", addr);
-//         let url_parsed = Url::parse(&url).unwrap();
-//         let jar = Arc::new(Jar::default());
-//         // This value should be a valid session cookie for your AuthToken logic
-//         let (user_pubkey, session_secret) = create_session(&db);
-//         jar.add_cookie_str(&format!("session={}", session_secret), &url_parsed);
-//         let client = Client::builder().cookie_provider(jar.clone()).build().unwrap();
-//         let res = client
-//             .get(url)
-//             .send()
-//             .await
-//             .unwrap();
-//         assert_eq!(res.status(), reqwest::StatusCode::UNAUTHORIZED);
-//         assert!(res.headers().get("x-user-id").is_none());
-//     }
+        (user_pubkey, session_secret)
+    }
 
-//     #[tokio::test]
-//     async fn returns_401_for_invalid_session_but_valid_cookie() {
-//         let (addr, db) = spawn_app().await;   
-//         let url = format!("http://{}/extract_pubky_from_session_cookie", addr);
-//         let url_parsed = Url::parse(&url).unwrap();
-//         let jar = Arc::new(Jar::default());
-//         // This value should be a valid session cookie for your AuthToken logic
-//         let (_, session_secret) = create_session(&db);   
-//         jar.add_cookie_str(&format!("session={}", session_secret), &url_parsed);
-//         let client = Client::builder().cookie_provider(jar.clone()).build().unwrap();
-//         let res = client
-//             .get(url)
-//             .send()
-//             .await
-//             .unwrap();
-//         assert_eq!(res.status(), reqwest::StatusCode::UNAUTHORIZED);
-//         assert!(res.headers().get("x-user-id").is_none());
-//     }
+    #[tokio::test]
+    async fn returns_200_for_valid_session() {
+        let (addr, db) = spawn_app().await;
+        let url = format!("http://{}/nginx_auth_request", addr);
+        let url_parsed = Url::parse(&url).unwrap();
+        let jar = Arc::new(Jar::default());
+        let (user_pubkey, session_secret) = create_session(&db);
+        jar.add_cookie_str(
+            &format!("{}={}", user_pubkey.to_z32(), session_secret),
+            &url_parsed,
+        );
+        let client = Client::builder()
+            .cookie_provider(jar.clone())
+            .build()
+            .unwrap();
+        let res = client
+            .get(url)
+            .header("pubky-host", user_pubkey.to_z32().as_str())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), reqwest::StatusCode::OK);
+        let header = res.headers().get("x-user-id");
+        assert!(header.is_some(), "x-user-id header should be present");
+        assert_eq!(
+            header.unwrap().to_str().unwrap(),
+            user_pubkey.to_z32().as_str(),
+            "x-user-id header should match the user pubkey"
+        );
+    }
 
-//     #[tokio::test]
-//     async fn returns_401_for_missing_cookie() {
-//         let (addr, _) = spawn_app().await;
-//         let client = Client::new();
-//         let res = client
-//             .get(&format!("http://{}/extract_pubky_from_session_cookie", addr))
-//             .send()
-//             .await
-//             .unwrap();
-//         assert_eq!(res.status(), reqwest::StatusCode::UNAUTHORIZED);
-//     }
-// }
+    #[tokio::test]
+    async fn returns_401_for_invalid_session_but_valid_cookie() {
+        let (addr, _) = spawn_app().await;
+        let url = format!("http://{}/nginx_auth_request", addr);
+        let url_parsed = Url::parse(&url).unwrap();
+        let jar = Arc::new(Jar::default());
+        let user_pubkey = Keypair::random().public_key();
+        jar.add_cookie_str(&format!("{}=123456", user_pubkey.to_z32()), &url_parsed);
+        let client = Client::builder()
+            .cookie_provider(jar.clone())
+            .build()
+            .unwrap();
+        let res = client
+            .get(url)
+            .header("pubky-host", user_pubkey.to_z32().as_str())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), reqwest::StatusCode::UNAUTHORIZED);
+        assert!(res.headers().get("x-user-id").is_none());
+    }
 
+    #[tokio::test]
+    async fn returns_401_for_missing_cookie() {
+        let (addr, _) = spawn_app().await;
+        let client = Client::new();
+        let user_pubkey = Keypair::random().public_key();
+        let res = client
+            .get(&format!("http://{}/nginx_auth_request", addr))
+            .header("pubky-host", user_pubkey.to_z32().as_str())
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(res.status(), reqwest::StatusCode::UNAUTHORIZED);
+    }
+}

--- a/pubky-homeserver/src/admin/routes/nginx_auth_request.rs
+++ b/pubky-homeserver/src/admin/routes/nginx_auth_request.rs
@@ -89,9 +89,9 @@ mod tests {
         let db = LmDB::test();
         let state = AppState::new(db.clone());
         let app = Router::new()
-            .route("/nginx_auth_request", get(nginx_auth_request))
+            .route("/nginx_auth_request", get(nginx_auth_request).layer(PubkyHostLayer))
             .with_state(state)
-            .layer(PubkyHostLayer)
+
             .layer(CookieManagerLayer::new());
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();

--- a/pubky-homeserver/src/admin/routes/nginx_auth_request.rs
+++ b/pubky-homeserver/src/admin/routes/nginx_auth_request.rs
@@ -19,7 +19,7 @@ use tower_cookies::Cookies;
 /// Usage:
 /// ```nginx
 /// location /protected/ {
-///     auth_request /extract_pubky_from_session_cookie;
+///     auth_request /nginx_auth_request;
 ///     # Set $user_id from the x-user-id header returned by the homeserver
 ///     auth_request_set $user_id $upstream_http_x_user_id;
 ///

--- a/pubky-homeserver/src/admin/routes/nginx_auth_request.rs
+++ b/pubky-homeserver/src/admin/routes/nginx_auth_request.rs
@@ -1,0 +1,118 @@
+use super::super::app_state::AppState;
+use crate::shared::{HttpError, HttpResult, PubkyHost};
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::IntoResponse,
+};
+
+
+
+/// Delete a single entry from the database.
+pub async fn nginx_auth_request(
+    State(mut state): State<AppState>,
+    pubky: PubkyHost,
+) -> HttpResult<impl IntoResponse> {
+    Ok((StatusCode::NO_CONTENT, ()))
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use crate::persistence::lmdb::LmDB;
+
+//     use super::*;
+//     use axum::{Router, routing::get};
+//     use pkarr::{Keypair, PublicKey};
+//     use pubky_common::{capabilities::Capability, crypto::random_bytes, session::Session};
+//     use tokio::net::TcpListener;
+//     use std::{net::SocketAddr, sync::Arc};
+//     use base32::{encode as base32_encode, Alphabet};
+//     use reqwest::{Client, cookie::Jar, Url};
+//     use axum_extra::extract::cookie::CookieJar;
+
+//     // Helper to spawn the app on a random port
+//     async fn spawn_app() -> (SocketAddr, LmDB) {
+//         let db = LmDB::test();
+//         let state = AppState::new(db.clone());
+//         let app = Router::new()
+//             .route("/nginx_auth_request", get(nginx_auth_request)).with_state(state);
+//         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+//         let addr = listener.local_addr().unwrap();
+//         tokio::spawn(async move {
+//             axum::serve(listener, app).await.unwrap();
+//         });
+//         (addr, db)
+//     }
+
+//     fn create_session(db: &LmDB) -> (PublicKey, String) {
+//         let user_pubkey = Keypair::random().public_key();
+//         let session_secret = base32_encode(Alphabet::Crockford, &random_bytes::<16>());
+//         let session = Session::new(
+//             &user_pubkey,
+//             &vec![Capability::try_from("/pub/pubky.app/:rw").unwrap()],
+//             None,
+//         )
+//         .serialize();
+        
+//         let mut wtxn = db.env.write_txn().unwrap();
+//         db
+//             .tables
+//             .sessions
+//             .put(&mut wtxn, &session_secret, &session)
+//             .unwrap();
+//         wtxn.commit().unwrap();
+
+//         (user_pubkey, session_secret)
+//     }
+
+//     #[tokio::test]
+//     async fn returns_200_for_valid_session() {
+//         let (addr, db)   = spawn_app().await;
+//         let url = format!("http://{}/extract_pubky_from_session_cookie", addr);
+//         let url_parsed = Url::parse(&url).unwrap();
+//         let jar = Arc::new(Jar::default());
+//         // This value should be a valid session cookie for your AuthToken logic
+//         let (user_pubkey, session_secret) = create_session(&db);
+//         jar.add_cookie_str(&format!("session={}", session_secret), &url_parsed);
+//         let client = Client::builder().cookie_provider(jar.clone()).build().unwrap();
+//         let res = client
+//             .get(url)
+//             .send()
+//             .await
+//             .unwrap();
+//         assert_eq!(res.status(), reqwest::StatusCode::UNAUTHORIZED);
+//         assert!(res.headers().get("x-user-id").is_none());
+//     }
+
+//     #[tokio::test]
+//     async fn returns_401_for_invalid_session_but_valid_cookie() {
+//         let (addr, db) = spawn_app().await;   
+//         let url = format!("http://{}/extract_pubky_from_session_cookie", addr);
+//         let url_parsed = Url::parse(&url).unwrap();
+//         let jar = Arc::new(Jar::default());
+//         // This value should be a valid session cookie for your AuthToken logic
+//         let (_, session_secret) = create_session(&db);   
+//         jar.add_cookie_str(&format!("session={}", session_secret), &url_parsed);
+//         let client = Client::builder().cookie_provider(jar.clone()).build().unwrap();
+//         let res = client
+//             .get(url)
+//             .send()
+//             .await
+//             .unwrap();
+//         assert_eq!(res.status(), reqwest::StatusCode::UNAUTHORIZED);
+//         assert!(res.headers().get("x-user-id").is_none());
+//     }
+
+//     #[tokio::test]
+//     async fn returns_401_for_missing_cookie() {
+//         let (addr, _) = spawn_app().await;
+//         let client = Client::new();
+//         let res = client
+//             .get(&format!("http://{}/extract_pubky_from_session_cookie", addr))
+//             .send()
+//             .await
+//             .unwrap();
+//         assert_eq!(res.status(), reqwest::StatusCode::UNAUTHORIZED);
+//     }
+// }
+

--- a/pubky-homeserver/src/core/extractors.rs
+++ b/pubky-homeserver/src/core/extractors.rs
@@ -9,7 +9,6 @@ use axum::{
 
 use crate::core::error::Result;
 
-
 #[derive(Debug)]
 pub struct ListQueryParams {
     pub limit: Option<u16>,

--- a/pubky-homeserver/src/core/extractors.rs
+++ b/pubky-homeserver/src/core/extractors.rs
@@ -1,51 +1,14 @@
-use std::{collections::HashMap, fmt::Display};
+use std::collections::HashMap;
 
 use axum::{
     extract::{FromRequestParts, Query},
-    http::{request::Parts, StatusCode},
+    http::request::Parts,
     response::{IntoResponse, Response},
     RequestPartsExt,
 };
 
-use pkarr::PublicKey;
-
 use crate::core::error::Result;
 
-#[derive(Debug, Clone)]
-pub struct PubkyHost(pub(crate) PublicKey);
-
-impl PubkyHost {
-    pub fn public_key(&self) -> &PublicKey {
-        &self.0
-    }
-}
-
-impl Display for PubkyHost {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl<S> FromRequestParts<S> for PubkyHost
-where
-    S: Sync + Send,
-{
-    type Rejection = Response;
-
-    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
-        let pubky_host = parts
-            .extensions
-            .get::<PubkyHost>()
-            .cloned()
-            .ok_or((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Can't extract PubkyHost. Is `PubkyHostLayer` enabled?",
-            ))
-            .map_err(|e| e.into_response())?;
-
-        Ok(pubky_host)
-    }
-}
 
 #[derive(Debug)]
 pub struct ListQueryParams {

--- a/pubky-homeserver/src/core/layers/authz.rs
+++ b/pubky-homeserver/src/core/layers/authz.rs
@@ -12,9 +12,9 @@ use tower_cookies::Cookies;
 
 use crate::core::{
     error::{Error, Result},
-    extractors::PubkyHost,
     AppState,
 };
+use crate::shared::PubkyHost;
 
 /// A Tower Layer to handle authorization for write operations.
 #[derive(Debug, Clone)]

--- a/pubky-homeserver/src/core/layers/mod.rs
+++ b/pubky-homeserver/src/core/layers/mod.rs
@@ -1,3 +1,2 @@
 pub mod authz;
-pub mod pubky_host;
 pub mod trace;

--- a/pubky-homeserver/src/core/layers/trace.rs
+++ b/pubky-homeserver/src/core/layers/trace.rs
@@ -7,7 +7,7 @@ use tower_http::trace::{
 };
 use tracing::{Level, Span};
 
-use crate::core::extractors::PubkyHost;
+use crate::shared::PubkyHost;
 
 pub fn with_trace_layer(router: Router, excluded_paths: &[&str]) -> Router {
     let excluded_paths = Arc::new(

--- a/pubky-homeserver/src/core/routes/mod.rs
+++ b/pubky-homeserver/src/core/routes/mod.rs
@@ -13,7 +13,7 @@ use tower::ServiceBuilder;
 use tower_cookies::CookieManagerLayer;
 use tower_http::cors::CorsLayer;
 
-use crate::{core::AppState, shared::PubkyHostLayer};
+use crate::core::AppState;
 
 use super::layers::trace::with_trace_layer;
 
@@ -46,7 +46,7 @@ pub fn create_app(state: AppState) -> Router {
         .with_state(state);
 
     // Apply trace and pubky host layers to the complete router.
-    with_trace_layer(app, &TRACING_EXCLUDED_PATHS).layer(PubkyHostLayer)
+    with_trace_layer(app, &TRACING_EXCLUDED_PATHS)
 }
 
 // Middleware to add a `Server` header to all responses

--- a/pubky-homeserver/src/core/routes/mod.rs
+++ b/pubky-homeserver/src/core/routes/mod.rs
@@ -13,9 +13,9 @@ use tower::ServiceBuilder;
 use tower_cookies::CookieManagerLayer;
 use tower_http::cors::CorsLayer;
 
-use crate::core::AppState;
+use crate::{core::AppState, shared::PubkyHostLayer};
 
-use super::layers::{pubky_host::PubkyHostLayer, trace::with_trace_layer};
+use super::layers::trace::with_trace_layer;
 
 mod auth;
 mod feed;

--- a/pubky-homeserver/src/core/routes/tenants/mod.rs
+++ b/pubky-homeserver/src/core/routes/tenants/mod.rs
@@ -9,7 +9,7 @@ use axum::{
     Router,
 };
 
-use crate::core::{layers::authz::AuthorizationLayer, AppState};
+use crate::{core::{layers::authz::AuthorizationLayer, AppState}, shared::PubkyHostLayer};
 
 pub mod read;
 pub mod session;
@@ -30,4 +30,5 @@ pub fn router(state: AppState) -> Router<AppState> {
         // TODO: different max size for sessions and other routes?
         .layer(DefaultBodyLimit::max(100 * 1024 * 1024))
         .layer(AuthorizationLayer::new(state.clone()))
+        .layer(PubkyHostLayer)
 }

--- a/pubky-homeserver/src/core/routes/tenants/read.rs
+++ b/pubky-homeserver/src/core/routes/tenants/read.rs
@@ -8,12 +8,12 @@ use httpdate::HttpDate;
 use pkarr::PublicKey;
 use std::str::FromStr;
 
-use crate::core::{
+use crate::{core::{
     err_if_user_is_invalid::err_if_user_is_invalid,
     error::{Error, Result},
-    extractors::{ListQueryParams, PubkyHost},
+    extractors::ListQueryParams,
     AppState,
-};
+}, shared::PubkyHost};
 use crate::persistence::lmdb::tables::entries::Entry;
 
 pub async fn head(

--- a/pubky-homeserver/src/core/routes/tenants/read.rs
+++ b/pubky-homeserver/src/core/routes/tenants/read.rs
@@ -8,13 +8,16 @@ use httpdate::HttpDate;
 use pkarr::PublicKey;
 use std::str::FromStr;
 
-use crate::{core::{
-    err_if_user_is_invalid::err_if_user_is_invalid,
-    error::{Error, Result},
-    extractors::ListQueryParams,
-    AppState,
-}, shared::PubkyHost};
 use crate::persistence::lmdb::tables::entries::Entry;
+use crate::{
+    core::{
+        err_if_user_is_invalid::err_if_user_is_invalid,
+        error::{Error, Result},
+        extractors::ListQueryParams,
+        AppState,
+    },
+    shared::PubkyHost,
+};
 
 pub async fn head(
     State(state): State<AppState>,

--- a/pubky-homeserver/src/core/routes/tenants/session.rs
+++ b/pubky-homeserver/src/core/routes/tenants/session.rs
@@ -1,12 +1,15 @@
 use axum::{extract::State, http::StatusCode, response::IntoResponse};
 use tower_cookies::Cookies;
 
-use crate::{core::{
-    err_if_user_is_invalid::err_if_user_is_invalid,
-    error::{Error, Result},
-    layers::authz::session_secret_from_cookies,
-    AppState,
-}, shared::PubkyHost};
+use crate::{
+    core::{
+        err_if_user_is_invalid::err_if_user_is_invalid,
+        error::{Error, Result},
+        layers::authz::session_secret_from_cookies,
+        AppState,
+    },
+    shared::PubkyHost,
+};
 
 pub async fn session(
     State(state): State<AppState>,

--- a/pubky-homeserver/src/core/routes/tenants/session.rs
+++ b/pubky-homeserver/src/core/routes/tenants/session.rs
@@ -1,13 +1,12 @@
 use axum::{extract::State, http::StatusCode, response::IntoResponse};
 use tower_cookies::Cookies;
 
-use crate::core::{
+use crate::{core::{
     err_if_user_is_invalid::err_if_user_is_invalid,
     error::{Error, Result},
-    extractors::PubkyHost,
     layers::authz::session_secret_from_cookies,
     AppState,
-};
+}, shared::PubkyHost};
 
 pub async fn session(
     State(state): State<AppState>,

--- a/pubky-homeserver/src/core/routes/tenants/write.rs
+++ b/pubky-homeserver/src/core/routes/tenants/write.rs
@@ -8,12 +8,11 @@ use axum::{
 };
 use futures_util::stream::StreamExt;
 
-use crate::core::{
+use crate::{core::{
     err_if_user_is_invalid::err_if_user_is_invalid,
     error::{Error, Result},
-    extractors::PubkyHost,
     AppState,
-};
+}, shared::PubkyHost};
 
 /// Fail with 507 if `(current + incoming − existing) > quota`.
 fn enforce_user_disk_quota(

--- a/pubky-homeserver/src/core/routes/tenants/write.rs
+++ b/pubky-homeserver/src/core/routes/tenants/write.rs
@@ -8,11 +8,14 @@ use axum::{
 };
 use futures_util::stream::StreamExt;
 
-use crate::{core::{
-    err_if_user_is_invalid::err_if_user_is_invalid,
-    error::{Error, Result},
-    AppState,
-}, shared::PubkyHost};
+use crate::{
+    core::{
+        err_if_user_is_invalid::err_if_user_is_invalid,
+        error::{Error, Result},
+        AppState,
+    },
+    shared::PubkyHost,
+};
 
 /// Fail with 507 if `(current + incoming − existing) > quota`.
 fn enforce_user_disk_quota(

--- a/pubky-homeserver/src/shared/mod.rs
+++ b/pubky-homeserver/src/shared/mod.rs
@@ -1,5 +1,7 @@
 mod http_error;
 mod pubkey_path_validator;
+mod pubky_host;
 
 pub(crate) use http_error::{HttpError, HttpResult};
 pub(crate) use pubkey_path_validator::Z32Pubkey;
+pub(crate) use pubky_host::{PubkyHost, PubkyHostLayer};

--- a/pubky-homeserver/src/shared/pubky_host.rs
+++ b/pubky-homeserver/src/shared/pubky_host.rs
@@ -120,7 +120,10 @@ where
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "Can't extract PubkyHost. Is `PubkyHostLayer` enabled?",
             ))
-            .map_err(|e| e.into_response())?;
+            .map_err(|e| {
+                tracing::debug!("Failed to extract PubkyHost.");
+                e.into_response()
+            })?;
 
         Ok(pubky_host)
     }

--- a/pubky-homeserver/src/shared/pubky_host.rs
+++ b/pubky-homeserver/src/shared/pubky_host.rs
@@ -1,12 +1,20 @@
-use crate::core::error::Result;
-use crate::core::extractors::PubkyHost;
 use axum::{body::Body, http::Request};
 use futures_util::future::BoxFuture;
 use pkarr::PublicKey;
 use std::{convert::Infallible, task::Poll};
 use tower::{Layer, Service};
+use std::fmt::Display;
+
+use axum::{
+    extract::FromRequestParts,
+    http::{request::Parts, StatusCode},
+    response::{IntoResponse, Response},
+};
+
 
 /// A Tower Layer to extract and inject the PubkyHost into request extensions.
+/// This is added to the router so the host is extracted automatically for each request.
+/// You then can use `PubkyHost` extractor to get the host from the request.
 #[derive(Debug, Clone)]
 pub struct PubkyHostLayer;
 
@@ -80,4 +88,44 @@ fn extract_pubky(req: &Request<Body>) -> Option<PublicKey> {
         });
     }
     pubky
+}
+
+
+
+
+/// Extractor for the PubkyHost.
+#[derive(Debug, Clone)]
+pub struct PubkyHost(pub(crate) PublicKey);
+
+impl PubkyHost {
+    pub fn public_key(&self) -> &PublicKey {
+        &self.0
+    }
+}
+
+impl Display for PubkyHost {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl<S> FromRequestParts<S> for PubkyHost
+where
+    S: Sync + Send,
+{
+    type Rejection = Response;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let pubky_host = parts
+            .extensions
+            .get::<PubkyHost>()
+            .cloned()
+            .ok_or((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Can't extract PubkyHost. Is `PubkyHostLayer` enabled?",
+            ))
+            .map_err(|e| e.into_response())?;
+
+        Ok(pubky_host)
+    }
 }

--- a/pubky-homeserver/src/shared/pubky_host.rs
+++ b/pubky-homeserver/src/shared/pubky_host.rs
@@ -95,11 +95,11 @@ impl Display for ParamName {
 
 #[derive(thiserror::Error, Debug)]
 enum ExtractPubKeyError {
-    #[error("{1} {0} not found")]
+    #[error("{1} '{0}' not found")]
     NotFound(ParamName, ExtractPubKeySource),
-    #[error("{1} {0} is not valid UTF-8")]
+    #[error("{1} '{0}' is not valid UTF-8")]
     InvalidUtf8(ParamName, ExtractPubKeySource),
-    #[error("{1} {0} failed to parse public key: {2} {3}")]
+    #[error("{1} '{0}' value '{2}' failed to parse public key: {3}")]
     InvalidPublicKey(ParamName, ExtractPubKeySource, String, pkarr::errors::PublicKeyError),
 }
 

--- a/pubky-homeserver/src/shared/pubky_host.rs
+++ b/pubky-homeserver/src/shared/pubky_host.rs
@@ -1,16 +1,15 @@
 use axum::{body::Body, http::Request};
 use futures_util::future::BoxFuture;
 use pkarr::PublicKey;
+use std::fmt::Display;
 use std::{convert::Infallible, task::Poll};
 use tower::{Layer, Service};
-use std::fmt::Display;
 
 use axum::{
     extract::FromRequestParts,
     http::{request::Parts, StatusCode},
     response::{IntoResponse, Response},
 };
-
 
 /// A Tower Layer to extract and inject the PubkyHost into request extensions.
 /// This is added to the router so the host is extracted automatically for each request.
@@ -89,9 +88,6 @@ fn extract_pubky(req: &Request<Body>) -> Option<PublicKey> {
     }
     pubky
 }
-
-
-
 
 /// Extractor for the PubkyHost.
 #[derive(Debug, Clone)]

--- a/pubky-homeserver/src/shared/pubky_host.rs
+++ b/pubky-homeserver/src/shared/pubky_host.rs
@@ -189,7 +189,7 @@ where
                 "Can't extract PubkyHost. Is `PubkyHostLayer` enabled?",
             ))
             .map_err(|e| {
-                tracing::debug!("Failed to extract PubkyHost.");
+                tracing::debug!("Failed to extract PubkyHost for {} {}.", parts.method, parts.uri);
                 e.into_response()
             })?;
 

--- a/pubky-homeserver/src/shared/pubky_host.rs
+++ b/pubky-homeserver/src/shared/pubky_host.rs
@@ -168,6 +168,18 @@ fn extract_pubky_from_request(req: &Request<Body>) -> Result<PublicKey, Vec<Extr
 }
 
 /// Extractor for the PubkyHost.
+/// 
+/// Usage example:
+/// ```ignore
+/// pub async fn request_handler(
+///     State(state): State<AppState>,
+///     pubky: PubkyHost,
+/// ) -> HttpResult<impl IntoResponse> {
+/// ```
+/// 
+/// 
+/// Required the `PubkyHostLayer` to be added to the router.
+/// 
 #[derive(Debug, Clone)]
 pub struct PubkyHost(pub(crate) PublicKey);
 
@@ -199,7 +211,7 @@ where
                 "Can't extract PubkyHost. Is `PubkyHostLayer` enabled?",
             ))
             .map_err(|e| {
-                tracing::debug!("Failed to extract PubkyHost for {} {}.", parts.method, parts.uri);
+                tracing::error!("Failed to extract PubkyHost for {} {}. Is `PubkyHostLayer` enabled?", parts.method, parts.uri);
                 e.into_response()
             })?;
 

--- a/pubky-homeserver/src/shared/pubky_host.rs
+++ b/pubky-homeserver/src/shared/pubky_host.rs
@@ -55,7 +55,7 @@ where
             Ok(key) => key,
             Err(errors) => {
                 return Box::pin(async move {
-                    let error_message = errors.iter().map(|e| e.to_string()).collect::<Vec<_>>().join(", ");
+                    let error_message = errors.iter().map(|e| e.to_string()).collect::<Vec<_>>().join(".\n");
                     let error_message = format!("Missing or invalid pubky_host header or query param:\n{}", error_message);
                     tracing::error!("Failed to extract PubkyHost: {}", error_message);
                     Ok(HttpError::new(StatusCode::BAD_REQUEST, Some(error_message)).into_response())


### PR DESCRIPTION
Implements a session validation and user pubkey extraction endpoint compatible with the nginx `auth_request` module to the admin server.

With this endpoint, nginx is capable of assigning requests to user pubkeys and can therefore rate limit requests based on users.


Nginx usage example:

```nginx
location /protected/ {
    auth_request http://admin-homeserver:6288/nginx_auth_request;
    # Set $user_id from the x-user-id header returned by the homeserver
    auth_request_set $user_id $upstream_http_x_user_id;
    # Use $user_id for rate limiting
    limit_req_zone $user_id zone=user_limit:10m rate=1r/s;
    limit_req zone=user_limit burst=5 nodelay;
}
```