### PR TITLE
feat(homeserver): logging options

### DIFF
--- a/pubky-homeserver/config.sample.toml
+++ b/pubky-homeserver/config.sample.toml
@@ -107,3 +107,7 @@ dht_relay_nodes = ["https://pkarr.pubky.app", "https://pkarr.pubky.org"]
 
 # Default UDP request timeout for the DHT
 dht_request_timeout_ms = 2000
+
+[logging]
+level = "info"
+filters = ["pubky_homeserver=debug", "tower_http=debug"]

--- a/pubky-homeserver/src/data_directory/config_toml.rs
+++ b/pubky-homeserver/src/data_directory/config_toml.rs
@@ -70,6 +70,12 @@ pub struct GeneralToml {
     pub user_storage_quota_mb: u64,
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct LoggingToml {
+    pub level: Option<String>,
+    pub filters: Option<Vec<String>>,
+}
+
 /// The overall application configuration, composed of several subsections.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct ConfigToml {
@@ -81,6 +87,8 @@ pub struct ConfigToml {
     pub admin: AdminToml,
     /// Peer‐to‐peer DHT / PKDNS settings (public endpoints, bootstrap, relays).
     pub pkdns: PkdnsToml,
+    /// Logging configuration. Environment variables override config settings
+    pub logging: LoggingToml,
 }
 
 impl Default for ConfigToml {
@@ -104,6 +112,18 @@ impl Default for AdminToml {
 impl Default for PkdnsToml {
     fn default() -> Self {
         ConfigToml::default().pkdns
+    }
+}
+
+impl Default for LoggingToml {
+    fn default() -> Self {
+        Self {
+            level: Some("info".to_string()),
+            filters: Some(vec![
+                "pubky_homeserver=debug".to_string(),
+                "tower_http=debug".to_string(),
+            ]),
+        }
     }
 }
 

--- a/pubky-homeserver/src/main.rs
+++ b/pubky-homeserver/src/main.rs
@@ -3,7 +3,6 @@ use std::path::PathBuf;
 use anyhow::Result;
 use clap::Parser;
 use pubky_homeserver::HomeserverSuite;
-use tracing_subscriber::EnvFilter;
 
 fn default_config_dir_path() -> PathBuf {
     dirs::home_dir().unwrap_or_default().join(".pubky")
@@ -30,14 +29,6 @@ struct Cli {
 async fn main() -> Result<()> {
     let args = Cli::parse();
 
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| EnvFilter::new("pubky_homeserver=debug,tower_http=debug")),
-        )
-        .init();
-
-    tracing::debug!("Using data dir: {}", args.data_dir.display());
     let server = HomeserverSuite::start_with_persistent_data_dir_path(args.data_dir).await?;
 
     tracing::info!(


### PR DESCRIPTION
As @SHAcollision suggested now log level options could be provided via configuration file along with common option for example.

```bash
RUST_LOG="pubky_homeserver=info,tower_http=info" cargo run
```

Environment option has superiority over config options. 
Writing into log file could be added, too. For this reason initialization was moved into HomeserverSuite::start, after reading config file.