### PR TITLE
feat: Only block disabled users from writing files, not reading

### DIFF
--- a/e2e/src/tests/auth.rs
+++ b/e2e/src/tests/auth.rs
@@ -94,11 +94,11 @@ async fn disabled_user() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
 
-    // Make sure the user cannot read their own file
+    // Make sure the user can still read their own file
     let response = client.get(file_url.clone()).send().await.unwrap();
-    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    assert_eq!(response.status(), StatusCode::OK);
 
-    // Make sure the user cannot write to their own file
+    // Make sure the user cannot write a new file
     let response = client
         .put(file_url.clone())
         .body(vec![])
@@ -107,9 +107,11 @@ async fn disabled_user() {
         .unwrap();
     assert_eq!(response.status(), StatusCode::FORBIDDEN);
 
-    // Make sure the user cannot sign in
-    let session = client.signin(&keypair).await;
-    assert!(session.is_err());
+    // Make sure the user can still sign in
+    client
+        .signin(&keypair)
+        .await
+        .expect("Signin should succeed");
 }
 
 #[tokio::test]

--- a/pubky-homeserver/src/core/err_if_user_is_invalid.rs
+++ b/pubky-homeserver/src/core/err_if_user_is_invalid.rs
@@ -6,10 +6,14 @@ use crate::persistence::lmdb::{tables::users::UserQueryError, LmDB};
 use super::Error;
 
 /// Returns an error if the user doesn't exist or is disabled.
-pub fn err_if_user_is_invalid(pubkey: &PublicKey, db: &LmDB) -> super::error::Result<()> {
+pub fn err_if_user_is_invalid(
+    pubkey: &PublicKey,
+    db: &LmDB,
+    err_if_disabled: bool,
+) -> super::error::Result<()> {
     match db.get_user(pubkey, &mut db.env.read_txn()?) {
         Ok(user) => {
-            if user.disabled {
+            if err_if_disabled && user.disabled {
                 return Err(Error::with_status(StatusCode::FORBIDDEN));
             }
         }

--- a/pubky-homeserver/src/core/routes/auth.rs
+++ b/pubky-homeserver/src/core/routes/auth.rs
@@ -123,7 +123,7 @@ fn create_session_and_cookie(
     capabilities: &[Capability],
     user_agent: Option<TypedHeader<UserAgent>>,
 ) -> Result<impl IntoResponse> {
-    err_if_user_is_invalid(public_key, &state.db)?;
+    err_if_user_is_invalid(public_key, &state.db, false)?;
 
     // 1) Create session
     let session_secret = encode(Alphabet::Crockford, &random_bytes::<16>());

--- a/pubky-homeserver/src/core/routes/tenants/read.rs
+++ b/pubky-homeserver/src/core/routes/tenants/read.rs
@@ -9,7 +9,6 @@ use pkarr::PublicKey;
 use std::str::FromStr;
 
 use crate::core::{
-    err_if_user_is_invalid::err_if_user_is_invalid,
     error::{Error, Result},
     extractors::{ListQueryParams, PubkyHost},
     AppState,
@@ -22,8 +21,6 @@ pub async fn head(
     headers: HeaderMap,
     path: OriginalUri,
 ) -> Result<impl IntoResponse> {
-    err_if_user_is_invalid(pubky.public_key(), &state.db)?;
-
     let rtxn = state.db.env.read_txn()?;
     get_entry(
         headers,
@@ -41,8 +38,6 @@ pub async fn get(
     path: OriginalUri,
     params: ListQueryParams,
 ) -> Result<impl IntoResponse> {
-    err_if_user_is_invalid(pubky.public_key(), &state.db)?;
-
     let public_key = pubky.public_key().clone();
     let path = path.0.path().to_string();
 
@@ -86,8 +81,6 @@ pub fn list(
     path: &str,
     params: ListQueryParams,
 ) -> Result<Response<Body>> {
-    err_if_user_is_invalid(public_key, &state.db)?;
-
     let txn = state.db.env.read_txn()?;
     let path = format!("{public_key}{path}");
 

--- a/pubky-homeserver/src/core/routes/tenants/session.rs
+++ b/pubky-homeserver/src/core/routes/tenants/session.rs
@@ -14,7 +14,7 @@ pub async fn session(
     cookies: Cookies,
     pubky: PubkyHost,
 ) -> Result<impl IntoResponse> {
-    err_if_user_is_invalid(pubky.public_key(), &state.db)?;
+    err_if_user_is_invalid(pubky.public_key(), &state.db, false)?;
     if let Some(secret) = session_secret_from_cookies(&cookies, pubky.public_key()) {
         if let Some(session) = state.db.get_session(&secret)? {
             // TODO: add content-type

--- a/pubky-homeserver/src/core/routes/tenants/write.rs
+++ b/pubky-homeserver/src/core/routes/tenants/write.rs
@@ -45,7 +45,7 @@ pub async fn delete(
     pubky: PubkyHost,
     path: OriginalUri,
 ) -> Result<impl IntoResponse> {
-    err_if_user_is_invalid(pubky.public_key(), &state.db)?;
+    err_if_user_is_invalid(pubky.public_key(), &state.db, false)?;
     let public_key = pubky.public_key();
     let full_path = path.0.path();
     let existing_bytes = state.db.get_entry_content_length(public_key, full_path)?;
@@ -69,7 +69,7 @@ pub async fn put(
     path: OriginalUri,
     body: Body,
 ) -> Result<impl IntoResponse> {
-    err_if_user_is_invalid(pubky.public_key(), &state.db)?;
+    err_if_user_is_invalid(pubky.public_key(), &state.db, true)?;
     let public_key = pubky.public_key();
     let full_path = path.0.path();
     let existing_entry_bytes = state.db.get_entry_content_length(public_key, full_path)?;


### PR DESCRIPTION
This changes the homeservers behaviour when a user is disabled.

- A disabled user can still login, create sessions, read, and delete all their files.
- A disabled user can NOT write files anymore.

FYI @dzdidi 