### PR TITLE
feat(homeserver): Whitelist for rate limits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,6 +893,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "embedded-io"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1649,6 +1655,7 @@ checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.2",
+ "serde",
 ]
 
 [[package]]
@@ -1671,6 +1678,15 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1950,6 +1966,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2075,6 +2100,12 @@ dependencies = [
  "rand_core 0.6.4",
  "subtle",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -2311,6 +2342,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2409,6 +2461,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde-toml-merge",
+ "serde_valid",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
@@ -3046,6 +3099,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_valid"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b615bed66931a7a9809b273937adc8a402d038b1e509d027fcaf62f084d33d1"
+dependencies = [
+ "indexmap",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "paste",
+ "regex",
+ "serde",
+ "serde_json",
+ "serde_valid_derive",
+ "serde_valid_literal",
+ "thiserror 1.0.69",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "serde_valid_derive"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa1a5a21ea5aab06d2e6a6b59837d450fb2be9695be97735a711edfbe79ea07"
+dependencies = [
+ "itertools",
+ "paste",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "serde_valid_literal"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd07331596ea967dccf9a35bde71ecd757490e09827b938a5c6226c648e3a25e"
+dependencies = [
+ "paste",
+ "regex",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3644,6 +3742,12 @@ name = "unicode-ident"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "universal-hash"

--- a/pubky-homeserver/Cargo.toml
+++ b/pubky-homeserver/Cargo.toml
@@ -55,6 +55,7 @@ dyn-clone = "1.0.19"
 reqwest = "0.12.15"
 governor = "0.10.0"
 fast-glob = "0.4.5"
+serde_valid = "1.0.5"
 
 
 [dev-dependencies]

--- a/pubky-homeserver/config.sample.toml
+++ b/pubky-homeserver/config.sample.toml
@@ -38,6 +38,7 @@ icann_listen_socket = "127.0.0.1:6286"
 #  - "user" limits based on the user pubkey. Requires the endpoint to have authentication.
 # `burst` is a temporary allowance of quota that is added to the limit. 
 #   By default, burst is equal the quota rate.
+# `whitelist` is a list of IP addresses or user pubkeys that are exempt from the rate limit.
 #
 # Limit login attempts to 20 requests per minute per IP. 
 [[drive.rate_limits]]
@@ -45,6 +46,9 @@ path = "/session"
 method = "POST"
 quota = "20r/m"
 key = "ip"
+whitelist = [
+    "127.0.0.1"
+]
 #
 # Limit file uploads to 1 megabyte per second per user with a temporary burst of 10 megabytes.
 [[drive.rate_limits]]

--- a/pubky-homeserver/src/data_directory/quota_config/http_method.rs
+++ b/pubky-homeserver/src/data_directory/quota_config/http_method.rs
@@ -53,3 +53,18 @@ impl<'de> Deserialize<'de> for HttpMethod {
         HttpMethod::from_str(&s).map_err(serde::de::Error::custom)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_http_method_serde() {
+        let method = Method::GET;
+        let http_method = HttpMethod(method);
+        assert_eq!(http_method.to_string(), "GET");
+
+        let deserialized: HttpMethod = "GET".parse().unwrap();
+        assert_eq!(deserialized, http_method);
+    }
+}

--- a/pubky-homeserver/src/data_directory/quota_config/limit_key.rs
+++ b/pubky-homeserver/src/data_directory/quota_config/limit_key.rs
@@ -1,13 +1,44 @@
 use std::fmt;
+use std::net::IpAddr;
 use std::str::FromStr;
+
+use pkarr::PublicKey;
 
 /// The key to limit the quota on.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum LimitKey {
-    /// Limit on the user id    
-    User,
+    /// Limit on the user pubkey
+    User(PublicKey),
     /// Limit on the ip address
-    Ip,
+    Ip(IpAddr),
+}
+
+impl LimitKey {
+    /// Get the type of the limit key.
+    pub fn get_type(&self) -> LimitKeyType {
+        match self {
+            LimitKey::User(_) => LimitKeyType::User,
+            LimitKey::Ip(_) => LimitKeyType::Ip,
+        }
+    }
+}
+
+impl FromStr for LimitKey {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let pubkey_parse_error = match s.parse::<PublicKey>() {
+            Ok(user_pubkey) => return Ok(LimitKey::User(user_pubkey)),
+            Err(e) => e,
+        };
+
+        let ip_parse_error = match s.parse::<IpAddr>() {
+            Ok(ip_addr) => return Ok(LimitKey::Ip(ip_addr)),
+            Err(e) => e,
+        };
+
+        anyhow::bail!("Invalid limit key. Can't be parsed as a public key or ip address:\n- Public key error: {pubkey_parse_error}\n- Ip address error: {ip_parse_error}")
+    }
 }
 
 impl fmt::Display for LimitKey {
@@ -16,22 +47,10 @@ impl fmt::Display for LimitKey {
             f,
             "{}",
             match self {
-                LimitKey::User => "user",
-                LimitKey::Ip => "ip",
+                LimitKey::User(user_pubkey) => user_pubkey.to_string(),
+                LimitKey::Ip(ip_addr) => ip_addr.to_string(),
             }
         )
-    }
-}
-
-impl FromStr for LimitKey {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "user" => Ok(LimitKey::User),
-            "ip" => Ok(LimitKey::Ip),
-            _ => Err(format!("Invalid limit key: {}", s)),
-        }
     }
 }
 
