### PR TITLE
fix(hs): Cookie Samesite Strict

### DIFF
--- a/pubky-homeserver/src/core/routes/auth.rs
+++ b/pubky-homeserver/src/core/routes/auth.rs
@@ -166,14 +166,19 @@ fn create_session_and_cookie(
     let mut cookie = Cookie::new(public_key.to_string(), session_secret);
     cookie.set_path("/");
     if is_secure(host) {
+        // Allow this cookie only to be sent over HTTPS.
         cookie.set_secure(true);
-        cookie.set_same_site(SameSite::None);
+        // Allow this cookie to be sent to only the same domain it originated from.
+        cookie.set_same_site(SameSite::Strict);
     }
+    // Prevent javascript from accessing the cookie.
     cookie.set_http_only(true);
+    // Set the cookie to expire in one year.
     let one_year = Duration::days(365);
     let expiry = OffsetDateTime::now_utc() + one_year;
     cookie.set_max_age(one_year);
     cookie.set_expires(expiry);
+
     cookies.add(cookie);
 
     Ok(session)


### PR DESCRIPTION
Until now, the cookie was sent to any location with SameSite::None. This is insecure. The cookie should only be sent to the homeserver itself.

This PR fixes this.

This might also resolve issues related parallel usage of `beta.pubky.app` and `pubky.app`.

FYI: @catch-21 