### PR TITLE
chore(deps): bump opendal to 0.54

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -861,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "dav-server-opendalfs"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a962d50f6fbb5ef2330de6c916b9892d1951480139769ec1d84594ee9099e161"
+checksum = "5305e1e00d258d119aae1e1fbdee3a704cf66b632b4f1a6d384d65531d84c35c"
 dependencies = [
  "anyhow",
  "bytes",
@@ -1728,7 +1728,7 @@ dependencies = [
  "http-body",
  "hyper",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.8",
  "tokio",
  "tower-service",
  "tracing",
@@ -1925,6 +1925,17 @@ checksum = "a0c10553d664a4d0bcff9f4215d0aac67a639cc68ef660840afe309b807bc9f5"
 dependencies = [
  "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -2348,12 +2359,11 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opendal"
-version = "0.53.3"
+version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f947c4efbca344c1a125753366033c8107f552b2e3f8251815ed1908f116ca3e"
+checksum = "ffb9838d0575c6dbaf3fcec7255af8d5771996d4af900bbb6fa9a314dec00a1a"
 dependencies = [
  "anyhow",
- "async-trait",
  "backon",
  "base64 0.22.1",
  "bytes",
@@ -3012,7 +3022,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.5.8",
  "thiserror 2.0.12",
  "tokio",
  "tracing",
@@ -3047,7 +3057,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.5.8",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -3807,6 +3817,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4045,20 +4065,22 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "43864ed400b6043a4757a25c7a64a8efde741aed79a056a2fb348a406701bb35"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/pubky-homeserver/Cargo.toml
+++ b/pubky-homeserver/Cargo.toml
@@ -60,10 +60,10 @@ fast-glob = "0.4.5"
 tokio-util = "0.7.15"
 percent-encoding = "2.3.1"
 serde_valid = "1.0.5"
-opendal = { version = "0.53.3", features = ["services-fs"] }
+opendal = { version = "0.54.0", features = ["services-fs"] }
 infer = "0.19.0"
 mime_guess = "2.0.5"
-dav-server-opendalfs = "0.6.1"
+dav-server-opendalfs = "0.6.2"
 dav-server = "0.8.0"
 
 

--- a/pubky-homeserver/src/persistence/files/entry_layer.rs
+++ b/pubky-homeserver/src/persistence/files/entry_layer.rs
@@ -114,45 +114,6 @@ impl<A: Access> LayeredAccess for EntryAccessor<A> {
     async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
         self.inner.presign(path, args).await
     }
-
-    type BlockingReader = A::BlockingReader;
-    type BlockingWriter = A::BlockingWriter;
-    type BlockingLister = A::BlockingLister;
-    type BlockingDeleter = A::BlockingDeleter;
-
-    fn blocking_read(
-        &self,
-        path: &str,
-        args: opendal::raw::OpRead,
-    ) -> opendal::Result<(opendal::raw::RpRead, Self::BlockingReader)> {
-        self.inner.blocking_read(path, args)
-    }
-
-    fn blocking_write(
-        &self,
-        _path: &str,
-        _args: opendal::raw::OpWrite,
-    ) -> opendal::Result<(opendal::raw::RpWrite, Self::BlockingWriter)> {
-        Err(opendal::Error::new(
-            opendal::ErrorKind::Unsupported,
-            "Writing is not supported in blocking mode",
-        ))
-    }
-
-    fn blocking_delete(&self) -> opendal::Result<(opendal::raw::RpDelete, Self::BlockingDeleter)> {
-        Err(opendal::Error::new(
-            opendal::ErrorKind::Unsupported,
-            "Deleting is not supported in blocking mode",
-        ))
-    }
-
-    fn blocking_list(
-        &self,
-        path: &str,
-        args: opendal::raw::OpList,
-    ) -> opendal::Result<(opendal::raw::RpList, Self::BlockingLister)> {
-        self.inner.blocking_list(path, args)
-    }
 }
 
 /// Wrapper around the writer that updates the entry in the database when the file is closed.

--- a/pubky-homeserver/src/persistence/files/user_quota_layer.rs
+++ b/pubky-homeserver/src/persistence/files/user_quota_layer.rs
@@ -135,47 +135,6 @@ impl<A: Access> LayeredAccess for UserQuotaAccessor<A> {
     async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
         self.inner.presign(path, args).await
     }
-
-    type BlockingReader = A::BlockingReader;
-    type BlockingWriter = A::BlockingWriter;
-    type BlockingLister = A::BlockingLister;
-    type BlockingDeleter = A::BlockingDeleter;
-
-    fn blocking_read(
-        &self,
-        path: &str,
-        args: opendal::raw::OpRead,
-    ) -> opendal::Result<(opendal::raw::RpRead, Self::BlockingReader)> {
-        self.inner.blocking_read(path, args)
-    }
-
-    fn blocking_write(
-        &self,
-        _path: &str,
-        _args: opendal::raw::OpWrite,
-    ) -> opendal::Result<(opendal::raw::RpWrite, Self::BlockingWriter)> {
-        // Not supported because we user quota not implemented in blocking mode.
-        Err(opendal::Error::new(
-            opendal::ErrorKind::Unsupported,
-            "Writing is not supported in blocking mode",
-        ))
-    }
-
-    fn blocking_delete(&self) -> opendal::Result<(opendal::raw::RpDelete, Self::BlockingDeleter)> {
-        // Not supported because we user quota not implemented in blocking mode.
-        Err(opendal::Error::new(
-            opendal::ErrorKind::Unsupported,
-            "Deleting is not supported in blocking mode",
-        ))
-    }
-
-    fn blocking_list(
-        &self,
-        path: &str,
-        args: opendal::raw::OpList,
-    ) -> opendal::Result<(opendal::raw::RpList, Self::BlockingLister)> {
-        self.inner.blocking_list(path, args)
-    }
 }
 
 /// Update the user quota by the given amount.


### PR DESCRIPTION
Attempting to fix  https://github.com/pubky/pubky-nexus/actions/runs/16568273872/job/46853557170?pr=513

For some reason direct dependency on `opendal` and transient dependencies on `opendal` get into conflict when we import and use `pubky-testnet` .

In this PR I bump version of both `opendal` and `dav-server-opendalfs` .

Opendal 0.54 has a breaking change that I have sorted by "simply removing it" which helped me confirm compilation is OK and test suites of downstream crates now pass https://github.com/pubky/pubky-nexus/actions/runs/16569835925/job/46858827162?pr=513

 However, "simply removing it" might have altered the behavior of the homeserver. Invoking @SeverinAlexB for a more in depth check of this `opendal` breaking change.