### PR TITLE
Mime types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,6 +461,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "cfb"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38f2da7a0a2c4ccf0065be06397cc26a81f4e528be095826eee9d4adbb8c60f"
+dependencies = [
+ "byteorder",
+ "fnv",
+ "uuid",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,6 +1682,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "infer"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
+dependencies = [
+ "cfb",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2467,6 +2487,7 @@ dependencies = [
  "hex",
  "hostname-validator",
  "httpdate",
+ "infer",
  "page_size",
  "percent-encoding",
  "pkarr",
@@ -3857,6 +3878,16 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "valuable"

--- a/pubky-homeserver/Cargo.toml
+++ b/pubky-homeserver/Cargo.toml
@@ -58,6 +58,7 @@ fast-glob = "0.4.5"
 tokio-util = "0.7.15"
 percent-encoding = "2.3.1"
 serde_valid = "1.0.5"
+infer = "0.19.0"
 
 
 [dev-dependencies]

--- a/pubky-homeserver/src/persistence/lmdb/tables/files/blobs.rs
+++ b/pubky-homeserver/src/persistence/lmdb/tables/files/blobs.rs
@@ -61,6 +61,17 @@ impl LmDB {
         let id = InDbFileId::new();
         let mut file_handle = file.open_file_handle()?;
 
+        let mut buffer = [0u8; 512];
+        let n = file_handle.read(&mut buffer)?;
+
+        // Run type inference on the buffer slice
+        if let Some(kind) = infer::get(&buffer[..n]) {
+            println!("Detected type: {}", kind.mime_type());
+            println!("Extension: {}", kind.extension());
+        } else {
+            println!("Could not determine file type.");
+        }
+
         let mut blob_index: u32 = 0;
         loop {
             let mut blob = vec![0_u8; self.max_chunk_size];

--- a/pubky-homeserver/src/persistence/lmdb/tables/files/entries.rs
+++ b/pubky-homeserver/src/persistence/lmdb/tables/files/entries.rs
@@ -58,6 +58,7 @@ impl LmDB {
         entry.set_content_hash(*file.hash());
         entry.set_content_length(file.len());
         let file_id = self.write_file_sync(file, &mut wtxn)?;
+        entry.set_content_type("HERE".to_string());
         entry.set_timestamp(file_id.timestamp());
         let entry_key = path.to_string();
         self.tables
@@ -344,6 +345,11 @@ impl Entry {
 
     pub fn set_content_length(&mut self, content_length: usize) -> &mut Self {
         self.content_length = content_length;
+        self
+    }
+
+    pub fn set_content_type(&mut self, ct: String) -> &mut Self {
+        self.content_type = ct;
         self
     }
 

--- a/pubky-homeserver/src/persistence/lmdb/tables/files/entries.rs
+++ b/pubky-homeserver/src/persistence/lmdb/tables/files/entries.rs
@@ -57,8 +57,8 @@ impl LmDB {
         let mut entry = Entry::new();
         entry.set_content_hash(*file.hash());
         entry.set_content_length(file.len());
-        let file_id = self.write_file_sync(file, &mut wtxn)?;
-        entry.set_content_type("HERE".to_string());
+        let ( file_id, file_type) = self.write_file_sync(file, &mut wtxn)?;
+        entry.set_content_type(file_type);
         entry.set_timestamp(file_id.timestamp());
         let entry_key = path.to_string();
         self.tables

--- a/pubky-homeserver/src/persistence/lmdb/tables/files/in_db_file.rs
+++ b/pubky-homeserver/src/persistence/lmdb/tables/files/in_db_file.rs
@@ -99,6 +99,14 @@ impl AsyncInDbTempFileWriter {
         file.complete().await
     }
 
+    #[cfg(test)]
+    pub async fn png_pixel() -> Result<InDbTempFile, std::io::Error> {
+        let mut file = Self::new().await?;
+        let png_magic_bytes: [u8; 8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        file.write_chunk(&png_magic_bytes).await?;
+        file.complete().await
+    }
+
     /// Write a chunk to the file.
     /// Chunk writing is done by the axum body stream and by LMDB itself.
     pub async fn write_chunk(&mut self, chunk: &[u8]) -> Result<(), std::io::Error> {
@@ -197,6 +205,11 @@ impl InDbTempFile {
     #[cfg(test)]
     pub async fn zeros(size_bytes: usize) -> Result<Self, std::io::Error> {
         AsyncInDbTempFileWriter::zeros(size_bytes).await
+    }
+
+    #[cfg(test)]
+    pub async fn png_pixel() -> Result<Self, std::io::Error> {
+        AsyncInDbTempFileWriter::png_pixel().await
     }
 
     /// Create a new InDbTempFile with zero content.


### PR DESCRIPTION
The main idea is to put content type identification into `write_file_sync` function where file content being read before re-writing it to the database.

Write_file_sync now returns a MIME type `anyhow::Result<(InDbFileId, String)>` as String. Very likely @SeverinAlexB wants a wrapper type, please confirm. Otherwise type checking is outsourced to `infer` library.

Initially I've tried to identify txt files but figured out that `infer` cant determine text type (and some other types). I don't know if it has to be addressed immidiately. Please let me know @SHAcollision. It may happen, additional types will require to bring in new internalized inference logic. 