### PR TITLE
fix(hs): SVCB priority

### DIFF
--- a/pubky-homeserver/src/core/key_republisher.rs
+++ b/pubky-homeserver/src/core/key_republisher.rs
@@ -115,7 +115,7 @@ pub fn create_signed_packet(
 
     // `SVCB(HTTPS)` record pointing to the pubky tls port and the public ip address
     // This is what is used in all applications expect for browsers.
-    let mut svcb = SVCB::new(0, root_name.clone());
+    let mut svcb = SVCB::new(1, root_name.clone());
     svcb.set_port(public_pubky_tls_port);
     match &public_ip {
         IpAddr::V4(ip) => {


### PR DESCRIPTION
Turns out that SVCB priority of `0` has a [special meaning](https://kb.isc.org/docs/svcb-and-https-resource-records-what-are-they) similar to a cname. This PR changes the priority to `1` to comply with the standard.