### PR TITLE
chore(release): bump to v0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2815,7 +2815,7 @@ checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "pubky"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -2840,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-common"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "argon2",
  "base32",
@@ -2859,7 +2859,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-homeserver"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "axum",
@@ -2911,7 +2911,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-testnet"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/pubky-client/Cargo.toml
+++ b/pubky-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubky"
 description = "Pubky-Core Client"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 authors = [
     "SeverinAlexB <severin@synonym.to>",
@@ -24,7 +24,7 @@ categories = [
 crate-type = ["rlib"]
 
 [dependencies]
-pubky-common = { path = "../pubky-common", version = "0.5.1" }
+pubky-common = { path = "../pubky-common", version = "0.5.2" }
 thiserror = "2.0.11"
 url = "2.5.4"
 bytes = "^1.10.0"

--- a/pubky-common/Cargo.toml
+++ b/pubky-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubky-common"
 description = "Types and struct in common between Pubky client and homeserver"
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/pubky-homeserver/Cargo.toml
+++ b/pubky-homeserver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubky-homeserver"
 description = "Pubky core's homeserver."
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -33,7 +33,7 @@ hex = "0.4.3"
 httpdate = "1.0.3"
 postcard = { version = "1.1.1", features = ["alloc"] }
 pkarr = { workspace = true, features = ["dht", "lmdb-cache", "tls"] }
-pubky-common = { path = "../pubky-common", version = "0.5.1" }
+pubky-common = { path = "../pubky-common", version = "0.5.2" }
 serde = { version = "1.0.217", features = ["derive"] }
 tokio = { version = "1.43.0", features = ["full"] }
 toml = "0.8.20"
@@ -52,18 +52,19 @@ hostname-validator = "1.1.1"
 axum-test = "17.2.0"
 tempfile = { version = "3.10.1" }
 dyn-clone = "1.0.19"
-reqwest = { version = "0.12.15", default-features = false, features = ["rustls-tls"] }
+reqwest = { version = "0.12.15", default-features = false, features = [
+    "rustls-tls",
+] }
 governor = "0.10.0"
 fast-glob = "0.4.5"
 tokio-util = "0.7.15"
 percent-encoding = "2.3.1"
 serde_valid = "1.0.5"
-opendal = { version = "0.53.3", features =["services-fs"]}
+opendal = { version = "0.53.3", features = ["services-fs"] }
 infer = "0.19.0"
 mime_guess = "2.0.5"
 dav-server-opendalfs = "0.6.1"
 dav-server = "0.8.0"
-
 
 
 [dev-dependencies]
@@ -72,14 +73,10 @@ uuid = { version = "1.7.0", features = ["v4"] }
 
 
 [features]
-default = [
-    "storage-gcs",
-]
+default = ["storage-gcs"]
 # Optional storage types
 storage-gcs = ["opendal/services-gcs"]
 storage-memory = ["opendal/services-memory"]
 
 # Optional testing methods
-testing = [
-    "storage-memory"
-]
+testing = ["storage-memory"]

--- a/pubky-testnet/Cargo.toml
+++ b/pubky-testnet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubky-testnet"
 description = "A local test network for Pubky Core development."
-version = "0.5.1"
+version = "0.5.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true
@@ -19,9 +19,11 @@ tokio = { version = "1.43.0", features = ["full"] }
 tracing-subscriber = "0.3.19"
 url = "2.5.4"
 
-pubky = { path = "../pubky-client", version = "0.5.1" }
-pubky-common = { path = "../pubky-common", version = "0.5.1" }
-pubky-homeserver = { path = "../pubky-homeserver", version = "0.5.1", default-features = false, features = ["testing"] }
+pubky = { path = "../pubky-client", version = "0.5.2" }
+pubky-common = { path = "../pubky-common", version = "0.5.2" }
+pubky-homeserver = { path = "../pubky-homeserver", version = "0.5.2", default-features = false, features = [
+    "testing",
+] }
 http-relay = { path = "../http-relay", version = "0.5.1" }
 tempfile = "3.19.1"
 tracing = "0.1.41"


### PR DESCRIPTION
Bumped all `pubky-` versions to v0.5.2 so we can release with the main objective of fixing the dockerized setups for Windows and MacOS.

In my opinion, there is no reason to re-release and match versions with the `pkarr-republisher` or `http-relay` crates. In fact, these two could be ejected into their own projects.

Bumped `pubky-common` although I do not think anything has changed since last release.