### PR TITLE
fix (homeserver): disable relays when republishing user keys

### DIFF
--- a/pubky-homeserver/src/core/user_keys_republisher.rs
+++ b/pubky-homeserver/src/core/user_keys_republisher.rs
@@ -57,7 +57,8 @@ impl UserKeysRepublisher {
             );
         }
 
-        let pkarr_builder = context.pkarr_builder.clone();
+        let mut pkarr_builder = context.pkarr_builder.clone();
+        pkarr_builder.no_relays(); // Disable relays to avoid their rate limiting.
         let handle = tokio::spawn(async move {
             tokio::time::sleep(initial_delay).await;
             Self::run_loop(db, republish_interval, pkarr_builder).await


### PR DESCRIPTION
The relay will rate limit the republishing. To avoid this, we disable them.