### PR TITLE
chore (repo): Version Unification

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,33 @@
+# Contributors
+
+## Create a Feature
+
+1. (Optional) Describe the problem that the PR is solving in an issue first.
+2. Fork the repo and create your feature branch. 
+    -  Avoid having multiple features in one branch. See [Separation of Concerns](https://nalexn.github.io/separation-of-concerns/).
+    -  Do not create feature branches in the main repository.
+3. Code your feature.
+    - Commits do NOT need to follow any convention.
+4. Create a PR when finished. Use [Conventional Commits format](https://www.conventionalcommits.org/) as the PR title.
+    - PR title format: `type (module): Summary of the changes`. Possible types are:
+        - `BREAKING CHANGE` For changes that break the API.
+        - `feat` For new features.
+        - `fix` For bug fixes
+        - `chore` For everything that is not covered in the above types.
+        - The module is the workspace member name, for example `homeserver`, `client`, or `testnet`.
+    - Use the [Draft feature](https://github.blog/2019-02-14-introducing-draft-pull-requests/) in case you need an early review.
+    - Assign a reviewer. Every PR needs to be reviewed at least once. More reviews are possible on request.
+5. Always squash the PR when merging. One commit == one feature/fix.
+
+## Versioning
+
+1. Merge all PRs in the main branch that you want to include in the next version.
+2. Update versions in client and service by running `npm run version -- <x.x.x|major|minor|patch>` from the repository root.
+3. Update `CHANGELOG.md` with the given format. Use the commit history on the master to determine the changes.
+4. Create a PR with the title: `chore: vx.x.x`.
+5. Let the PR review and squash + merge.
+6. Publish the client library with `cd client && npm publish`.
+7. Create a [new Github release](https://github.com/synonymdev/blocktank-lsp-ln2/releases/new).
+    - Tag: `vx.x.x`
+    - Title: `vx.x.x`
+    - Description: Changelog for the current version.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,12 +22,18 @@
 ## Versioning
 
 1. Merge all PRs in the main branch that you want to include in the next version.
-2. Update versions in client and service by running `npm run version -- <x.x.x|major|minor|patch>` from the repository root.
-3. Update `CHANGELOG.md` with the given format. Use the commit history on the master to determine the changes.
+2. Update versions in the workspace [Config.toml](./Cargo.toml). Use [SemVer](https://semver.org/).
+    - Update the member dependencies too. 
 4. Create a PR with the title: `chore: vx.x.x`.
 5. Let the PR review and squash + merge.
-6. Publish the client library with `cd client && npm publish`.
-7. Create a [new Github release](https://github.com/synonymdev/blocktank-lsp-ln2/releases/new).
+6. Publish each **changed** member with cargo publish
+    - `cargo publish -p http-relay`
+    - `cargo publish -p pkarr-republisher`
+    - `cargo publish -p pubky-common`
+    - `cargo publish -p pubky-homeserver`
+    - `cargo publish -p pubky`
+    - `cargo publish -p pubky-testnet`
+7. Create a [new Github release](https://github.com/pubky/pubky-core/releases/new).
     - Tag: `vx.x.x`
     - Title: `vx.x.x`
     - Description: Changelog for the current version.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1404,7 +1404,7 @@ dependencies = [
 
 [[package]]
 name = "http-relay"
-version = "0.3.0-rc.0"
+version = "0.5.0-rc.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2224,7 +2224,7 @@ dependencies = [
 
 [[package]]
 name = "pkarr-republisher"
-version = "0.2.0-rc.0"
+version = "0.5.0-rc.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2327,7 +2327,7 @@ checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "pubky"
-version = "0.4.3-rc.0"
+version = "0.5.0-rc.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2361,7 +2361,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-common"
-version = "0.4.0-rc.0"
+version = "0.5.0-rc.0"
 dependencies = [
  "argon2",
  "base32",
@@ -2380,7 +2380,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-homeserver"
-version = "0.2.0-rc.0"
+version = "0.5.0-rc.0"
 dependencies = [
  "anyhow",
  "axum",
@@ -2423,7 +2423,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-testnet"
-version = "0.2.0-rc.1"
+version = "0.5.0-rc.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2347,7 +2347,6 @@ dependencies = [
  "mainline",
  "pkarr",
  "pubky-common",
- "pubky-testnet",
  "reqwest",
  "thiserror 2.0.12",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ resolver = "2"
 version = "0.5.0-rc.0"
 edition = "2021"
 authors = [
-    "Severin Bühler <severin@synonym.to>",
+    "SeverinAlexB <severin@synonym.to>",
     "SHAcollision <shacollision@synonym.to>",
     "Nuh <nuh@nuh.dev>"
 ]
@@ -32,10 +32,10 @@ pkarr = { version = "3.7.1" }
 mainline = { version = "5.4.0" }
 pkarr-relay = { version = "0.9.1" }
 
-# Workspace Members
-pubky-common = { path = "pubky-common" }
-http-relay = { path = "http-relay" }
-pubky = { path = "pubky-client" }
-pubky-homeserver = { path = "pubky-homeserver" }
-pubky-testnet = {path = "pubky-testnet"}
-pkarr-republisher = { path = "pkarr-republisher"}
+# Workspace Members Dependencies
+pubky-common = { version = "0.5.0-rc.0", path = "pubky-common" }
+http-relay = { version = "0.5.0-rc.0", path = "http-relay" }
+pubky = { version = "0.5.0-rc.0", path = "pubky-client" }
+pubky-homeserver = { version = "0.5.0-rc.0", path = "pubky-homeserver" }
+pubky-testnet = { version = "0.5.0-rc.0", path = "pubky-testnet"}
+pkarr-republisher = { version = "0.5.0-rc.0", path = "pkarr-republisher"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,20 @@ members = [
   "e2e",
 ]
 
-# See: https://github.com/rust-lang/rust/issues/90148#issuecomment-949194352
 resolver = "2"
+
+[workspace.package]
+version = "0.5.0-rc.0"
+edition = "2021"
+authors = [
+    "Severin Bühler <severin@synonym.to>",
+    "SHAcollision <shacollision@synonym.to>",
+    "Nuh <nuh@nuh.dev>"
+]
+license = "MIT"
+homepage = "https://github.com/pubky/pubky-core"
+repository = "https://github.com/pubky/pubky-core"
+
 
 [profile.release]
 lto = true
@@ -19,3 +31,11 @@ opt-level = 'z'
 pkarr = { version = "3.7.1" }
 mainline = { version = "5.4.0" }
 pkarr-relay = { version = "0.9.1" }
+
+# Workspace Members
+pubky-common = { path = "pubky-common" }
+http-relay = { path = "http-relay" }
+pubky = { path = "pubky-client" }
+pubky-homeserver = { path = "pubky-homeserver" }
+pubky-testnet = {path = "pubky-testnet"}
+pkarr-republisher = { path = "pkarr-republisher"}

--- a/README.md
+++ b/README.md
@@ -59,3 +59,8 @@ Then in a different terminal window:
 ```bash
 npm test
 ```
+
+
+## Links
+
+- [Contributors Guide](./CONTRIBUTORS.md)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 	An open protocol for per-public-key backends for censorship resistant web applications.
 </h3>
 
+
+
+
 <div align="center">
   <h3>
     <a href="https://pubky.github.io/pubky-core/">
@@ -14,15 +17,17 @@
       Rust Client's Docs
     </a>
     <span> | </span>
-    <a href="https://github.com/pubky/pubky-core/releases">
-      Releases
-    </a>
     <span> | </span>
     <a href="https://www.npmjs.com/package/@synonymdev/pubky">
       JS bindings 
     </a>
   </h3>
 </div>
+
+[![GitHub Release](https://img.shields.io/github/v/release/pubky/pkdns)](https://github.com/pubky/pubky-core/releases/latest/)
+![Crates.io Version](https://img.shields.io/crates/v/pubky)
+[![Telegram Chat Group](https://img.shields.io/badge/Chat-Telegram-violet)](https://t.me/pubkycore)
+![GitHub License](https://img.shields.io/github/license/pubky/pubky-core)
 
 > The Web, long centralized, must decentralize; Long decentralized, must centralize.
 

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "e2e"
+edition.workspace = true
 version = "0.1.0"
-edition = "2021"
+publish = false
 
 [dependencies]
-pubky-testnet = { path = "../pubky-testnet" }
-pubky-common = { path = "../pubky-common" }
+pubky-testnet = { workspace = true }
+pubky-common = { workspace = true }
 tokio = { version = "1.43.0", features = ["full", "test-util"] }
 tracing-subscriber = "0.3.19"
 pkarr = {workspace = true}

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "authn"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+publish = false
 
 [[bin]]
 name = "signup"
@@ -19,8 +20,8 @@ path = "./request/main.rs"
 anyhow = "1.0.95"
 base64 = "0.22.1"
 clap = { version = "4.5.29", features = ["derive"] }
-pubky = { path = "../pubky-client" }
-pubky-common = { path = "../pubky-common" }
+pubky = { workspace = true }
+pubky-common = { workspace = true }
 reqwest = "0.12.12"
 rpassword = "7.3.1"
 tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }

--- a/http-relay/Cargo.toml
+++ b/http-relay/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "http-relay"
-version = "0.3.0-rc.0"
-edition = "2021"
-authors = ["Nuh <nuh@nuh.dev>"]
 description = "A Rust implementation of _some_ of [Http relay spec](https://httprelay.io/)."
-license = "MIT"
-homepage = "https://github.com/pubky/pubky-core"
-repository = "https://github.com/pubky/pubky-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 keywords = ["httprelay", "http", "relay"]
 categories = ["web-programming"]
 

--- a/pkarr-republisher/Cargo.toml
+++ b/pkarr-republisher/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "pkarr-republisher"
-version = "0.2.0-rc.0"
-edition = "2021"
-authors = ["Severin Alex Bühler <severin@synonym.to>"]
 description = "A pkarr packet republisher."
-license = "MIT"
-homepage = "https://github.com/pubky/pubky-core"
-repository = "https://github.com/pubky/pubky-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 keywords = ["pkarr", "mainline", "pubky"]
 categories = ["web-programming"]
 

--- a/pubky-client/Cargo.toml
+++ b/pubky-client/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
 name = "pubky"
-version = "0.4.3-rc.0"
-edition = "2021"
-description = "Pubky core client"
-license = "MIT"
-repository = "https://github.com/pubky/pubky"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 keywords = ["web", "dht", "dns", "decentralized", "identity"]
 categories = [
     "network-programming",
@@ -17,7 +18,7 @@ categories = [
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pubky-common = { version = "0.4.0-rc.0", path = "../pubky-common" }
+pubky-common = { workspace = true }
 thiserror = "2.0.11"
 wasm-bindgen = "0.2.100"
 url = "2.5.4"
@@ -57,7 +58,7 @@ web-sys = "0.3.77"
 [dev-dependencies]
 anyhow = "1.0.95"
 futures-lite = "2.6.0"
-pubky-testnet = { path = "../pubky-testnet" }
+pubky-testnet = { workspace = true }
 tokio = "1.43.0"
 tracing-subscriber = "0.3.19"
 mainline = { workspace = true }

--- a/pubky-client/Cargo.toml
+++ b/pubky-client/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "pubky"
+description = "Pubky-Core Client"
 version.workspace = true
 edition.workspace = true
 authors.workspace = true
@@ -58,7 +59,6 @@ web-sys = "0.3.77"
 [dev-dependencies]
 anyhow = "1.0.95"
 futures-lite = "2.6.0"
-pubky-testnet = { workspace = true }
 tokio = "1.43.0"
 tracing-subscriber = "0.3.19"
 mainline = { workspace = true }

--- a/pubky-client/src/lib.rs
+++ b/pubky-client/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = include_str!("../README.md")]
+//! #![doc = include_str!("../README.md")]
 //!
 
 // TODO: deny missing docs.

--- a/pubky-common/Cargo.toml
+++ b/pubky-common/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "pubky-common"
-version = "0.4.0-rc.0"
-edition = "2021"
-authors = ["Nuh <nuh@nuh.dev>"]
 description = "Types and struct in common between Pubky client and homeserver"
-license = "MIT"
-homepage = "https://github.com/pubky/pubky-core"
-repository = "https://github.com/pubky/pubky-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 keywords = ["pkarr", "pubky", "auth", "pubkey"]
 categories = ["web-programming", "authentication", "cryptography"]
 

--- a/pubky-homeserver/Cargo.toml
+++ b/pubky-homeserver/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "pubky-homeserver"
-version = "0.2.0-rc.0"
-edition = "2021"
-authors = ["Nuh <nuh@nuh.dev>"]
 description = "Pubky core's homeserver."
-license = "MIT"
-homepage = "https://github.com/pubky/pubky-core"
-repository = "https://github.com/pubky/pubky-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 keywords = ["pkarr", "sovereign", "web", "pkarr", "datastore"]
 categories = [
     "network-programming",
@@ -32,7 +32,7 @@ hex = "0.4.3"
 httpdate = "1.0.3"
 postcard = { version = "1.1.1", features = ["alloc"] }
 pkarr = { workspace = true, features = ["dht", "lmdb-cache", "tls"] }
-pubky-common = { version = "0.4.0-rc.0", path = "../pubky-common" }
+pubky-common = { workspace = true }
 serde = { version = "1.0.217", features = ["derive"] }
 tokio = { version = "1.43.0", features = ["full"] }
 toml = "0.8.20"
@@ -45,7 +45,7 @@ url = { version = "2.5.4", features = ["serde"] }
 axum-server = { version = "0.7.1", features = ["tls-rustls-no-provider"] }
 tower = "0.5.2"
 page_size = "0.6.0"
-pkarr-republisher = { version = "0.2.0-rc.0", path = "../pkarr-republisher" }
+pkarr-republisher = { workspace = true }
 thiserror = "2.0.12"
 dirs = "6.0.0"
 hostname-validator = "1.1.1"

--- a/pubky-testnet/Cargo.toml
+++ b/pubky-testnet/Cargo.toml
@@ -1,12 +1,14 @@
 [package]
 name = "pubky-testnet"
-version = "0.2.0-rc.1"
-edition = "2021"
-authors = ["Nuh <nuh@nuh.dev>"]
 description = "A local test network for Pubky Core development."
-license = "MIT"
-homepage = "https://github.com/pubky/pubky-core"
-repository = "https://github.com/pubky/pubky-core"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+
 keywords = ["pkarr", "pubky", "testnet", "testing"]
 categories = ["web-programming", "authentication", "cryptography"]
 
@@ -17,10 +19,10 @@ tokio = { version = "1.43.0", features = ["full"] }
 tracing-subscriber = "0.3.19"
 url = "2.5.4"
 
-pubky = { version = "0.4.3-rc.0", path = "../pubky-client" }
-pubky-common = { version = "0.4.0-rc.0", path = "../pubky-common" }
-pubky-homeserver = { version = "0.2.0-rc.0", path = "../pubky-homeserver" }
-http-relay = { version = "0.3.0-rc.0", path = "../http-relay" }
+pubky = { workspace = true }
+pubky-common = { workspace = true }
+pubky-homeserver = { workspace = true }
+http-relay = { workspace = true }
 tempfile = "3.19.1"
 tracing = "0.1.41"
 pkarr = { workspace = true }


### PR DESCRIPTION
- Unifies the versioning of all workspace members to the top level Cargo.toml.
- New version `0.5.0-rc.0`.
- Added contributors guide similar to [Blocktank](https://github.com/synonymdev/blocktank-lsp-ln2/blob/master/CONTRIBUTORS.md).

I already published the new `0.5.0-rc.0` version on crates to test the workflow. I will create the Github release with the release notes after this PR is merged.

@SHAcollision Please check the guide as this will be new for pubky.