### PR TITLE
fix(bindings): wasm name on browser import

### DIFF
--- a/pubky-client/bindings/js/src/bin/bundle_pubky_npm.rs
+++ b/pubky-client/bindings/js/src/bin/bundle_pubky_npm.rs
@@ -23,6 +23,8 @@ fn build_wasm(target: &str) -> io::Result<ExitStatus> {
             target,
             "--out-dir",
             &format!("pkg/{}", target),
+            "--out-name",
+            "pubky",
         ])
         .output()?;
 

--- a/pubky-client/bindings/js/src/bin/patch.mjs
+++ b/pubky-client/bindings/js/src/bin/patch.mjs
@@ -10,8 +10,9 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 const cargoTomlContent = await readFile(path.join(__dirname, "../../Cargo.toml"), "utf8");
-const cargoPackageName = /\[package\]\nname = "(.*?)"/.exec(cargoTomlContent)[1]
-const name = cargoPackageName.replace(/-/g, '_')
+const pkgName = /\[package\]\nname = "(.*?)"/.exec(cargoTomlContent)[1];
+const base = pkgName.replace(/-wasm$/, "");
+const name = base.replace(/-/g, "_");
 
 const content = await readFile(path.join(__dirname, `../../pkg/nodejs/${name}.js`), "utf8");
 


### PR DESCRIPTION
I am not 100% sure this is the fix for https://pubky.app/post/w3ase343kdnbtp4y3x69qd1qyt8peyrdtkhf671ujucc9i8fge6y/0033PKNFSQM7G But I have tested it locally by using it on pubky-app and works as expected. This fix is already in release [v0.5.4](https://www.npmjs.com/package/@synonymdev/pubky/v/0.5.4)