### PR TITLE
feat(auth): optionally enforce terms of service on signup

### DIFF
--- a/pubky-homeserver/config.sample.toml
+++ b/pubky-homeserver/config.sample.toml
@@ -4,6 +4,11 @@
 # "token_required" - a signup token is required to signup.
 signup_mode = "token_required"
 
+# If set to true, users must accept the Terms of Service upon signup.
+# The ToS content is read from `tos.html` in your data directory.
+# And users can check it out at the `/tos` endpoint.
+enforce_tos = false
+
 # LMDB backup interval in seconds. 0 means disabled.
 # Periodically creates a "safe to copy" compacted backup on single
 # file under `{data_dir}/data/lmdb/backup.mdb`
@@ -46,13 +51,11 @@ path = "/session"
 method = "POST"
 quota = "20r/m"
 key = "ip"
-whitelist = [
-    "127.0.0.1"
-]
+whitelist = ["127.0.0.1"]
 #
 # Limit file uploads to 1 megabyte per second per user with a temporary burst of 10 megabytes.
 [[drive.rate_limits]]
-path = "/pub/**" 
+path = "/pub/**"
 method = "PUT"
 quota = "1mb/s"
 key = "user"

--- a/pubky-homeserver/default.tos.html
+++ b/pubky-homeserver/default.tos.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Terms of Service</title>
+    <style>
+        body { font-family: sans-serif; line-height: 1.6; padding: 2em; max-width: 800px; margin: auto; color: #333; }
+        h1 { color: #333; }
+        p { color: #555; }
+        .container { background-color: #f9f9f9; border: 1px solid #ddd; padding: 2em; border-radius: 5px; }
+        .admin-note { margin-top: 2em; padding: 1em; background-color: #fffbe6; border: 1px solid #ffe58f; border-radius: 5px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Terms of Service Not Yet Defined</h1>
+        <p>This homeserver is configured to enforce acceptance of its Terms of Service (ToS).</p>
+        <p>However, the administrator of this server has not yet provided the specific terms.</p>
+        <p>By proceeding, you are acknowledging this fact. Please contact the homeserver administrator for more information.</p>
+        
+        <div class="admin-note">
+            <p><strong>Note to the Administrator:</strong></p>
+            <p>You are seeing this default page because <code>enforce_tos</code> is set to <code>true</code> in your <code>config.toml</code>, but a custom <code>tos.html</code> was not found.</p>
+            <p>To set your own Terms of Service, please create or edit the <code>tos.html</code> file located in your homeserver's data directory (e.g., <code>~/.pubky/tos.html</code>).</p>
+        </div>
+    </div>
+</body>
+</html>

--- a/pubky-homeserver/src/app_context.rs
+++ b/pubky-homeserver/src/app_context.rs
@@ -81,6 +81,8 @@ impl TryFrom<Arc<dyn DataDir>> for AppContext {
         let conf = dir
             .read_or_create_config_file()
             .map_err(AppContextConversionError::Config)?;
+        dir.ensure_tos_file_exists_if_enforced(&conf)
+            .map_err(AppContextConversionError::DataDir)?;
         let keypair = dir
             .read_or_create_keypair()
             .map_err(AppContextConversionError::Keypair)?;

--- a/pubky-homeserver/src/core/homeserver_core.rs
+++ b/pubky-homeserver/src/core/homeserver_core.rs
@@ -32,6 +32,8 @@ pub(crate) struct AppState {
     pub(crate) signup_mode: SignupMode,
     /// If `Some(bytes)` the quota is enforced, else unlimited.
     pub(crate) user_quota_bytes: Option<u64>,
+    pub(crate) enforce_tos: bool,
+    pub(crate) data_dir: Arc<dyn crate::data_directory::DataDir>,
 }
 
 const INITIAL_DELAY_BEFORE_REPUBLISH: Duration = Duration::from_secs(60);
@@ -168,6 +170,8 @@ impl HomeserverCore {
             file_service: context.file_service.clone(),
             signup_mode: context.config_toml.general.signup_mode.clone(),
             user_quota_bytes: quota_bytes,
+            enforce_tos: context.config_toml.general.enforce_tos,
+            data_dir: context.data_dir.clone(),
         };
         super::routes::create_app(state.clone(), context)
     }

--- a/pubky-homeserver/src/core/routes/mod.rs
+++ b/pubky-homeserver/src/core/routes/mod.rs
@@ -23,6 +23,10 @@ mod auth;
 mod feed;
 mod root;
 mod tenants;
+mod tos;
+
+#[cfg(test)]
+mod test_helpers;
 
 static HOMESERVER_VERSION: &str = concat!("pubky.org", "@", env!("CARGO_PKG_VERSION"),);
 const TRACING_EXCLUDED_PATHS: [&str; 1] = ["/events/"];
@@ -30,6 +34,7 @@ const TRACING_EXCLUDED_PATHS: [&str; 1] = ["/events/"];
 fn base() -> Router<AppState> {
     Router::new()
         .route("/", get(root::handler))
+        .route("/tos", get(tos::handler))
         .route("/signup", post(auth::signup))
         .route("/session", post(auth::signin))
         // Events

--- a/pubky-homeserver/src/core/routes/test_helpers.rs
+++ b/pubky-homeserver/src/core/routes/test_helpers.rs
@@ -1,0 +1,44 @@
+use crate::{app_context::AppContext, core::HomeserverCore};
+use axum::{http::header, Router};
+use axum_test::TestServer;
+use pkarr::{Keypair, PublicKey};
+use pubky_common::{auth::AuthToken, capabilities::Capability};
+
+pub async fn create_test_signup(
+    server: &axum_test::TestServer,
+    keypair: &Keypair,
+) -> anyhow::Result<String> {
+    let auth_token = AuthToken::sign(keypair, vec![Capability::root()]);
+    let body_bytes: axum::body::Bytes = auth_token.serialize().into();
+    let response = server
+        .post("/signup")
+        .add_header("host", keypair.public_key().to_string())
+        .bytes(body_bytes)
+        .expect_success()
+        .await;
+
+    let header_value = response
+        .headers()
+        .get(header::SET_COOKIE)
+        .and_then(|h| h.to_str().ok())
+        .expect("should return a set-cookie header")
+        .to_string();
+
+    Ok(header_value)
+}
+
+pub async fn create_test_env() -> anyhow::Result<(AppContext, Router, TestServer, PublicKey, String)>
+{
+    let context = AppContext::test();
+    let router = HomeserverCore::create_router(&context);
+    let server = axum_test::TestServer::new(router.clone()).unwrap();
+
+    let keypair = Keypair::random();
+    let public_key = keypair.public_key();
+    let cookie = create_test_signup(&server, &keypair)
+        .await
+        .unwrap()
+        .to_string();
+
+    Ok((context, router, server, public_key, cookie))
+}

--- a/pubky-homeserver/src/core/routes/tos.rs
+++ b/pubky-homeserver/src/core/routes/tos.rs
@@ -1,0 +1,55 @@
+use axum::{
+    body::Body,
+    extract::State,
+    http::{header, Response, StatusCode},
+    response::IntoResponse,
+};
+
+use crate::{core::AppState, shared::HttpResult};
+
+pub async fn handler(State(state): State<AppState>) -> HttpResult<impl IntoResponse> {
+    let tos_path = state.data_dir.path().join("tos.html");
+    let tos_content = tokio::fs::read_to_string(tos_path).await?;
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
+        .body(Body::from(tos_content))
+        .unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        app_context::AppContext, core::HomeserverCore, data_directory::MockDataDir, ConfigToml,
+    };
+    #[tokio::test]
+    async fn tos_endpoint_returns_content() {
+        let mut config = ConfigToml::test();
+        config.general.enforce_tos = true; // Not strictly needed, but good for testing file creation.
+        let data_dir = MockDataDir::new(config, None).unwrap();
+        let context = AppContext::try_from(data_dir).unwrap();
+        let router = HomeserverCore::create_router(&context);
+        let server = axum_test::TestServer::new(router.clone()).unwrap();
+
+        // Check that default file was created.
+        let tos_path = context.data_dir.path().join("tos.html");
+        assert!(tos_path.exists());
+
+        let response = server.get("/tos").expect_success().await;
+
+        response.assert_status_ok();
+        response.assert_header("content-type", "text/html; charset=utf-8");
+        let body = response.text();
+        assert!(body.contains("Terms of Service Not Yet Defined"));
+
+        // Now, let's test with a custom ToS file
+        let custom_tos = "<h1>My Custom ToS</h1>";
+        std::fs::write(&tos_path, custom_tos).unwrap();
+
+        let response2 = server.get("/tos").expect_success().await;
+        response2.assert_status_ok();
+        let body2 = response2.text();
+        assert_eq!(body2, custom_tos);
+    }
+}

--- a/pubky-homeserver/src/data_directory/config.default.toml
+++ b/pubky-homeserver/src/data_directory/config.default.toml
@@ -2,7 +2,7 @@
 signup_mode = "token_required"
 lmdb_backup_interval_s = 0
 user_storage_quota_mb = 0
-
+enforce_tos = false
 
 [drive]
 pubky_listen_socket = "127.0.0.1:6287"
@@ -19,7 +19,7 @@ admin_password = "admin"
 [pkdns]
 public_ip = "127.0.0.1"
 icann_domain = "localhost"
-user_keys_republisher_interval = 14400 # 4 hours in seconds
+user_keys_republisher_interval = 14400                                   # 4 hours in seconds
 dht_relay_nodes = ["https://pkarr.pubky.app", "https://pkarr.pubky.org"]
 
 [logging]

--- a/pubky-homeserver/src/data_directory/config_toml.rs
+++ b/pubky-homeserver/src/data_directory/config_toml.rs
@@ -30,6 +30,9 @@ pub const DEFAULT_CONFIG: &str = include_str!("config.default.toml");
 /// Example configuration file
 pub const SAMPLE_CONFIG: &str = include_str!("../../config.sample.toml");
 
+/// Default content for the `tos.html` file.
+pub const DEFAULT_TOS: &str = include_str!("../../default.tos.html");
+
 /// Error that can occur when reading a configuration file.
 #[derive(Debug, thiserror::Error)]
 pub enum ConfigReadError {
@@ -74,6 +77,7 @@ pub struct AdminToml {
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default)]
 pub struct GeneralToml {
     pub signup_mode: SignupMode,
+    pub enforce_tos: bool,
     pub lmdb_backup_interval_s: u64,
     pub user_storage_quota_mb: u64,
 }
@@ -181,6 +185,7 @@ impl ConfigToml {
     pub fn test() -> Self {
         let mut config = Self::default();
         config.general.signup_mode = SignupMode::Open;
+        config.general.enforce_tos = false;
         // Use ephemeral ports (0) so parallel tests don't collide.
         config.drive.icann_listen_socket = SocketAddr::from(([127, 0, 0, 1], 0));
         config.drive.pubky_listen_socket = SocketAddr::from(([127, 0, 0, 1], 0));
@@ -216,6 +221,7 @@ mod tests {
     fn test_default_config() {
         let c = ConfigToml::default();
         assert_eq!(c.general.signup_mode, SignupMode::TokenRequired);
+        assert!(!c.general.enforce_tos);
         assert_eq!(c.general.user_storage_quota_mb, 0);
         assert_eq!(c.general.lmdb_backup_interval_s, 0);
         assert_eq!(

--- a/pubky-homeserver/src/data_directory/data_dir.rs
+++ b/pubky-homeserver/src/data_directory/data_dir.rs
@@ -20,6 +20,10 @@ pub trait DataDir: std::fmt::Debug + DynClone + Send + Sync {
     /// Reads the secret file from the data directory.
     /// Creates a new secret file if it doesn't exist.
     fn read_or_create_keypair(&self) -> anyhow::Result<pkarr::Keypair>;
+
+    /// Ensures the ToS file exists if `enforce_tos` is true.
+    /// Creates a default one if it doesn't.
+    fn ensure_tos_file_exists_if_enforced(&self, config: &ConfigToml) -> anyhow::Result<()>;
 }
 
 dyn_clone::clone_trait_object!(DataDir);

--- a/pubky-homeserver/src/data_directory/mock_data_dir.rs
+++ b/pubky-homeserver/src/data_directory/mock_data_dir.rs
@@ -1,5 +1,7 @@
 use std::path::Path;
 
+use crate::data_directory::config_toml::DEFAULT_TOS;
+
 use super::DataDir;
 
 /// Mock data directory for testing.
@@ -54,6 +56,16 @@ impl DataDir for MockDataDir {
 
     fn ensure_data_dir_exists_and_is_writable(&self) -> anyhow::Result<()> {
         Ok(()) // Always ok because this is validated by the tempfile crate.
+    }
+
+    fn ensure_tos_file_exists_if_enforced(&self, config: &super::ConfigToml) -> anyhow::Result<()> {
+        if config.general.enforce_tos {
+            let tos_path = self.path().join("tos.html");
+            if !tos_path.exists() {
+                std::fs::write(tos_path, DEFAULT_TOS)?;
+            }
+        }
+        Ok(())
     }
 
     fn read_or_create_config_file(&self) -> anyhow::Result<super::ConfigToml> {

--- a/pubky-homeserver/src/data_directory/persistent_data_dir.rs
+++ b/pubky-homeserver/src/data_directory/persistent_data_dir.rs
@@ -1,3 +1,5 @@
+use crate::data_directory::config_toml::DEFAULT_TOS;
+
 use super::{data_dir::DataDir, ConfigToml};
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
@@ -48,6 +50,17 @@ impl PersistentDataDir {
     /// Returns the config file path in this directory.
     pub fn get_config_file_path(&self) -> PathBuf {
         self.expanded_path.join("config.toml")
+    }
+
+    /// Returns the path to the ToS file.
+    pub fn get_tos_file_path(&self) -> PathBuf {
+        self.expanded_path.join("tos.html")
+    }
+
+    fn write_default_tos_file(&self) -> anyhow::Result<()> {
+        let tos_file_path = self.get_tos_file_path();
+        std::fs::write(tos_file_path, DEFAULT_TOS)?;
+        Ok(())
     }
 
     fn write_sample_config_file(&self) -> anyhow::Result<()> {
@@ -104,6 +117,22 @@ impl DataDir for PersistentDataDir {
             .map_err(|err| anyhow::anyhow!("Failed to write to data directory: {}", err))?;
         std::fs::remove_file(test_file_path)
             .map_err(|err| anyhow::anyhow!("Failed to write to data directory: {}", err))?;
+        Ok(())
+    }
+
+    /// Ensures the ToS file exists if `enforce_tos` is true.
+    /// Creates a default one if it doesn't.
+    fn ensure_tos_file_exists_if_enforced(&self, config: &ConfigToml) -> anyhow::Result<()> {
+        if config.general.enforce_tos {
+            let tos_path = self.get_tos_file_path();
+            if !tos_path.exists() {
+                tracing::warn!(
+                    "`enforce_tos` is true but `tos.html` not found. Creating a default one at {}",
+                    tos_path.display()
+                );
+                self.write_default_tos_file()?;
+            }
+        }
         Ok(())
     }
 


### PR DESCRIPTION
This pull request adds support for enforcing Terms of Service (ToS) acceptance during user signup. This feature is opt-in and controlled via configuration, preserves backward compatibility.

## Key Changes  

- **New Config Flag**:  
  A new `enforce_tos` boolean flag under `[general]` in `config.toml`. Defaults to `false`.  

- **Conditional Signup Logic**:  
  If `enforce_tos = true`, the `/signup` endpoint requires `accept_tos=true` as a query parameter. If missing or false, the server returns `400 Bad Request` with an explicit message `"You must accept the Terms of Service to sign up."`

- **ToS File Handling**:  
  - The server looks for `tos.html` in the user's data directory (e.g., `~/.pubky/tos.html`).  
  - If `enforce_tos = true` and the file is missing, a default placeholder is created at startup with guidance for customization.

- **New Endpoint `/tos`**:  
  Serves `tos.html` as `text/html`.

### Config Rationale  
The `enforce_tos` flag allows lightweight homeserver deployments (e.g., testing, casual use) without ToS enforcement. When neither `signup_token` nor `enforce_tos` are set, tenants can sign up using only `.signup(public_key)`. If both are enabled, clients must use `.signup(public_key, signup_token, true)`.

### ToS Format  
I decided for storing and serving ToS as `html` over `markdown` to take advantage of browser rendering when visiting the `/tos` endpoint. This favours direct inspection. If client apps end up rendering ToS content inside components, `markdown` could be a better fit and we can make the move, though `html` remains compatible.

## Test Suite Refactoring  

- Shared test utilities (`create_test_env`, `create_test_signup`, etc.) moved to `src/core/routes/test_helpers.rs`.  
- We had made a couple of very useful test utils under `routs/tenants/read.rs`, I extracted them so we can colocate testing for each handler without having to be overly verbose on the test definitions.
