### PR TITLE
feat(client/testnet): make testnet relay host configurable for Docker

### DIFF
--- a/pubky-client/src/api/http.rs
+++ b/pubky-client/src/api/http.rs
@@ -207,8 +207,20 @@ impl Client {
         }
 
         if let Some(e) = so_far {
+            // Check if the resolved domain is a testnet domain. It is if it's "localhost"
+            // or if it matches the testnet_host configured in the client.
+            let is_testnet_domain = e.domain().map_or(false, |domain| {
+                if domain == "localhost" {
+                    return true;
+                }
+                if let Some(test_host) = &self.testnet_host {
+                    return domain == test_host;
+                }
+                false
+            });
+
             // TODO: detect loopback IPs and other equivalent to localhost
-            if e.domain() == Some("localhost") {
+            if is_testnet_domain {
                 url.set_scheme("http")
                     .expect("couldn't replace pubky:// with http://");
 

--- a/pubky-client/src/client.rs
+++ b/pubky-client/src/client.rs
@@ -53,10 +53,17 @@ impl ClientBuilder {
         self
     }
 
-    #[cfg(target_arch = "wasm32")]
-    /// Sets the testnet host for wasm builds.
+    /// Sets the testnet host. This is only used for WASM builds.
     pub fn testnet_host(&mut self, host: String) -> &mut Self {
-        self.testnet_host = Some(host);
+        // The field itself is still conditional, so the logic is gated.
+        #[cfg(target_arch = "wasm32")]
+        {
+            self.testnet_host = Some(host);
+        }
+        // This avoids an "unused parameter" warning on non-WASM builds.
+        #[cfg(not(target_arch = "wasm32"))]
+        let _ = host;
+
         self
     }
 

--- a/pubky-testnet/src/static_testnet.rs
+++ b/pubky-testnet/src/static_testnet.rs
@@ -177,10 +177,10 @@ impl StaticTestnet {
         );
         config.pkdns.dht_relay_nodes = None;
         config.drive.icann_listen_socket =
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 6286);
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 6286);
         config.drive.pubky_listen_socket =
-            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 6287);
-        config.admin.listen_socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 6288);
+            SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 6287);
+        config.admin.listen_socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 6288);
         let mock = MockDataDir::new(config, Some(keypair))?;
 
         let homeserver = HomeserverSuite::start_with_mock_data_dir(mock).await?;


### PR DESCRIPTION
This PR introduces several changes to improve the flexibility of the testnet environment, allowing it to run seamlessly within a Docker-based setup while maintaining backward compatibility with existing `localhost` development workflows.

This work was originally proposed and implemented by @SpontaneousOverthrow here https://github.com/pubky/pubky-core/commit/26bd8423f3fc380cd64c812575c7d1cb22ef7454  to address issues with service discovery in our containerized testnet. 

### The Problem

Previously, the testnet configuration was hardcoded to use `localhost` for service and relay addresses. While this works for local development, it prevents services from communicating within a Docker network, where containers are typically accessed via their service names (e.g., `homeserver`). In other words, any testnet stack was limited to work exclusively when all services are running on the same machine.

### The Solution

This PR addresses the issue by making the testnet hostname configurable and updating network bindings:

1.  **Configurable Testnet Host:**
    * The native `ClientBuilder` now includes a `testnet_with_host(&str)` method, allowing a custom hostname to be specified. The original `testnet()` method now defaults to `localhost` for backward compatibility.
    * The WASM `Client::testnet()` constructor now accepts an optional `host` argument. If not provided, it defaults to `localhost`.

2.  **Docker-Friendly Network Bindings:**
    * The services in the `pubky-testnet` crate are now configured to listen on `0.0.0.0` instead of `127.0.0.1`. This allows them to accept connections from other containers on the same Docker network. Does not affect behvaiour for our current local development setups.

3.  **Allow `"homeserver"` as a non-secure origin**:
    * The `is_secure` check in `pubky-homeserver` has been updated to recognize `"homeserver"` as a non-secure origin, which is necessary for authentication flows within the Docker testnet.

These _should_ be backwards compatible, current `localhost` should keep working without any modifications, while our CI and Docker-based environments can now function correctly by providing the appropriate hostname.