### PR TITLE
fix(homeserver): move exposed admin endpoints behind pw protection

### DIFF
--- a/e2e/src/tests/auth.rs
+++ b/e2e/src/tests/auth.rs
@@ -88,6 +88,7 @@ async fn disabled_user() {
     // Disable the user
     let response = admin_client
         .post(format!("http://{admin_socket}/users/{pubky}/disable"))
+        .header("X-Admin-Password", "admin")
         .send()
         .await
         .unwrap();

--- a/pubky-client/pkg/test/utils.js
+++ b/pubky-client/pkg/test/utils.js
@@ -9,7 +9,7 @@
  * @throws Will throw an error if the request fails.
  */
 export async function createSignupToken(client, homeserver_address ="localhost:6288", adminPassword = "admin") {
-  const adminUrl = `http://${homeserver_address}/admin/generate_signup_token`;
+  const adminUrl = `http://${homeserver_address}/generate_signup_token`;
   const response = await client.fetch(adminUrl, {
     method: "GET",
     headers: {

--- a/pubky-homeserver/src/admin/app.rs
+++ b/pubky-homeserver/src/admin/app.rs
@@ -168,14 +168,14 @@ mod tests {
         let server = TestServer::new(create_app(AppState::new(LmDB::test()), "test")).unwrap();
         // No password
         let response = server
-            .get("/admin/generate_signup_token")
+            .get("/generate_signup_token")
             .expect_failure()
             .await;
         response.assert_status_unauthorized();
 
         // wrong password
         let response = server
-            .get("/admin/generate_signup_token")
+            .get("/generate_signup_token")
             .add_header("X-Admin-Password", "wrongpassword")
             .expect_failure()
             .await;
@@ -186,7 +186,7 @@ mod tests {
     async fn test_generate_signup_token_success() {
         let server = TestServer::new(create_app(AppState::new(LmDB::test()), "test")).unwrap();
         let response = server
-            .get("/admin/generate_signup_token")
+            .get("/generate_signup_token")
             .add_header("X-Admin-Password", "test")
             .expect_success()
             .await;

--- a/pubky-homeserver/src/admin/app.rs
+++ b/pubky-homeserver/src/admin/app.rs
@@ -167,10 +167,7 @@ mod tests {
     async fn test_generate_signup_token_fail() {
         let server = TestServer::new(create_app(AppState::new(LmDB::test()), "test")).unwrap();
         // No password
-        let response = server
-            .get("/generate_signup_token")
-            .expect_failure()
-            .await;
+        let response = server.get("/generate_signup_token").expect_failure().await;
         response.assert_status_unauthorized();
 
         // wrong password

--- a/pubky-homeserver/src/admin/app.rs
+++ b/pubky-homeserver/src/admin/app.rs
@@ -22,6 +22,12 @@ fn create_admin_router(password: &str) -> Router<AppState> {
             "/generate_signup_token",
             get(generate_signup_token::generate_signup_token),
         )
+        .route(
+            "/webdav/{pubkey}/{*path}",
+            delete(delete_entry::delete_entry),
+        )
+        .route("/users/{pubkey}/disable", post(disable_user))
+        .route("/users/{pubkey}/enable", post(enable_user))
         .layer(AdminAuthLayer::new(password.to_string()))
 }
 
@@ -33,12 +39,6 @@ fn create_app(state: AppState, password: &str) -> axum::routing::IntoMakeService
     let app = Router::new()
         .nest("/admin", admin_router)
         .route("/", get(root::root))
-        .route(
-            "/webdav/{pubkey}/{*path}",
-            delete(delete_entry::delete_entry),
-        )
-        .route("/users/{pubkey}/disable", post(disable_user))
-        .route("/users/{pubkey}/enable", post(enable_user))
         .with_state(state)
         .layer(CorsLayer::very_permissive());
 

--- a/pubky-homeserver/src/admin/app.rs
+++ b/pubky-homeserver/src/admin/app.rs
@@ -33,8 +33,7 @@ fn create_protected_router(password: &str) -> Router<AppState> {
 /// Public router without any authentication.
 /// NO PASSWORD PROTECTION!
 fn create_public_router() -> Router<AppState> {
-    Router::new()
-    .route("/", get(root::root))
+    Router::new().route("/", get(root::root))
 }
 
 /// Create the app

--- a/pubky-homeserver/src/admin/app.rs
+++ b/pubky-homeserver/src/admin/app.rs
@@ -14,9 +14,8 @@ use axum_server::Handle;
 use tokio::task::JoinHandle;
 use tower_http::cors::CorsLayer;
 
-/// Folder /admin router
-/// Admin password required.
-fn create_admin_router(password: &str) -> Router<AppState> {
+/// Admin password protected router.
+fn create_protected_router(password: &str) -> Router<AppState> {
     Router::new()
         .route(
             "/generate_signup_token",
@@ -31,14 +30,20 @@ fn create_admin_router(password: &str) -> Router<AppState> {
         .layer(AdminAuthLayer::new(password.to_string()))
 }
 
-/// main / router
-/// This part is not protected by the admin auth middleware
-fn create_app(state: AppState, password: &str) -> axum::routing::IntoMakeService<Router> {
-    let admin_router = create_admin_router(password);
+/// Public router without any authentication.
+/// NO PASSWORD PROTECTION!
+fn create_public_router() -> Router<AppState> {
+    Router::new()
+    .route("/", get(root::root))
+}
 
+/// Create the app
+fn create_app(state: AppState, password: &str) -> axum::routing::IntoMakeService<Router> {
+    let admin_router = create_protected_router(password);
+    let public_router = create_public_router();
     let app = Router::new()
-        .nest("/admin", admin_router)
-        .route("/", get(root::root))
+        .merge(admin_router)
+        .merge(public_router)
         .with_state(state)
         .layer(CorsLayer::very_permissive());
 
@@ -124,7 +129,7 @@ impl AdminServer {
     /// Create a signup token for the given homeserver.
     pub async fn create_signup_token(&self) -> anyhow::Result<String> {
         let admin_socket = self.listen_socket();
-        let url = format!("http://{}/admin/generate_signup_token", admin_socket);
+        let url = format!("http://{}/generate_signup_token", admin_socket);
         let response = reqwest::Client::new()
             .get(url)
             .header("X-Admin-Password", &self.password)


### PR DESCRIPTION
Newly added admin endpoints added in #110 are not password protected. This PR fixes this.