### PR TITLE
Re-use read-/write-keypair from updated `pkarr`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2597,9 +2597,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkarr"
-version = "3.9.1"
+version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e80bbe1ea7bd30855c856cd796e67212eade4c275ab8554ce5458d7c75b4a63b"
+checksum = "5eb1f2f4311bae1da11f930c804c724c9914cf55ae51a9ee0440fc98826984f7"
 dependencies = [
  "async-compat",
  "base32",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,6 @@ opt-level = 'z'
 # Setting "default-features = false" because cargo doesn't allow member crates to override the root "default-features" flag, which if not set, is implied to be true.
 # Member crates that need "default-features = false" should leave it out of their dependency specification, as it's inherited from here.
 # Member crates that need "default-features = true" should add a "default" feature to the features list, which is equivalent.
-pkarr = { version = "3.9.1", default-features = false }
+pkarr = { version = "3.10.0", default-features = false }
 mainline = { version = "5.4.0" }
 pkarr-relay = { version = "0.11.0" }

--- a/pubky-homeserver/src/data_directory/persistent_data_dir.rs
+++ b/pubky-homeserver/src/data_directory/persistent_data_dir.rs
@@ -108,6 +108,7 @@ impl DataDir for PersistentDataDir {
         if !secret_file_path.exists() {
             // Create a new secret file
             pkarr::Keypair::random().write_secret_key_file(&secret_file_path)?;
+            tracing::info!("Secret file created at {}", secret_file_path.display());
         }
         // Read the secret file
         let keypair = pkarr::Keypair::from_secret_key_file(&secret_file_path)?;

--- a/pubky-homeserver/src/data_directory/persistent_data_dir.rs
+++ b/pubky-homeserver/src/data_directory/persistent_data_dir.rs
@@ -1,6 +1,5 @@
 use super::{data_dir::DataDir, ConfigToml};
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
+
 use std::{
     io::Write,
     path::{Path, PathBuf},
@@ -62,21 +61,6 @@ impl PersistentDataDir {
     pub fn get_secret_file_path(&self) -> PathBuf {
         self.expanded_path.join("secret")
     }
-
-    /// Writes the keypair to the secret file.
-    /// If the file already exists, it will be overwritten.
-    pub fn write_keypair(&self, keypair: &pkarr::Keypair) -> anyhow::Result<()> {
-        let secret_file_path = self.get_secret_file_path();
-        let secret = keypair.secret_key();
-        let hex_string = hex::encode(secret);
-        std::fs::write(secret_file_path.clone(), hex_string)?;
-        #[cfg(unix)]
-        {
-            std::fs::set_permissions(&secret_file_path, std::fs::Permissions::from_mode(0o600))?;
-        }
-        tracing::info!("Secret file created at {}", secret_file_path.display());
-        Ok(())
-    }
 }
 
 impl Default for PersistentDataDir {
@@ -123,16 +107,10 @@ impl DataDir for PersistentDataDir {
         let secret_file_path = self.get_secret_file_path();
         if !secret_file_path.exists() {
             // Create a new secret file
-            self.write_keypair(&pkarr::Keypair::random())?;
+            pkarr::Keypair::random().write_secret_key_file(&secret_file_path)?;
         }
         // Read the secret file
-        let secret = std::fs::read(secret_file_path)?;
-        let secret_string = String::from_utf8_lossy(&secret).trim().to_string();
-        let secret_bytes = hex::decode(secret_string)?;
-        let secret_bytes: [u8; 32] = secret_bytes.try_into().map_err(|_| {
-            anyhow::anyhow!("Failed to convert secret bytes into array of length 32")
-        })?;
-        let keypair = pkarr::Keypair::from_secret_key(&secret_bytes);
+        let keypair = pkarr::Keypair::from_secret_key_file(&secret_file_path)?;
         Ok(keypair)
     }
 }


### PR DESCRIPTION
The "read-/write-keypair" logic has been outsourced to `pkarr` in https://github.com/pubky/pkarr/pull/166 , essentially by moving that code from this crate to `pkarr`.

This PR removes the outsourced code and re-uses the new methods of `pkarr`.