@@ -51,5 +70,104 @@ impl<'de> serde::Deserialize<'de> for LimitKey {
     {
         let s = String::deserialize(deserializer)?;
         LimitKey::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+/// The key type to limit the quota on.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum LimitKeyType {
+    /// Limit on the user id    
+    User,
+    /// Limit on the ip address
+    Ip,
+}
+
+impl fmt::Display for LimitKeyType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                LimitKeyType::User => "user",
+                LimitKeyType::Ip => "ip",
+            }
+        )
+    }
+}
+
+impl FromStr for LimitKeyType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "user" => Ok(LimitKeyType::User),
+            "ip" => Ok(LimitKeyType::Ip),
+            _ => Err(format!("Invalid limit key: {}", s)),
+        }
+    }
+}
+
+impl serde::Serialize for LimitKeyType {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.to_string().as_str())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for LimitKeyType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        LimitKeyType::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::Ipv4Addr;
+
+    use pkarr::Keypair;
+
+    use super::*;
+
+    #[test]
+    fn test_limit_key_pubkey() {
+        let keypair = Keypair::from_secret_key(&[0u8; 32]);
+        let pubkey = keypair.public_key();
+
+        let limit_key = LimitKey::User(pubkey);
+        assert_eq!(limit_key.get_type(), LimitKeyType::User);
+        let string = limit_key.to_string();
+        assert_eq!(
+            string,
+            "8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo"
+        );
+
+        let limit_key_from_str = LimitKey::from_str(&string).unwrap();
+        assert_eq!(limit_key, limit_key_from_str);
+    }
+
+    #[test]
+    fn test_limit_key_ip() {
+        let ip = IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1));
+
+        let limit_key = LimitKey::Ip(ip);
+        assert_eq!(limit_key.get_type(), LimitKeyType::Ip);
+        let string = limit_key.to_string();
+        assert_eq!(string, "127.0.0.1");
+
+        let limit_key_from_str = LimitKey::from_str(&string).unwrap();
+        assert_eq!(limit_key, limit_key_from_str);
+    }
+
+    #[test]
+    fn test_limit_key_parse_error() {
+        let string = "invalid";
+        let result = LimitKey::from_str(&string);
+        assert!(result.is_err());
     }
 }

--- a/pubky-homeserver/src/data_directory/quota_config/mod.rs
+++ b/pubky-homeserver/src/data_directory/quota_config/mod.rs
@@ -8,7 +8,7 @@ mod time_unit;
 
 pub use glob_pattern::GlobPattern;
 pub use http_method::HttpMethod;
-pub use limit_key::LimitKey;
+pub use limit_key::{LimitKey, LimitKeyType};
 pub use path_limit::*;
 pub use quota_value::QuotaValue;
 pub use rate_unit::RateUnit;

--- a/pubky-homeserver/src/data_directory/quota_config/path_limit.rs
+++ b/pubky-homeserver/src/data_directory/quota_config/path_limit.rs
@@ -73,22 +73,10 @@ impl std::fmt::Display for PathLimit {
             .burst
             .map(|b| format!(" burst {}", b))
             .unwrap_or("".to_string());
-        let whitelist_str = if self.whitelist.is_empty() {
-            "".to_string()
-        } else {
-            format!(
-                " whitelist: {}",
-                self.whitelist
-                    .iter()
-                    .map(|k| k.to_string())
-                    .collect::<Vec<String>>()
-                    .join(", ")
-            )
-        };
         write!(
             f,
-            "{} {}: {}{burst_str} by {}.{whitelist_str}",
-            self.method, self.path, self.quota, self.key,
+            "{} {}: {}{burst_str} by {}.whitelist: {:?}",
+            self.method, self.path, self.quota, self.key, self.whitelist
         )
     }
 }

--- a/pubky-homeserver/src/data_directory/quota_config/path_limit.rs
+++ b/pubky-homeserver/src/data_directory/quota_config/path_limit.rs
@@ -1,10 +1,20 @@
-use super::{GlobPattern, HttpMethod, LimitKey, QuotaValue};
+use super::{limit_key::LimitKey, GlobPattern, HttpMethod, LimitKeyType, QuotaValue};
 use axum::http::Method;
 use serde::{Deserialize, Serialize};
+use serde_valid::Validate;
 use std::num::NonZeroU32;
 
