### PR TITLE
fix(hs): Return 401 instead of a 500 when the signup token is invalid

### DIFF
--- a/e2e/src/tests/auth.rs
+++ b/e2e/src/tests/auth.rs
@@ -334,6 +334,11 @@ async fn test_signup_with_token() {
         invalid_signup.is_err(),
         "Signup should fail with an invalid signup token"
     );
+    let err = invalid_signup.unwrap_err();
+    assert!(
+        err.to_string().to_lowercase().contains("401"),
+        "Signup should fail with a 401 status code"
+    );
 
     // 3. Call the admin endpoint to generate a valid signup token.
     let valid_token = server.admin().create_signup_token().await.unwrap();

--- a/pubky-homeserver/src/core/routes/auth.rs
+++ b/pubky-homeserver/src/core/routes/auth.rs
@@ -49,14 +49,22 @@ pub async fn signup(
 
     // 3) If signup_mode == token_required, require & validate a `signup_token` param.
     if state.signup_mode == SignupMode::TokenRequired {
-        let signup_token_param = params.get("signup_token").ok_or(HttpError::new_with_message(StatusCode::BAD_REQUEST, "signup token required"))?;
+        let signup_token_param = params
+            .get("signup_token")
+            .ok_or(HttpError::new_with_message(
+                StatusCode::BAD_REQUEST,
+                "signup token required",
+            ))?;
         // Validate it in the DB (marks it used)
         if let Err(e) = state
             .db
             .validate_and_consume_signup_token(signup_token_param, public_key)
         {
             tracing::warn!("Failed to signup. Invalid signup token: {:?}", e);
-            return Err(HttpError::new_with_message(StatusCode::UNAUTHORIZED, "invalid signup token"));
+            return Err(HttpError::new_with_message(
+                StatusCode::UNAUTHORIZED,
+                "invalid signup token",
+            ));
         }
     }
 

--- a/pubky-homeserver/src/core/routes/auth.rs
+++ b/pubky-homeserver/src/core/routes/auth.rs
@@ -49,13 +49,15 @@ pub async fn signup(
 
     // 3) If signup_mode == token_required, require & validate a `signup_token` param.
     if state.signup_mode == SignupMode::TokenRequired {
-        let signup_token_param = params.get("signup_token").ok_or_else(|| {
-            HttpError::new_with_message(StatusCode::BAD_REQUEST, "signup_token required")
-        })?;
+        let signup_token_param = params.get("signup_token").ok_or(HttpError::new_with_message(StatusCode::BAD_REQUEST, "signup token required"))?;
         // Validate it in the DB (marks it used)
-        state
+        if let Err(e) = state
             .db
-            .validate_and_consume_signup_token(signup_token_param, public_key)?;
+            .validate_and_consume_signup_token(signup_token_param, public_key)
+        {
+            tracing::warn!("Failed to signup. Invalid signup token: {:?}", e);
+            return Err(HttpError::new_with_message(StatusCode::UNAUTHORIZED, "invalid signup token"));
+        }
     }
 
     // 4) Create the new user record


### PR DESCRIPTION
The homeserver returns a HTTP `500` Internal Server Error when the signup token is invalid but required.

This PR turns it into a `401` Unauthorized + improved test.

FYI @catch-21 