### PR TITLE
[Postgres] Fix DB connection URL typo

### DIFF
--- a/docs/DEV_TESTING_GUIDES.md
+++ b/docs/DEV_TESTING_GUIDES.md
@@ -20,7 +20,7 @@ This command creates a postgres container and also automatically creates the `pu
 
 ```toml
 [general]
-database_url = "postgres://postgres@postgres@localhost:5432/pubky_homeserver"
+database_url = "postgres://postgres:postgres@localhost:5432/pubky_homeserver"
 ```
 
 [pgadmin](https://www.pgadmin.org/) is a great explorer to inspect database values.
@@ -41,6 +41,6 @@ sudo -u postgres psql -c 'create database pubky_homeserver;'
 If compiled with the `testing` feature, `?pubky-test=true` can be added to the database url.
 This way, an empheral test database is created and dropped after the test.
 
-**Example** `postgres://postgres@postgres@localhost:5432/postgres?pubky-test=true` For each test, the homeserver will connect to the 
+**Example** `postgres://postgres:postgres@localhost:5432/postgres?pubky-test=true` For each test, the homeserver will connect to the 
 specified database (postgres in this case) and create a new test database. With the `#[pubky_test_utils::test]` macro, the test database is
 dropped again after the test completes/panics.


### PR DESCRIPTION
In a few places, the DB connection URL specified the test user and password as `user@password` instead of `user:password`.

This PR fixes those typos.