### PR TITLE
fix(js-client): optional client config fields on ts interface

### DIFF
--- a/pubky-client/bindings/js/src/constructor.rs
+++ b/pubky-client/bindings/js/src/constructor.rs
@@ -18,9 +18,11 @@ static TESTNET_RELAYS: [&str; 1] = ["http://localhost:15411/"];
 #[serde(rename_all = "camelCase")]
 pub struct PkarrConfig {
     /// The list of relays to access the DHT with.
+    #[tsify(optional)]
     pub(crate) relays: Option<Vec<String>>,
     /// The timeout for DHT requests in milliseconds.
     /// Default is 2000ms.
+    #[tsify(optional)]
     pub(crate) request_timeout: Option<NonZeroU64>,
 }
 
@@ -30,9 +32,11 @@ pub struct PkarrConfig {
 #[serde(rename_all = "camelCase")]
 pub struct PubkyClientConfig {
     /// Configuration on how to access pkarr packets on the mainline DHT.
+    #[tsify(optional)]
     pub(crate) pkarr: Option<PkarrConfig>,
     /// The maximum age of a record in seconds.
     /// If the user pkarr record is older than this, it will be automatically refreshed.
+    #[tsify(optional)]
     pub(crate) user_max_record_age: Option<NonZeroU64>,
 }
 


### PR DESCRIPTION
Fixes #144

Client config interface fields can now be left `undefined` 
```ts
/**
 * Pubky Client Config
 */
export interface PubkyClientConfig {
    /**
     * Configuration on how to access pkarr packets on the mainline DHT.
     */
    pkarr?: PkarrConfig;
    /**
     * The maximum age of a record in seconds.
     * If the user pkarr record is older than this, it will be automatically refreshed.
     */
    userMaxRecordAge?: NonZeroU64;
}
```

```ts
/**
 * Pkarr Config
 */
export interface PkarrConfig {
    /**
     * The list of relays to access the DHT with.
     */
    relays?: string[];
    /**
     * The timeout for DHT requests in milliseconds.
     * Default is 2000ms.
     */
    requestTimeout?: NonZeroU64;
}
```

Thank you @SeverinAlexB for figuring this out. Possibly useful as well on our `pubky-app-specs` wasm bindings.