### PR TITLE
Consolidate, bump `pkarr` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2597,9 +2597,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkarr"
-version = "3.8.0"
+version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a50f65a2b97031863fbdff2f085ba832360b4bef3106d1fcff9ab5bf4063fe"
+checksum = "e80bbe1ea7bd30855c856cd796e67212eade4c275ab8554ce5458d7c75b4a63b"
 dependencies = [
  "async-compat",
  "base32",
@@ -2635,9 +2635,9 @@ dependencies = [
 
 [[package]]
 name = "pkarr-relay"
-version = "0.9.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c90db47e95f4f07fab0ff0967238c9f7bdb9cb197713a9c2f760ab6b99846952"
+checksum = "4894f84699243d702526e0f3415d6436377dc3194c69e20da3d872374458efdc"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,9 @@ opt-level = 'z'
 
 
 [workspace.dependencies]
-pkarr = { version = "3.8.0" }
+# Setting "default-features = false" because cargo doesn't allow member crates to override the root "default-features" flag, which if not set, is implied to be true.
+# Member crates that need "default-features = false" should leave it out of their dependency specification, as it's inherited from here.
+# Member crates that need "default-features = true" should add a "default" feature to the features list, which is equivalent.
+pkarr = { version = "3.9.1", default-features = false }
 mainline = { version = "5.4.0" }
-pkarr-relay = { version = "0.9.2" }
+pkarr-relay = { version = "0.11.0" }

--- a/pkarr-republisher/Cargo.toml
+++ b/pkarr-republisher/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["web-programming"]
 
 [dependencies]
 anyhow = "1.0.98"
-pkarr = { workspace = true }
+pkarr = { workspace = true, features = ["default"] }
 tokio = { version = "1.45.1", features = ["full"] }
 tracing = "0.1.41"
 futures-lite = { version = "2.6.0" }

--- a/pubky-client/Cargo.toml
+++ b/pubky-client/Cargo.toml
@@ -29,7 +29,7 @@ thiserror = "2.0.11"
 url = "2.5.4"
 bytes = "^1.10.0"
 base64 = "0.22.1"
-pkarr = { version = "3.7.1", features = ["full"] }
+pkarr = { workspace = true, features = ["full"] }
 cookie = "0.18.1"
 cookie_store = { version = "0.21.1", default-features = false }
 anyhow = "1.0.95"

--- a/pubky-client/bindings/js/Cargo.toml
+++ b/pubky-client/bindings/js/Cargo.toml
@@ -33,7 +33,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde-wasm-bindgen = "0.4"
 tsify = "0.5.5"
 pubky = { path = "../../../pubky-client", default-features = false }
-pkarr = { version = "3.7.1", default-features = false, features = ["relays"] }
+pkarr = { workspace = true, features = ["relays"] }
 pubky-common = { path = "../../../pubky-common" }
 web-sys = { version = "0.3.77", default-features = false, features = [
     "Request",


### PR DESCRIPTION
This PR consolidates the `pkarr` version used across the member crates. It defines it just once, in the workspace root, then re-uses that version.

---

`default-features` was set to `false` in the root `Cargo.toml` because cargo doesn't allow member crates to override that setting.

Consolidating the version would otherwise result in a compilation error

```
Caused by:
  error inheriting `pkarr` from workspace root manifest's `workspace.dependencies.pkarr`

Caused by:
  `default-features = false` cannot override workspace's `default-features`
```

because `pubky-client/bindings/js/Cargo.toml` was trying to set it to `false` when the flag is implied to be `true` in the workspace root.