### PR TITLE
feat(client): add convenience constructors

### DIFF
--- a/e2e/src/tests/auth.rs
+++ b/e2e/src/tests/auth.rs
@@ -12,7 +12,7 @@ async fn basic_authn() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let keypair = Keypair::random();
 
@@ -56,7 +56,7 @@ async fn disabled_user() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let keypair = Keypair::random();
     let pubky = keypair.public_key();
@@ -132,13 +132,13 @@ async fn authz() {
     // Third party app side
     let capabilities: Capabilities = "/pub/pubky.app/:rw,/pub/foo.bar/file:r".try_into().unwrap();
 
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let pubky_auth_request = client.auth_request(http_relay_url, &capabilities).unwrap();
 
     // Authenticator side
     {
-        let client = testnet.pubky_client_builder().build().unwrap();
+        let client = testnet.pubky_client();
 
         client
             .signup(&keypair, &server.public_key(), None)
@@ -197,7 +197,7 @@ async fn multiple_users() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let first_keypair = Keypair::random();
     let second_keypair = Keypair::random();
@@ -257,7 +257,7 @@ async fn authz_timeout_reconnect() {
     {
         let url = pubky_auth_request.url().clone();
 
-        let client = testnet.pubky_client_builder().build().unwrap();
+        let client = testnet.pubky_client();
         client
             .signup(&keypair, &server.public_key(), None)
             .await
@@ -316,7 +316,7 @@ async fn authz_timeout_reconnect() {
 async fn test_signup_with_token() {
     // 1. Start a test homeserver with closed signups (i.e. signup tokens required)
     let mut testnet = Testnet::new().await.unwrap();
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let mut mock_dir = MockDataDir::test();
     mock_dir.config_toml.general.signup_mode = SignupMode::TokenRequired;
@@ -433,7 +433,7 @@ async fn test_republish_on_signin_not_old_enough() {
     // Setup the testnet and run a homeserver.
     let testnet = EphemeralTestnet::start().await.unwrap();
     // Create a client that will republish conditionally if a record is older than 1hr.
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let server = testnet.homeserver_suite();
     let keypair = Keypair::random();

--- a/e2e/src/tests/auth.rs
+++ b/e2e/src/tests/auth.rs
@@ -12,7 +12,7 @@ async fn basic_authn() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let keypair = Keypair::random();
 
@@ -56,7 +56,7 @@ async fn disabled_user() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let keypair = Keypair::random();
     let pubky = keypair.public_key();
@@ -132,13 +132,13 @@ async fn authz() {
     // Third party app side
     let capabilities: Capabilities = "/pub/pubky.app/:rw,/pub/foo.bar/file:r".try_into().unwrap();
 
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let pubky_auth_request = client.auth_request(http_relay_url, &capabilities).unwrap();
 
     // Authenticator side
     {
-        let client = testnet.pubky_client();
+        let client = testnet.pubky_client().unwrap();
 
         client
             .signup(&keypair, &server.public_key(), None)
@@ -197,7 +197,7 @@ async fn multiple_users() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let first_keypair = Keypair::random();
     let second_keypair = Keypair::random();
@@ -257,7 +257,7 @@ async fn authz_timeout_reconnect() {
     {
         let url = pubky_auth_request.url().clone();
 
-        let client = testnet.pubky_client();
+        let client = testnet.pubky_client().unwrap();
         client
             .signup(&keypair, &server.public_key(), None)
             .await
@@ -316,7 +316,7 @@ async fn authz_timeout_reconnect() {
 async fn test_signup_with_token() {
     // 1. Start a test homeserver with closed signups (i.e. signup tokens required)
     let mut testnet = Testnet::new().await.unwrap();
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let mut mock_dir = MockDataDir::test();
     mock_dir.config_toml.general.signup_mode = SignupMode::TokenRequired;
@@ -433,7 +433,7 @@ async fn test_republish_on_signin_not_old_enough() {
     // Setup the testnet and run a homeserver.
     let testnet = EphemeralTestnet::start().await.unwrap();
     // Create a client that will republish conditionally if a record is older than 1hr.
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let server = testnet.homeserver_suite();
     let keypair = Keypair::random();

--- a/e2e/src/tests/http.rs
+++ b/e2e/src/tests/http.rs
@@ -6,7 +6,7 @@ async fn http_get_pubky() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let response = client
         .get(format!("https://{}/", server.public_key()))
@@ -21,7 +21,7 @@ async fn http_get_pubky() {
 async fn http_get_icann() {
     let testnet = EphemeralTestnet::start().await.unwrap();
 
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let response = client
         .request(Method::GET, "https://google.com/")

--- a/e2e/src/tests/http.rs
+++ b/e2e/src/tests/http.rs
@@ -6,7 +6,7 @@ async fn http_get_pubky() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let response = client
         .get(format!("https://{}/", server.public_key()))
@@ -21,7 +21,7 @@ async fn http_get_pubky() {
 async fn http_get_icann() {
     let testnet = EphemeralTestnet::start().await.unwrap();
 
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let response = client
         .request(Method::GET, "https://google.com/")

--- a/e2e/src/tests/public.rs
+++ b/e2e/src/tests/public.rs
@@ -8,7 +8,7 @@ async fn put_get_delete() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let keypair = Keypair::random();
 
@@ -80,7 +80,7 @@ async fn put_get_delete() {
 async fn put_quota_applied() {
     // Start a test homeserver with 1 MB user data limit
     let mut testnet = Testnet::new().await.unwrap();
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let mut mock_dir = MockDataDir::test();
     mock_dir.config_toml.general.user_storage_quota_mb = 1; // 1 MB
@@ -138,7 +138,7 @@ async fn unauthorized_put_delete() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let keypair = Keypair::random();
 
@@ -152,7 +152,7 @@ async fn unauthorized_put_delete() {
     let url = format!("pubky://{public_key}/pub/foo.txt");
     let url = url.as_str();
 
-    let other_client = testnet.pubky_client_builder().build().unwrap();
+    let other_client = testnet.pubky_client();
     {
         let other = Keypair::random();
 
@@ -206,7 +206,7 @@ async fn list() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let keypair = Keypair::random();
 
@@ -412,7 +412,7 @@ async fn list_shallow() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let keypair = Keypair::random();
 
@@ -625,7 +625,7 @@ async fn list_events() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let keypair = Keypair::random();
 
@@ -656,7 +656,7 @@ async fn list_events() {
 
     let feed_url = format!("https://{}/events/", server.public_key());
 
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let cursor;
 
@@ -724,7 +724,7 @@ async fn read_after_event() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let keypair = Keypair::random();
 
@@ -741,7 +741,7 @@ async fn read_after_event() {
 
     let feed_url = format!("https://{}/events/", server.public_key());
 
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     {
         let response = client
@@ -777,7 +777,7 @@ async fn dont_delete_shared_blobs() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let homeserver = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let homeserver_pubky = homeserver.public_key();
 
@@ -853,7 +853,7 @@ async fn stream() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let keypair = Keypair::random();
 

--- a/e2e/src/tests/public.rs
+++ b/e2e/src/tests/public.rs
@@ -8,7 +8,7 @@ async fn put_get_delete() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let keypair = Keypair::random();
 
@@ -80,7 +80,7 @@ async fn put_get_delete() {
 async fn put_quota_applied() {
     // Start a test homeserver with 1 MB user data limit
     let mut testnet = Testnet::new().await.unwrap();
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let mut mock_dir = MockDataDir::test();
     mock_dir.config_toml.general.user_storage_quota_mb = 1; // 1 MB
@@ -138,7 +138,7 @@ async fn unauthorized_put_delete() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let keypair = Keypair::random();
 
@@ -152,7 +152,7 @@ async fn unauthorized_put_delete() {
     let url = format!("pubky://{public_key}/pub/foo.txt");
     let url = url.as_str();
 
-    let other_client = testnet.pubky_client();
+    let other_client = testnet.pubky_client().unwrap();
     {
         let other = Keypair::random();
 
@@ -206,7 +206,7 @@ async fn list() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let keypair = Keypair::random();
 
@@ -412,7 +412,7 @@ async fn list_shallow() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let keypair = Keypair::random();
 
@@ -625,7 +625,7 @@ async fn list_events() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let keypair = Keypair::random();
 
@@ -656,7 +656,7 @@ async fn list_events() {
 
     let feed_url = format!("https://{}/events/", server.public_key());
 
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let cursor;
 
@@ -724,7 +724,7 @@ async fn read_after_event() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let keypair = Keypair::random();
 
@@ -741,7 +741,7 @@ async fn read_after_event() {
 
     let feed_url = format!("https://{}/events/", server.public_key());
 
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     {
         let response = client
@@ -777,7 +777,7 @@ async fn dont_delete_shared_blobs() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let homeserver = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let homeserver_pubky = homeserver.public_key();
 
@@ -853,7 +853,7 @@ async fn stream() {
     let testnet = EphemeralTestnet::start().await.unwrap();
     let server = testnet.homeserver_suite();
 
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let keypair = Keypair::random();
 

--- a/e2e/src/tests/rate_limiting.rs
+++ b/e2e/src/tests/rate_limiting.rs
@@ -15,7 +15,7 @@ use tokio::time::Instant;
 #[tokio::test]
 async fn test_limit_signin_get_session() {
     let mut testnet = Testnet::new().await.unwrap();
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let mut config = ConfigToml::test();
     config.drive.rate_limits = vec![
@@ -65,7 +65,7 @@ async fn test_limit_signin_get_session() {
 async fn test_limit_signin_get_session_whitelist() {
     let keypair = Keypair::random();
     let mut testnet = Testnet::new().await.unwrap();
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let mut config = ConfigToml::test();
     let mut limit = PathLimit::new(
@@ -120,7 +120,7 @@ async fn test_limit_signin_get_session_whitelist() {
 #[tokio::test]
 async fn test_limit_events() {
     let mut testnet = Testnet::new().await.unwrap();
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let mut config = ConfigToml::test();
     config.drive.rate_limits = vec![
@@ -149,7 +149,7 @@ async fn test_limit_events() {
 #[tokio::test]
 async fn test_limit_upload() {
     let mut testnet = Testnet::new().await.unwrap();
-    let client = testnet.pubky_client_builder().build().unwrap();
+    let client = testnet.pubky_client();
 
     let mut config = ConfigToml::test();
     config.drive.rate_limits = vec![
@@ -234,7 +234,7 @@ async fn test_concurrent_write_read() {
     impl TestClient {
         fn new(testnet: &mut Testnet) -> Self {
             let keypair = Keypair::random();
-            let client = testnet.pubky_client_builder().build().unwrap();
+            let client = testnet.pubky_client();
             Self { keypair, client }
         }
         pub async fn signup(&self, hs_pubkey: &PublicKey) {

--- a/e2e/src/tests/rate_limiting.rs
+++ b/e2e/src/tests/rate_limiting.rs
@@ -15,7 +15,7 @@ use tokio::time::Instant;
 #[tokio::test]
 async fn test_limit_signin_get_session() {
     let mut testnet = Testnet::new().await.unwrap();
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let mut config = ConfigToml::test();
     config.drive.rate_limits = vec![
@@ -65,7 +65,7 @@ async fn test_limit_signin_get_session() {
 async fn test_limit_signin_get_session_whitelist() {
     let keypair = Keypair::random();
     let mut testnet = Testnet::new().await.unwrap();
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let mut config = ConfigToml::test();
     let mut limit = PathLimit::new(
@@ -120,7 +120,7 @@ async fn test_limit_signin_get_session_whitelist() {
 #[tokio::test]
 async fn test_limit_events() {
     let mut testnet = Testnet::new().await.unwrap();
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let mut config = ConfigToml::test();
     config.drive.rate_limits = vec![
@@ -149,7 +149,7 @@ async fn test_limit_events() {
 #[tokio::test]
 async fn test_limit_upload() {
     let mut testnet = Testnet::new().await.unwrap();
-    let client = testnet.pubky_client();
+    let client = testnet.pubky_client().unwrap();
 
     let mut config = ConfigToml::test();
     config.drive.rate_limits = vec![
@@ -234,7 +234,7 @@ async fn test_concurrent_write_read() {
     impl TestClient {
         fn new(testnet: &mut Testnet) -> Self {
             let keypair = Keypair::random();
-            let client = testnet.pubky_client();
+            let client = testnet.pubky_client().unwrap();
             Self { keypair, client }
         }
         pub async fn signup(&self, hs_pubkey: &PublicKey) {

--- a/examples/authn/signup.rs
+++ b/examples/authn/signup.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
 
     let homeserver = cli.homeserver;
 
-    let client = Client::builder().build()?;
+    let client = Client::default();
 
     println!("Enter your recovery_file's passphrase to signup:");
     let passphrase = rpassword::read_password()?;

--- a/examples/authn/signup.rs
+++ b/examples/authn/signup.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
 
     let homeserver = cli.homeserver;
 
-    let client = Client::default();
+    let client = Client::new()?;
 
     println!("Enter your recovery_file's passphrase to signup:");
     let passphrase = rpassword::read_password()?;

--- a/examples/authz/authenticator.rs
+++ b/examples/authz/authenticator.rs
@@ -67,7 +67,7 @@ async fn main() -> Result<()> {
     println!("PublicKey: {}", keypair.public_key());
 
     let client = if cli.testnet {
-        let client = Client::testnet();
+        let client = Client::testnet()?;
 
         // For the purposes of this demo, we need to make sure
         // the user has an account on the local homeserver.
@@ -79,7 +79,7 @@ async fn main() -> Result<()> {
 
         client
     } else {
-        Client::default()
+        Client::new()?
     };
 
     println!("Sending AuthToken to the 3rd party app...");

--- a/examples/authz/authenticator.rs
+++ b/examples/authz/authenticator.rs
@@ -67,8 +67,7 @@ async fn main() -> Result<()> {
     println!("PublicKey: {}", keypair.public_key());
 
     let client = if cli.testnet {
-        dbg!("HERE");
-        let client = Client::builder().testnet().build()?;
+        let client = Client::testnet();
 
         // For the purposes of this demo, we need to make sure
         // the user has an account on the local homeserver.
@@ -80,7 +79,7 @@ async fn main() -> Result<()> {
 
         client
     } else {
-        Client::builder().build()?
+        Client::default()
     };
 
     println!("Sending AuthToken to the 3rd party app...");

--- a/examples/request/main.rs
+++ b/examples/request/main.rs
@@ -28,9 +28,9 @@ async fn main() -> Result<()> {
         .init();
 
     let client = if args.testnet {
-        Client::testnet()
+        Client::testnet()?
     } else {
-        Client::default()
+        Client::new()?
     };
 
     // Build the request

--- a/examples/request/main.rs
+++ b/examples/request/main.rs
@@ -28,9 +28,9 @@ async fn main() -> Result<()> {
         .init();
 
     let client = if args.testnet {
-        Client::builder().testnet().build()?
+        Client::testnet()
     } else {
-        Client::builder().build()?
+        Client::default()
     };
 
     // Build the request

--- a/pubky-client/README.md
+++ b/pubky-client/README.md
@@ -12,7 +12,7 @@ use pubky::Keypair;
 async fn main () {
   // Mainline Dht testnet and a temporary homeserver for unit testing.
   let testnet = EphemeralTestnet::start().await.unwrap();
-  let client = testnet.pubky_client_builder().build().unwrap();
+  let client = testnet.pubky_client();
 
   let homeserver = testnet.homeserver_suite();
 

--- a/pubky-client/README.md
+++ b/pubky-client/README.md
@@ -12,7 +12,7 @@ use pubky::Keypair;
 async fn main () {
   // Mainline Dht testnet and a temporary homeserver for unit testing.
   let testnet = EphemeralTestnet::start().await.unwrap();
-  let client = testnet.pubky_client();
+  let client = testnet.pubky_client().unwrap();
 
   let homeserver = testnet.homeserver_suite();
 

--- a/pubky-client/src/client.rs
+++ b/pubky-client/src/client.rs
@@ -24,7 +24,7 @@ pub struct ClientBuilder {
 impl ClientBuilder {
     #[cfg(not(target_arch = "wasm32"))]
     /// Creates a client connected to a local test network using `localhost`.
-    /// To use a custom host, see `testnet_with_host`.
+    /// To use a custom host, use `testnet_with_host`.
     pub fn testnet(&mut self) -> &mut Self {
         self.testnet_with_host("localhost")
     }
@@ -183,11 +183,36 @@ impl Client {
         builder
     }
 
+    /// Creates a client configured to use testnet DHT and Pkarr relays running on `localhost`.
+    /// You need an instance of `pubky-testnet` running on `localhost`
+    pub fn testnet() -> Self {
+        let mut builder = Self::builder();
+
+        #[cfg(not(target_arch = "wasm32"))]
+        builder.testnet();
+
+        #[cfg(target_arch = "wasm32")]
+        builder.testnet_host("localhost".to_string());
+
+        builder
+            .build()
+            .expect("Default testnet client should build")
+    }
+
     // === Getters ===
 
     /// Returns a reference to the internal Pkarr Client.
     pub fn pkarr(&self) -> &pkarr::Client {
         &self.pkarr
+    }
+}
+
+impl Default for Client {
+    /// Creates a client configured for public mainline DHT and pkarr relays.
+    fn default() -> Self {
+        Self::builder()
+            .build()
+            .expect("Default mainnet client should build")
     }
 }
 

--- a/pubky-client/src/client.rs
+++ b/pubky-client/src/client.rs
@@ -176,6 +176,11 @@ pub struct Client {
 }
 
 impl Client {
+    /// Creates a client configured for public mainline DHT and pkarr relays.
+    pub fn new() -> Result<Client, BuildError> {
+        Self::builder().build()
+    }
+
     /// Returns a builder to edit settings before creating [Client].
     pub fn builder() -> ClientBuilder {
         let mut builder = ClientBuilder::default();
@@ -185,7 +190,7 @@ impl Client {
 
     /// Creates a client configured to use testnet DHT and Pkarr relays running on `localhost`.
     /// You need an instance of `pubky-testnet` running on `localhost`
-    pub fn testnet() -> Self {
+    pub fn testnet() -> Result<Client, BuildError> {
         let mut builder = Self::builder();
 
         #[cfg(not(target_arch = "wasm32"))]
@@ -194,9 +199,7 @@ impl Client {
         #[cfg(target_arch = "wasm32")]
         builder.testnet_host("localhost".to_string());
 
-        builder
-            .build()
-            .expect("Default testnet client should build")
+        builder.build()
     }
 
     // === Getters ===
@@ -207,22 +210,13 @@ impl Client {
     }
 }
 
-impl Default for Client {
-    /// Creates a client configured for public mainline DHT and pkarr relays.
-    fn default() -> Self {
-        Self::builder()
-            .build()
-            .expect("Default mainnet client should build")
-    }
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
 
     #[tokio::test]
     async fn test_fetch() {
-        let client = Client::builder().build().unwrap();
+        let client = Client::new().unwrap();
         let response = client.get("https://google.com/").send().await.unwrap();
         assert_eq!(response.status(), 200);
     }

--- a/pubky-testnet/README.md
+++ b/pubky-testnet/README.md
@@ -18,7 +18,7 @@ async fn main () {
   let testnet = EphemeralTestnet::start().await.unwrap();
 
   // Create a Pubky Client from the testnet.
-  let client = testnet.pubky_client_builder().build().unwrap();
+  let client = testnet.pubky_client();
 
   // Use the homeserver
   let homeserver = testnet.homeserver_suite();
@@ -33,6 +33,6 @@ async fn main () {
 If you need to run the testnet in a separate process, for example to test Pubky Core in browsers, you need to run this binary, which will create these components with hardcoded configurations:
 
 1. A local DHT with bootstrapping nodes: `&["localhost:6881"]`
-3. A Pkarr Relay running on port [15411](pubky_common::constants::testnet_ports::PKARR_RELAY)
-2. A Homeserver with address is hardcoded to `8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo`
+2. A Pkarr Relay running on port [15411](pubky_common::constants::testnet_ports::PKARR_RELAY)
+3. A Homeserver with address is hardcoded to `8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo`
 4. An HTTP relay running on port [15412](pubky_common::constants::testnet_ports::HTTP_RELAY)

--- a/pubky-testnet/README.md
+++ b/pubky-testnet/README.md
@@ -18,7 +18,7 @@ async fn main () {
   let testnet = EphemeralTestnet::start().await.unwrap();
 
   // Create a Pubky Client from the testnet.
-  let client = testnet.pubky_client();
+  let client = testnet.pubky_client().unwrap();
 
   // Use the homeserver
   let homeserver = testnet.homeserver_suite();

--- a/pubky-testnet/src/ephemeral_testnet.rs
+++ b/pubky-testnet/src/ephemeral_testnet.rs
@@ -32,7 +32,7 @@ impl EphemeralTestnet {
     }
 
     /// Creates a `pubky::Client` pre-configured to use this test network.
-    pub fn pubky_client(&self) -> pubky::Client {
+    pub fn pubky_client(&self) -> Result<pubky::Client, pubky::BuildError> {
         self.testnet.pubky_client()
     }
 

--- a/pubky-testnet/src/ephemeral_testnet.rs
+++ b/pubky-testnet/src/ephemeral_testnet.rs
@@ -31,6 +31,11 @@ impl EphemeralTestnet {
         self.testnet.pubky_client_builder()
     }
 
+    /// Creates a `pubky::Client` pre-configured to use this test network.
+    pub fn pubky_client(&self) -> pubky::Client {
+        self.testnet.pubky_client()
+    }
+
     /// Create a new pkarr client builder.
     pub fn pkarr_client_builder(&self) -> pkarr::ClientBuilder {
         self.testnet.pkarr_client_builder()

--- a/pubky-testnet/src/static_testnet.rs
+++ b/pubky-testnet/src/static_testnet.rs
@@ -72,7 +72,7 @@ impl StaticTestnet {
     }
 
     /// Creates a `pubky::Client` pre-configured to use this test network.
-    pub fn pubky_client(&self) -> pubky::Client {
+    pub fn pubky_client(&self) -> Result<pubky::Client, pubky::BuildError> {
         self.testnet.pubky_client()
     }
 

--- a/pubky-testnet/src/static_testnet.rs
+++ b/pubky-testnet/src/static_testnet.rs
@@ -71,6 +71,12 @@ impl StaticTestnet {
         self.testnet.pubky_client_builder()
     }
 
+    /// Creates a `pubky::Client` pre-configured to use this test network.
+    pub fn pubky_client(&self) -> pubky::Client {
+        self.testnet.pubky_client()
+    }
+
+    /// Create a new pkarr client builder.
     pub fn pkarr_client_builder(&self) -> pkarr::ClientBuilder {
         self.testnet.pkarr_client_builder()
     }

--- a/pubky-testnet/src/testnet.rs
+++ b/pubky-testnet/src/testnet.rs
@@ -151,6 +151,19 @@ impl Testnet {
         builder
     }
 
+    /// Creates a `pubky::Client` pre-configured to use this test network.
+    ///
+    /// This is a convenience method that builds a client from `Self::pubky_client_builder`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the client fails to build, which should not happen in a test context.
+    pub fn pubky_client(&self) -> pubky::Client {
+        self.pubky_client_builder()
+            .build()
+            .expect("Building pubky client in testnet should not fail")
+    }
+
     /// Create a [pkarr::ClientBuilder] and configure it to use this local test network.
     pub fn pkarr_client_builder(&self) -> pkarr::ClientBuilder {
         let relays = self.dht_relay_urls();

--- a/pubky-testnet/src/testnet.rs
+++ b/pubky-testnet/src/testnet.rs
@@ -158,10 +158,8 @@ impl Testnet {
     /// # Panics
     ///
     /// Panics if the client fails to build, which should not happen in a test context.
-    pub fn pubky_client(&self) -> pubky::Client {
-        self.pubky_client_builder()
-            .build()
-            .expect("Building pubky client in testnet should not fail")
+    pub fn pubky_client(&self) -> Result<pubky::Client, pubky::BuildError> {
+        self.pubky_client_builder().build()
     }
 
     /// Create a [pkarr::ClientBuilder] and configure it to use this local test network.


### PR DESCRIPTION
This PR re-introduces two convenience methods for instantiating the `pubky::Client`, improving the developer experience by providing clear, idiomatic entry points for the most common use cases.

```rust
// Creates a client configured for public mainline DHT and pkarr relays.
let client = pubky::Client::default();
```

```rust
// Creates a client configured to talk to a local testnet running on `localhost`.
let client = pubky::Client::testnet();
```

**Why This Change?**
Previously, creating a client required using the builder pattern even for the most standard configurations. While the builder is powerful for custom setups, it adds unnecessary boilerplate for simple use cases. These two methods used to be available in very early versions of `pubky-client` crate.

Also updated **examples**, **pubky-testnet** (new convenience method to create clients), and **e2e** tests.