### PR TITLE
Fix Android storage handling for the homeserver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,6 +722,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,6 +828,16 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -1658,6 +1674,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2332,6 +2354,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "java-locator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c46c1fe465c59b1474e665e85e1256c3893dd00927b8d55f63b09044c1e64f"
+dependencies = [
+ "glob",
+]
+
+[[package]]
+name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "java-locator",
+ "jni-sys",
+ "libloading",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "js-sys"
 version = "0.3.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2416,6 +2471,16 @@ name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
 
 [[package]]
 name = "libm"
@@ -2639,6 +2704,12 @@ dependencies = [
  "security-framework-sys",
  "tempfile",
 ]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -3378,7 +3449,9 @@ dependencies = [
  "hostname-validator",
  "httpdate",
  "infer",
+ "jni",
  "mime_guess",
+ "ndk-context",
  "opendal",
  "page_size",
  "percent-encoding",
@@ -5402,6 +5475,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5434,6 +5516,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
 dependencies = [
  "windows-link 0.2.0",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -5489,6 +5586,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5501,6 +5604,12 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5510,6 +5619,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5537,6 +5652,12 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5546,6 +5667,12 @@ name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5561,6 +5688,12 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5570,6 +5703,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/pubky-homeserver/Cargo.toml
+++ b/pubky-homeserver/Cargo.toml
@@ -66,6 +66,10 @@ mime_guess = "2.0.5"
 dav-server-opendalfs = "0.6.2"
 dav-server = "0.8.0"
 
+[target.'cfg(target_os = "android")'.dependencies]
+jni = { version = "0.21.1", features = ["invocation"] }
+ndk-context = "0.1.1"
+
 
 [dev-dependencies]
 futures-lite = "2.6.0"

--- a/pubky-homeserver/README.md
+++ b/pubky-homeserver/README.md
@@ -78,7 +78,7 @@ async fn main() -> anyhow::Result<()> {
 
 ### Binary
 
-Use `cargo run -- --data-dir=~/.pubky`.
+Use `cargo run -- --data-dir=~/.pubky` on desktop platforms. Mobile builds default to the sandboxed application storage.
 
 ## Signup Token
 

--- a/pubky-homeserver/src/data_directory/mock_data_dir.rs
+++ b/pubky-homeserver/src/data_directory/mock_data_dir.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use super::DataDir;
+use crate::platform;
 
 /// Mock data directory for testing.
 ///
@@ -26,7 +27,7 @@ impl MockDataDir {
     ) -> anyhow::Result<Self> {
         let keypair = keypair.unwrap_or_else(pkarr::Keypair::random);
         Ok(Self {
-            temp_dir: std::sync::Arc::new(tempfile::TempDir::new()?),
+            temp_dir: std::sync::Arc::new(platform::create_temp_dir("pubky-mock")?),
             config_toml,
             keypair,
         })

--- a/pubky-homeserver/src/data_directory/persistent_data_dir.rs
+++ b/pubky-homeserver/src/data_directory/persistent_data_dir.rs
@@ -1,4 +1,5 @@
 use super::{data_dir::DataDir, ConfigToml};
+use crate::platform;
 
 use std::{
     io::Write,
@@ -21,6 +22,12 @@ impl PersistentDataDir {
         Self {
             expanded_path: Self::expand_home_dir(path),
         }
+    }
+
+    /// Returns the default path for persistent homeserver data on the current
+    /// platform.
+    pub fn default_path() -> PathBuf {
+        platform::default_data_dir_path()
     }
 
     /// Expands the data directory to the home directory if it starts with "~".
@@ -65,7 +72,7 @@ impl PersistentDataDir {
 
 impl Default for PersistentDataDir {
     fn default() -> Self {
-        Self::new(PathBuf::from("~/.pubky"))
+        Self::new(Self::default_path())
     }
 }
 

--- a/pubky-homeserver/src/lib.rs
+++ b/pubky-homeserver/src/lib.rs
@@ -18,6 +18,8 @@ mod core;
 mod data_directory;
 mod homeserver_suite;
 mod persistence;
+/// Platform-specific helpers such as filesystem paths and temporary storage.
+pub mod platform;
 mod shared;
 pub mod tracing;
 

--- a/pubky-homeserver/src/main.rs
+++ b/pubky-homeserver/src/main.rs
@@ -2,10 +2,10 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::Parser;
-use pubky_homeserver::{tracing::init_tracing_logs_if_set, HomeserverSuite};
+use pubky_homeserver::{tracing::init_tracing_logs_if_set, HomeserverSuite, PersistentDataDir};
 
 fn default_config_dir_path() -> PathBuf {
-    dirs::home_dir().unwrap_or_default().join(".pubky")
+    PersistentDataDir::default_path()
 }
 
 /// Validate that the data_dir path is a directory.
@@ -21,7 +21,7 @@ fn validate_config_dir_path(path: &str) -> Result<PathBuf, String> {
 #[derive(Parser, Debug)]
 #[command(version = env!("CARGO_PKG_VERSION"))]
 struct Cli {
-    /// Path to config file. Defaults to ~/.pubky/config.toml
+    /// Path to config file. Defaults to the platform-specific Pubky data directory.
     #[clap(short, long, default_value_os_t = default_config_dir_path(), value_parser = validate_config_dir_path)]
     data_dir: PathBuf,
 }

--- a/pubky-homeserver/src/platform/android.rs
+++ b/pubky-homeserver/src/platform/android.rs
@@ -1,0 +1,61 @@
+use std::{mem, path::PathBuf, ptr::NonNull};
+
+use anyhow::{Context, Result};
+use jni::{
+    objects::{JObject, JString},
+    JavaVM,
+};
+
+fn with_activity<F, R>(f: F) -> Result<R>
+where
+    F: FnOnce(&mut jni::JNIEnv<'_>, &JObject<'_>) -> Result<R>,
+{
+    let context = ndk_context::android_context();
+    let vm_ptr = NonNull::new(context.vm().cast()).context("Android VM pointer is null")?;
+    let activity_ptr =
+        NonNull::new(context.context().cast()).context("Android activity pointer is null")?;
+
+    let vm = unsafe { JavaVM::from_raw(vm_ptr.as_ptr()) }?;
+    let mut env = vm.attach_current_thread()?;
+
+    // SAFETY: The activity pointer is managed by the Android runtime and
+    // remains valid for the entire process lifetime. We purposely avoid
+    // releasing the reference when the JObject is dropped.
+    let activity = unsafe { JObject::from_raw(activity_ptr.as_ptr()) };
+    let result = f(&mut env, &activity);
+    mem::forget(activity);
+    result
+}
+
+fn dir_from_method(
+    env: &mut jni::JNIEnv<'_>,
+    activity: &JObject<'_>,
+    method: &str,
+) -> Result<PathBuf> {
+    let dir = env
+        .call_method(activity, method, "()Ljava/io/File;", &[])
+        .with_context(|| format!("calling {method}()"))?
+        .l()
+        .context("expected java.io.File from method")?;
+    let absolute_path: JString = env
+        .call_method(dir, "getAbsolutePath", "()Ljava/lang/String;", &[])
+        .context("calling getAbsolutePath()")?
+        .l()
+        .context("expected java.lang.String from getAbsolutePath()")?
+        .into();
+    let path: String = env
+        .get_string(&absolute_path)
+        .context("converting Java string to Rust string")?
+        .into();
+    Ok(PathBuf::from(path))
+}
+
+/// Returns the Android application's internal files directory.
+pub fn app_files_dir() -> Result<PathBuf> {
+    with_activity(|env, activity| dir_from_method(env, activity, "getFilesDir"))
+}
+
+/// Returns the Android application's cache directory.
+pub fn app_cache_dir() -> Result<PathBuf> {
+    with_activity(|env, activity| dir_from_method(env, activity, "getCacheDir"))
+}

--- a/pubky-homeserver/src/platform/mod.rs
+++ b/pubky-homeserver/src/platform/mod.rs
@@ -1,0 +1,57 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+
+#[cfg(target_os = "android")]
+mod android;
+#[cfg(target_os = "android")]
+pub use android::{app_cache_dir, app_files_dir};
+
+/// Compute the default data directory used by the homeserver.
+///
+/// On mobile platforms like Android we need to store data in the app's
+/// sandboxed storage. Desktop platforms continue to use the user's home
+/// directory.
+pub fn default_data_dir_path() -> PathBuf {
+    #[cfg(target_os = "android")]
+    {
+        match app_files_dir() {
+            Ok(mut dir) => {
+                dir.push("pubky");
+                return dir;
+            }
+            Err(error) => {
+                tracing::warn!(?error, "Falling back to home directory for data storage");
+            }
+        }
+    }
+
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".pubky")
+}
+
+/// Create a temporary directory that is valid for the current platform.
+///
+/// Android applications cannot access the global `/tmp` directory, so tests and
+/// helper utilities must place their temporary data inside the app's sandbox.
+/// Desktop platforms keep using the OS default temporary location.
+pub fn create_temp_dir(prefix: &str) -> Result<tempfile::TempDir> {
+    let mut builder = tempfile::Builder::new();
+    builder.prefix(prefix);
+
+    #[cfg(target_os = "android")]
+    {
+        match app_cache_dir() {
+            Ok(base) => {
+                std::fs::create_dir_all(&base)?;
+                return Ok(builder.tempdir_in(base)?);
+            }
+            Err(error) => {
+                tracing::warn!(?error, "Falling back to default temporary directory");
+            }
+        }
+    }
+
+    Ok(builder.tempdir()?)
+}

--- a/pubky-testnet/src/static_testnet.rs
+++ b/pubky-testnet/src/static_testnet.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::Testnet;
 use http_relay::HttpRelay;
 use pubky::Pubky;
-use pubky_homeserver::{ConfigToml, DomainPort, HomeserverSuite, MockDataDir};
+use pubky_homeserver::{platform, ConfigToml, DomainPort, HomeserverSuite, MockDataDir};
 
 /// A simple testnet with
 ///
@@ -157,7 +157,7 @@ impl StaticTestnet {
 
     /// Creates a fixed pkarr relay on port 15411 with a temporary storage directory.
     async fn run_fixed_pkarr_relays(&mut self) -> anyhow::Result<()> {
-        let temp_dir = tempfile::tempdir()?; // Gets cleaned up automatically when it drops
+        let temp_dir = platform::create_temp_dir("pubky-pkarr-static")?; // Gets cleaned up automatically when it drops
         let mut builder = pkarr_relay::Relay::builder();
         builder
             .http_port(15411)

--- a/pubky-testnet/src/testnet.rs
+++ b/pubky-testnet/src/testnet.rs
@@ -10,7 +10,8 @@ use anyhow::Result;
 use http_relay::HttpRelay;
 use pubky::{Keypair, Pubky};
 use pubky_homeserver::{
-    storage_config::StorageConfigToml, ConfigToml, DomainPort, HomeserverSuite, MockDataDir,
+    platform, storage_config::StorageConfigToml, ConfigToml, DomainPort, HomeserverSuite,
+    MockDataDir,
 };
 use url::Url;
 
@@ -97,7 +98,7 @@ impl Testnet {
     ///
     /// You can access the list of relays at [Self::pkarr_relays].
     pub async fn create_pkarr_relay(&mut self) -> Result<Url> {
-        let dir = tempfile::tempdir()?;
+        let dir = platform::create_temp_dir("pubky-pkarr")?;
         let mut builder = pkarr_relay::Relay::builder();
         builder
             .disable_rate_limiter()


### PR DESCRIPTION
## Summary
- add platform-specific filesystem helpers and Android-only dependencies so the homeserver stores data inside the sandbox on Android
- use the new helpers from persistent/mock data dirs and the testnet harness to create writable directories on Android
- document the platform-aware defaults for the CLI and README

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68ec6e5cdf188329843560b0cc26cf3e