### PR TITLE
fix(homeserver): Allow early tracing init to catch early errors

### DIFF
--- a/pubky-homeserver/src/lib.rs
+++ b/pubky-homeserver/src/lib.rs
@@ -19,6 +19,7 @@ mod data_directory;
 mod homeserver_suite;
 mod persistence;
 mod shared;
+pub mod tracing;
 
 pub use admin::{AdminServer, AdminServerBuildError};
 pub use app_context::{AppContext, AppContextConversionError};

--- a/pubky-homeserver/src/main.rs
+++ b/pubky-homeserver/src/main.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::Parser;
-use pubky_homeserver::HomeserverSuite;
+use pubky_homeserver::{tracing::init_tracing_logs_if_set, HomeserverSuite};
 
 fn default_config_dir_path() -> PathBuf {
     dirs::home_dir().unwrap_or_default().join(".pubky")
@@ -29,7 +29,9 @@ struct Cli {
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Cli::parse();
+    init_tracing_logs_if_set(&args.data_dir)?;
 
+    tracing::info!("Use data directory: {}", args.data_dir.display());
     let server = HomeserverSuite::start_with_persistent_data_dir_path(args.data_dir).await?;
 
     tracing::info!(

--- a/pubky-homeserver/src/tracing.rs
+++ b/pubky-homeserver/src/tracing.rs
@@ -1,0 +1,58 @@
+//!
+//! Module to initialize tracing logs.
+//!
+//! This module is used to initialize tracing logs based on the values defined in the config file.
+//! If the config file is not found, it will use default values.
+//!
+//! This method is used to initialize tracing before the homeserver is started.
+//! This way, we don't miss any logs, for example config file loading errors.
+//!
+
+use crate::{ConfigToml, PersistentDataDir};
+use std::path::Path;
+use tracing_subscriber::EnvFilter;
+
+fn read_config_from_file(data_dir: &Path) -> anyhow::Result<ConfigToml> {
+    let data_dir = PersistentDataDir::new(data_dir.to_path_buf());
+    let config_file_path = data_dir.get_config_file_path();
+    let config = ConfigToml::from_file(config_file_path)?;
+    Ok(config)
+}
+
+/// Initialize tracing logger based on the values defined in the config file.
+pub fn init_tracing_logs_with_config_if_set(config: &ConfigToml) -> anyhow::Result<()> {
+    let config = match &config.logging {
+        Some(config) => config,
+        None => return Ok(()),
+    };
+
+    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        let mut filter = EnvFilter::new("");
+        filter = filter.add_directive(config.level.to_owned().into());
+        // Add any specific filters
+        for filter_str in &config.module_levels {
+            filter = filter.add_directive(filter_str.to_owned().into());
+        }
+        filter
+    });
+    tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .try_init()
+        .map_err(|e| anyhow::anyhow!("Failed to initialize tracing: {}", e))?;
+
+    Ok(())
+}
+
+/// Initialize tracing logger based on the values defined in the config file.
+/// If the config file is not found, use default values.
+pub fn init_tracing_logs_if_set(data_dir: &Path) -> anyhow::Result<()> {
+    let config = match read_config_from_file(data_dir) {
+        Ok(config) => config,
+        Err(e) => {
+            println!("Failed to read config from file: {}", e);
+            ConfigToml::default()
+        }
+    };
+
+    init_tracing_logs_with_config_if_set(&config)
+}


### PR DESCRIPTION
This PR allows the `main` method to init tracing early. With #138, any logs before the homeserver suite start were hidden. This included the config parsing.

This PR fixes this and exposes a new `init_tracing_logs_if_set` method so anybody can initialize the logs early.