### PR TITLE
Revert "fix(hs): Cookie Samesite Strict"

### DIFF
--- a/pubky-homeserver/src/core/routes/auth.rs
+++ b/pubky-homeserver/src/core/routes/auth.rs
@@ -166,10 +166,13 @@ fn create_session_and_cookie(
     let mut cookie = Cookie::new(public_key.to_string(), session_secret);
     cookie.set_path("/");
     if is_secure(host) {
+        // Allow this cookie only to be sent over HTTPS.
         cookie.set_secure(true);
         cookie.set_same_site(SameSite::None);
     }
+    // Prevent javascript from accessing the cookie.
     cookie.set_http_only(true);
+    // Set the cookie to expire in one year.
     let one_year = Duration::days(365);
     let expiry = OffsetDateTime::now_utc() + one_year;
     cookie.set_max_age(one_year);

--- a/pubky-homeserver/src/core/routes/auth.rs
+++ b/pubky-homeserver/src/core/routes/auth.rs
@@ -166,19 +166,14 @@ fn create_session_and_cookie(
     let mut cookie = Cookie::new(public_key.to_string(), session_secret);
     cookie.set_path("/");
     if is_secure(host) {
-        // Allow this cookie only to be sent over HTTPS.
         cookie.set_secure(true);
-        // Allow this cookie to be sent to only the same domain it originated from.
-        cookie.set_same_site(SameSite::Strict);
+        cookie.set_same_site(SameSite::None);
     }
-    // Prevent javascript from accessing the cookie.
     cookie.set_http_only(true);
-    // Set the cookie to expire in one year.
     let one_year = Duration::days(365);
     let expiry = OffsetDateTime::now_utc() + one_year;
     cookie.set_max_age(one_year);
     cookie.set_expires(expiry);
-
     cookies.add(cookie);
 
     Ok(session)


### PR DESCRIPTION
Reverts pubky/pubky-core#174

This doesn't work for @flaviomoceri when he is running pubky-app on localhost and uses the staging backend. Reverting.