### PR TITLE
[Postgres] Prepend docker.io to postgres image names

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -46,7 +46,7 @@ jobs:
   test:
     services:
       postgres:
-        image: postgres:17-alpine          # official image
+        image: docker.io/postgres:17-alpine          # official image
         env:
           POSTGRES_USER: test_user
           POSTGRES_PASSWORD: test_pass
@@ -155,7 +155,7 @@ jobs:
   wasm-test:
     services:
       postgres:
-        image: postgres:17-alpine          # official image
+        image: docker.io/postgres:17-alpine          # official image
         env:
           POSTGRES_USER: test_user
           POSTGRES_PASSWORD: test_pass

--- a/docs/DEV_TESTING_GUIDES.md
+++ b/docs/DEV_TESTING_GUIDES.md
@@ -13,7 +13,7 @@ docker run --name postgres \
   -e POSTGRES_PASSWORD=postgres \
   -e POSTGRES_DB=pubky_homeserver \
   -p 5432:5432 \
-  -d postgres:17
+  -d docker.io/postgres:17
 ```
 
 This command creates a postgres container and also automatically creates the `pubky_homeserver` database. Use this connection string in the homeserver config:

--- a/pubky-testnet/README.md
+++ b/pubky-testnet/README.md
@@ -13,7 +13,7 @@ docker run --name postgres \
   -e POSTGRES_USER=postgres \
   -e POSTGRES_PASSWORD=postgres \
   -e POSTGRES_DB=pubky_homeserver \
-  -p 5432:5432 -d postgres:17
+  -p 5432:5432 -d docker.io/postgres:17
 
 # Run the testnet binary (all resources ephemeral). The environment variable must point to the postgres admin database.
 TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres' cargo run -p pubky-testnet


### PR DESCRIPTION
This PR fully specifies the `postgres` image by prepending `docker.io/` to its name.

This indicates the registry hostname where the image should be pulled from.

Removing the registry ambiguity is helpful for systems that don't default to the docker registry: maybe they run `podman` instead of `docker`, or otherwise have multiple registries configured.