### PR TITLE
chore(hs): rate limit key extraction change http code

### DIFF
--- a/pubky-homeserver/src/core/layers/rate_limiter/layer.rs
+++ b/pubky-homeserver/src/core/layers/rate_limiter/layer.rs
@@ -283,7 +283,7 @@ where
                     );
                     return Box::pin(async move {
                         Ok(HttpError::new_with_message(
-                            StatusCode::INTERNAL_SERVER_ERROR,
+                            StatusCode::BAD_REQUEST,
                             "Failed to extract key for rate limiting",
                         )
                         .into_response())


### PR DESCRIPTION
In case the `pubky-host` can't be extracted, the rate limiter returns an error. Before, this was a `500`. James run into this recently. This should be a `400 BAD REQUEST` though because it's the users fault not sending the pubky-host to the server.

FYI @catch-21 