### PR TITLE
chore(release): bump JS bindings to v0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2947,7 +2947,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-wasm"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "console_log",
  "getrandom 0.3.1",

--- a/pubky-client/bindings/js/Cargo.toml
+++ b/pubky-client/bindings/js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky-wasm"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2024"
 description = "Pubky-Core Client WASM bindings"
 authors = [

--- a/pubky-client/bindings/js/pkg/package.json
+++ b/pubky-client/bindings/js/pkg/package.json
@@ -2,7 +2,7 @@
   "name": "@synonymdev/pubky",
   "type": "module",
   "description": "Pubky client",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Missed one crate to version bump on #191