### PR TITLE
chore: bump pkarr to 3.7.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2158,9 +2158,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkarr"
-version = "3.7.1"
+version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e32222ae3d617bf92414db29085f8a959a4515effce916e038e9399a335a0d6d"
+checksum = "3f552a2c2f80b6f3415e1722032ea92f24cc3f83f71b5b9de5600121c4a49fdd"
 dependencies = [
  "async-compat",
  "base32",
@@ -2196,9 +2196,9 @@ dependencies = [
 
 [[package]]
 name = "pkarr-relay"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63aa8f8cd1693c358a0e9baf5221d56d15123ad8d385631c7277c7560a843fd2"
+checksum = "c90db47e95f4f07fab0ff0967238c9f7bdb9cb197713a9c2f760ab6b99846952"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,5 @@
 [workspace]
-members = [
-  "pubky-*", 
-  "http-relay",
-  "pkarr-republisher",
-  "examples", 
-  "e2e",
-]
+members = ["pubky-*", "http-relay", "pkarr-republisher", "examples", "e2e"]
 
 resolver = "2"
 
@@ -13,9 +7,9 @@ resolver = "2"
 version = "0.5.0-rc.0"
 edition = "2021"
 authors = [
-    "SeverinAlexB <severin@synonym.to>",
-    "SHAcollision <shacollision@synonym.to>",
-    "Nuh <nuh@nuh.dev>"
+  "SeverinAlexB <severin@synonym.to>",
+  "SHAcollision <shacollision@synonym.to>",
+  "Nuh <nuh@nuh.dev>",
 ]
 license = "MIT"
 homepage = "https://github.com/pubky/pubky-core"
@@ -28,14 +22,14 @@ opt-level = 'z'
 
 
 [workspace.dependencies]
-pkarr = { version = "3.7.1" }
+pkarr = { version = "3.7.2" }
 mainline = { version = "5.4.0" }
-pkarr-relay = { version = "0.9.1" }
+pkarr-relay = { version = "0.9.2" }
 
 # Workspace Members Dependencies
 pubky-common = { version = "0.5.0-rc.0", path = "pubky-common" }
 http-relay = { version = "0.5.0-rc.0", path = "http-relay" }
 pubky = { version = "0.5.0-rc.0", path = "pubky-client" }
 pubky-homeserver = { version = "0.5.0-rc.0", path = "pubky-homeserver" }
-pubky-testnet = { version = "0.5.0-rc.0", path = "pubky-testnet"}
-pkarr-republisher = { version = "0.5.0-rc.0", path = "pkarr-republisher"}
+pubky-testnet = { version = "0.5.0-rc.0", path = "pubky-testnet" }
+pkarr-republisher = { version = "0.5.0-rc.0", path = "pkarr-republisher" }


### PR DESCRIPTION
Bumping pkarr to 3.7.2 fixes the early termination of Dht publish/resolve when all relays return early. 