+/// Make sure all whitelist keys are of the same type as the limit key type.
+fn serde_validate_path_limit(limit: &PathLimit) -> Result<(), serde_valid::validation::Error> {
+    limit
+        .validate()
+        .map_err(|e| serde_valid::validation::Error::Custom(e.to_string()))?;
+    Ok(())
+}
+
 /// A limit on a path for a specific method.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash, Validate)]
+#[validate(custom = serde_validate_path_limit)]
 pub struct PathLimit {
     /// The path glob pattern to match against.
     pub path: GlobPattern,
@@ -13,9 +23,12 @@ pub struct PathLimit {
     /// The limit to apply.
     pub quota: QuotaValue,
     /// The key to limit.
-    pub key: LimitKey,
+    pub key: LimitKeyType,
     /// The burst to apply.
     pub burst: Option<NonZeroU32>,
+    /// The whitelist of keys to limit.
+    #[serde(default)]
+    pub whitelist: Vec<LimitKey>,
 }
 
 impl PathLimit {
@@ -24,7 +37,7 @@ impl PathLimit {
         path: GlobPattern,
         method: Method,
         quota: QuotaValue,
-        key: LimitKey,
+        key: LimitKeyType,
         burst: Option<NonZeroU32>,
     ) -> Self {
         Self {
@@ -33,20 +46,49 @@ impl PathLimit {
             quota,
             key,
             burst,
+            whitelist: vec![],
         }
+    }
+
+    /// Check if the key is whitelisted.
+    pub fn is_whitelisted(&self, key: &LimitKey) -> bool {
+        self.whitelist.iter().any(|k| k == key)
+    }
+
+    /// Validate the path limit.
+    pub fn validate(&self) -> anyhow::Result<()> {
+        if let Some(k) = self.whitelist.iter().find(|k| k.get_type() != self.key) {
+            let should_type = self.key.to_string();
+            let is_type = k.get_type().to_string();
+            let msg = format!("Whitelist key type mismatch for '{k}'. Expected type '{should_type}' but got '{is_type}'. Full path limit: {self}");
+            return Err(anyhow::anyhow!(msg));
+        }
+        Ok(())
     }
 }
 
 impl std::fmt::Display for PathLimit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let burst_str = self
+            .burst
+            .map(|b| format!(" burst {}", b))
+            .unwrap_or("".to_string());
+        let whitelist_str = if self.whitelist.is_empty() {
+            "".to_string()
+        } else {
+            format!(
+                " whitelist: {}",
+                self.whitelist
+                    .iter()
+                    .map(|k| k.to_string())
+                    .collect::<Vec<String>>()
+                    .join(", ")
+            )
+        };
         write!(
             f,
-            "{} {}: {}-{} by {}",
-            self.method,
-            self.path,
-            self.quota,
-            self.burst.map_or_else(String::new, |b| b.to_string()),
-            self.key
+            "{} {}: {}{burst_str} by {}.{whitelist_str}",
+            self.method, self.path, self.quota, self.key,
         )
     }
 }
@@ -63,15 +105,32 @@ impl From<PathLimit> for governor::Quota {
 
 #[cfg(test)]
 mod tests {
+    use std::{
+        net::{IpAddr, Ipv4Addr},
+        str::FromStr,
+    };
+
+    use pkarr::Keypair;
+
     use super::*;
 
     #[test]
-    fn test_http_method_serde() {
-        let method = Method::GET;
-        let http_method = HttpMethod(method);
-        assert_eq!(http_method.to_string(), "GET");
-
-        let deserialized: HttpMethod = "GET".parse().unwrap();
-        assert_eq!(deserialized, http_method);
+    fn test_validate_path_limit() {
+        let mut limit = PathLimit::new(
+            GlobPattern::new("*"),
+            Method::GET,
+            QuotaValue::from_str("10r/s").unwrap(),
+            LimitKeyType::Ip,
+            None,
+        );
+        assert!(limit.validate().is_ok());
+        limit
+            .whitelist
+            .push(LimitKey::Ip(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1))));
+        assert!(limit.validate().is_ok());
+        limit
+            .whitelist
+            .push(LimitKey::User(Keypair::random().public_key()));
+        assert!(limit.validate().is_err());
     }
 }


### PR DESCRIPTION
Adds the ability to add a whitelist to rate limits.

Examples:

```toml
[[drive.rate_limits]]
path = "/session"
method = "POST"
quota = "20r/m"
key = "ip"
whitelist = [
    "127.0.0.1"
]

[[drive.rate_limits]]
path = "/pub/**" 
method = "PUT"
quota = "1mb/s"
key = "user"
burst = 10
whitelist = [
    "8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo"
]
```

The whitelist is fully validated on ConfigToml parse. 
- It either is a valid pubkey or a IP address.
- Whitelist element must match the rate limit key type.

Includes an end2end test.