### PR TITLE
chore(hs): Improved session auth failed reasons and logs

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.87
           components: rustfmt
           override: true
       - name: Check formatting
@@ -28,7 +28,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.87
           components: clippy
           override: true
       - name: Cache
@@ -48,7 +48,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.87
           override: true
       - name: Install Nextest
         uses: taiki-e/install-action@nextest
@@ -87,7 +87,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: 1.87
           target: wasm32-unknown-unknown
           override: true
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
       - name: Lint with Clippy
-        run: cargo clippy --workspace --all-features -- -D warnings -A clippy::needless_lifetimes -A clippy::redundant_format_args
+        run: cargo clippy --workspace --all-features -- -D warnings -A clippy::needless_lifetimes
 
   test:
     strategy:

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
       - name: Lint with Clippy
-        run: cargo clippy --workspace --all-features -- -D warnings -A clippy::needless_lifetimes
+        run: cargo clippy --workspace --all-features -- -D warnings -A clippy::needless_lifetimes -A clippy::redundant_format_args
 
   test:
     strategy:

--- a/pubky-common/src/capabilities.rs
+++ b/pubky-common/src/capabilities.rs
@@ -197,7 +197,7 @@ impl Display for Capabilities {
             .collect::<Vec<_>>()
             .join(",");
 
-        write!(f, "{}", string)
+        write!(f, "{string}")
     }
 }
 

--- a/pubky-homeserver/src/core/layers/authz.rs
+++ b/pubky-homeserver/src/core/layers/authz.rs
@@ -125,34 +125,47 @@ fn authorize(
     let session_secret = match session_secret_from_cookies(cookies, public_key) {
         Some(session_secret) => session_secret,
         None => {
-            tracing::warn!("No session secret found in cookies for pubky-host: {}", public_key);
-            return Err(HttpError::unauthorized_with_message("No session secret found in cookies"));
+            tracing::warn!(
+                "No session secret found in cookies for pubky-host: {}",
+                public_key
+            );
+            return Err(HttpError::unauthorized_with_message(
+                "No session secret found in cookies",
+            ));
         }
     };
 
-    let session = match state
-        .db
-        .get_session(&session_secret)? {
-            Some(session) => session,
-            None => {
-                tracing::warn!("No session found in the database for session secret: {}, pubky: {}", session_secret, public_key);
-                return Err(HttpError::unauthorized_with_message("No session found for session secret"));
-            }
-        };
-
+    let session = match state.db.get_session(&session_secret)? {
+        Some(session) => session,
+        None => {
+            tracing::warn!(
+                "No session found in the database for session secret: {}, pubky: {}",
+                session_secret,
+                public_key
+            );
+            return Err(HttpError::unauthorized_with_message(
+                "No session found for session secret",
+            ));
+        }
+    };
 
     if session.pubky() != public_key {
-        tracing::warn!("Session public key does not match pubky-host: {} != {}", session.pubky(), public_key);
-        return Err(HttpError::unauthorized_with_message("Session public key does not match pubky-host"));
+        tracing::warn!(
+            "Session public key does not match pubky-host: {} != {}",
+            session.pubky(),
+            public_key
+        );
+        return Err(HttpError::unauthorized_with_message(
+            "Session public key does not match pubky-host",
+        ));
     }
 
     if session.capabilities().iter().any(|cap| {
-            path.starts_with(&cap.scope)
-                && cap
-                    .actions
-                    .contains(&pubky_common::capabilities::Action::Write)
-        })
-    {
+        path.starts_with(&cap.scope)
+            && cap
+                .actions
+                .contains(&pubky_common::capabilities::Action::Write)
+    }) {
         Ok(())
     } else {
         tracing::warn!(
@@ -161,7 +174,9 @@ fn authorize(
             public_key,
             path
         );
-        Err(HttpError::forbidden_with_message("Session does not have write access to path"))
+        Err(HttpError::forbidden_with_message(
+            "Session does not have write access to path",
+        ))
     }
 }
 

--- a/pubky-homeserver/src/core/layers/authz.rs
+++ b/pubky-homeserver/src/core/layers/authz.rs
@@ -68,6 +68,7 @@ where
             let pubky = match req.extensions().get::<PubkyHost>() {
                 Some(pk) => pk,
                 None => {
+                    tracing::warn!("Pubky Host is missing in request. Authorization failed.");
                     return Ok(HttpError::new_with_message(
                         StatusCode::NOT_FOUND,
                         "Pubky Host is missing",
@@ -121,16 +122,31 @@ fn authorize(
         ));
     }
 
-    let session_secret =
-        session_secret_from_cookies(cookies, public_key).ok_or(HttpError::unauthorized())?;
+    let session_secret = match session_secret_from_cookies(cookies, public_key) {
+        Some(session_secret) => session_secret,
+        None => {
+            tracing::warn!("No session secret found in cookies for pubky-host: {}", public_key);
+            return Err(HttpError::unauthorized_with_message("No session secret found in cookies"));
+        }
+    };
 
-    let session = state
+    let session = match state
         .db
-        .get_session(&session_secret)?
-        .ok_or(HttpError::unauthorized())?;
+        .get_session(&session_secret)? {
+            Some(session) => session,
+            None => {
+                tracing::warn!("No session found in the database for session secret: {}, pubky: {}", session_secret, public_key);
+                return Err(HttpError::unauthorized_with_message("No session found for session secret"));
+            }
+        };
 
-    if session.pubky() == public_key
-        && session.capabilities().iter().any(|cap| {
+
+    if session.pubky() != public_key {
+        tracing::warn!("Session public key does not match pubky-host: {} != {}", session.pubky(), public_key);
+        return Err(HttpError::unauthorized_with_message("Session public key does not match pubky-host"));
+    }
+
+    if session.capabilities().iter().any(|cap| {
             path.starts_with(&cap.scope)
                 && cap
                     .actions
@@ -140,11 +156,12 @@ fn authorize(
         Ok(())
     } else {
         tracing::warn!(
-            "Session {} does not have write access to {}. Access forbidden",
+            "Session {} pubkey {} does not have write access to {}. Access forbidden",
             session_secret,
+            public_key,
             path
         );
-        Err(HttpError::forbidden())
+        Err(HttpError::forbidden_with_message("Session does not have write access to path"))
     }
 }
 

--- a/pubky-homeserver/src/shared/http_error.rs
+++ b/pubky-homeserver/src/shared/http_error.rs
@@ -55,16 +55,16 @@ impl HttpError {
         )
     }
 
-    pub fn forbidden() -> HttpError {
-        Self::new_with_message(StatusCode::FORBIDDEN, "Forbidden")
-    }
-
     pub fn forbidden_with_message(message: impl ToString) -> HttpError {
         Self::new_with_message(StatusCode::FORBIDDEN, message)
     }
 
     pub fn unauthorized() -> HttpError {
         Self::new_with_message(StatusCode::UNAUTHORIZED, "Unauthorized")
+    }
+
+    pub fn unauthorized_with_message(message: impl ToString) -> HttpError {
+        Self::new_with_message(StatusCode::UNAUTHORIZED, message)
     }
 }
 


### PR DESCRIPTION
We get random logouts with a 404 Not Found error when calling /session. This PR improves the http response message in this case + adds logs.

I had to fix the rust version for the pipeline to 1.87. The new rust 1.88 adds new clippy warnings that I didn't want to fix in this PR.

FYI: @catch-21 