### PR TITLE
Feat/pubky host url

### DIFF
--- a/e2e/src/tests/public.rs
+++ b/e2e/src/tests/public.rs
@@ -49,12 +49,7 @@ async fn put_get_delete() {
     // We set `non.pubky.host` header as otherwise he client will use by default
     // the homeserver pubky as host and this request will resolve the `/pub/foo.txt` of
     // the wrong tenant user
-    let response = client
-        .get(regular_url)
-        .header("Host", "non.pubky.host")
-        .send()
-        .await
-        .unwrap();
+    let response = client.get(regular_url).send().await.unwrap();
 
     let content_header = response.headers().get("content-type").unwrap();
     // Tests if MIME type was inferred correctly from the file path (magic bytes do not work)

--- a/pubky-client/bindings/js/src/api/http.rs
+++ b/pubky-client/bindings/js/src/api/http.rs
@@ -3,7 +3,7 @@
 use js_sys::Promise;
 use url::Url;
 use wasm_bindgen::prelude::*;
-use web_sys::{Headers, Request, RequestInit, ServiceWorkerGlobalScope};
+use web_sys::{Request, RequestInit, ServiceWorkerGlobalScope};
 
 use crate::constructor::Client;
 use crate::js_result::JsResult;
@@ -15,11 +15,12 @@ impl Client {
         // 1. parse
         let mut url = Url::parse(url).map_err(|e| JsValue::from_str(&e.to_string()))?;
         let req_init = init.unwrap_or_default();
-        // 2. add pubky-host header if needed
+
+        // 2. add pubky-host query string if needed
         if let Some(host) = self.0.prepare_request(&mut url).await {
-            let headers = Headers::new()?;
-            headers.append("pubky-host", &host)?;
-            req_init.set_headers(&headers.into());
+            if url.query_pairs().any(|(k, _)| k != "pubky-host") {
+                url.query_pairs_mut().append_pair("pubky-host", &host);
+            };
         }
         // 3. build JS Request
         let js_req = Request::new_with_str_and_init(url.as_str(), &req_init)

--- a/pubky-client/src/api/http.rs
+++ b/pubky-client/src/api/http.rs
@@ -152,9 +152,10 @@ impl Client {
         let mut url = Url::parse(original_url).expect("Invalid url in inner_request");
 
         if let Some(pubky_host) = self.prepare_request(&mut url).await {
+            url.query_pairs_mut().append_pair("pubky-host", &pubky_host);
+
             self.http
                 .request(method, url.clone())
-                .header::<&str, &str>("pubky-host", &pubky_host)
                 .fetch_credentials_include()
         } else {
             self.http

--- a/pubky-homeserver/src/core/layers/pubky_host.rs
+++ b/pubky-homeserver/src/core/layers/pubky_host.rs
@@ -50,7 +50,7 @@ where
 
 /// Extracts a PublicKey from the query parameter "pubky-host".
 fn extract_pubky(req: &Request<Body>) -> Option<PublicKey> {
-    req.uri().query().and_then(|query| {
+    let pubky = req.uri().query().and_then(|query| {
         query.split('&').find_map(|pair| {
             let mut parts = pair.splitn(2, '=');
             if let (Some(key), Some(val)) = (parts.next(), parts.next()) {
@@ -60,5 +60,7 @@ fn extract_pubky(req: &Request<Body>) -> Option<PublicKey> {
             }
             None
         })
-    })
+    });
+
+    pubky
 }

--- a/pubky-homeserver/src/core/layers/pubky_host.rs
+++ b/pubky-homeserver/src/core/layers/pubky_host.rs
@@ -50,7 +50,7 @@ where
 
 /// Extracts a PublicKey from the query parameter "pubky-host".
 fn extract_pubky(req: &Request<Body>) -> Option<PublicKey> {
-    let pubky = req.uri().query().and_then(|query| {
+    req.uri().query().and_then(|query| {
         query.split('&').find_map(|pair| {
             let mut parts = pair.splitn(2, '=');
             if let (Some(key), Some(val)) = (parts.next(), parts.next()) {
@@ -60,7 +60,5 @@ fn extract_pubky(req: &Request<Body>) -> Option<PublicKey> {
             }
             None
         })
-    });
-
-    pubky
+    })
 }

--- a/pubky-homeserver/src/core/routes/tenants/read.rs
+++ b/pubky-homeserver/src/core/routes/tenants/read.rs
@@ -205,7 +205,7 @@ mod tests {
 
         server
             .put("/pub/foo")
-            .add_header("host", public_key.to_string())
+            .add_query_param("pubky-host", public_key.to_string())
             .add_header(header::COOKIE, cookie)
             .bytes(data.into())
             .expect_success()
@@ -213,13 +213,13 @@ mod tests {
 
         let response = server
             .get("/pub/foo")
-            .add_header("host", public_key.to_string())
+            .add_query_param("pubky-host", public_key.to_string())
             .expect_success()
             .await;
 
         let response = server
             .get("/pub/foo")
-            .add_header("host", public_key.to_string())
+            .add_query_param("pubky-host", public_key.to_string())
             .add_header(
                 header::IF_MODIFIED_SINCE,
                 response.headers().get(header::LAST_MODIFIED).unwrap(),
@@ -237,7 +237,7 @@ mod tests {
 
         server
             .put("/pub/foo")
-            .add_header("host", public_key.to_string())
+            .add_query_param("pubky-host", public_key.to_string())
             .add_header(header::COOKIE, cookie)
             .bytes(data.into())
             .expect_success()
@@ -245,13 +245,13 @@ mod tests {
 
         let response = server
             .get("/pub/foo")
-            .add_header("host", public_key.to_string())
+            .add_query_param("pubky-host", public_key.to_string())
             .expect_success()
             .await;
 
         let response = server
             .get("/pub/foo")
-            .add_header("host", public_key.to_string())
+            .add_query_param("pubky-host", public_key.to_string())
             .add_header(
                 header::IF_NONE_MATCH,
                 response.headers().get(header::ETAG).unwrap(),
@@ -269,7 +269,7 @@ mod tests {
 
         server
             .put("/pub/foo")
-            .add_header("host", public_key.to_string())
+            .add_query_param("pubky-host", public_key.to_string())
             .add_header(header::COOKIE, cookie)
             .bytes(data.into())
             .expect_success()
@@ -277,7 +277,7 @@ mod tests {
 
         let response = server
             .get("/pub/foo")
-            .add_header("host", public_key.to_string())
+            .add_query_param("pubky-host", public_key.to_string())
             .await;
 
         response.assert_header(header::CONTENT_TYPE, "image/png");
@@ -291,7 +291,7 @@ mod tests {
 
         server
             .put("/pub/text.txt")
-            .add_header("host", public_key.to_string())
+            .add_query_param("pubky-host", public_key.to_string())
             .add_header(header::COOKIE, cookie)
             .bytes(data.into())
             .expect_success()
@@ -299,7 +299,7 @@ mod tests {
 
         let response = server
             .get("/pub/text.txt")
-            .add_header("host", public_key.to_string())
+            .add_query_param("pubky-host", public_key.to_string())
             .await;
 
         response.assert_header(header::CONTENT_TYPE, "text/plain");


### PR DESCRIPTION
Support `host` only as a query string.

For more details see https://github.com/pubky/pubky-core/issues/216


## BREAKING CHANGE:
Requires updates in following order:
1. client 
2. homeserver