### PR TITLE
fix: feed cursor empty when no file

### DIFF
--- a/pubky-homeserver/src/core/routes/feed.rs
+++ b/pubky-homeserver/src/core/routes/feed.rs
@@ -34,9 +34,7 @@ pub async fn feed(
         .iter()
         .map(|event| format!("{} pubky://{}", event.event_type, event.path.as_str()))
         .collect::<Vec<String>>();
-    let next_cursor = events
-        .last()
-        .map(|event| event.id.to_string());
+    let next_cursor = events.last().map(|event| event.id.to_string());
 
     if let Some(next_cursor) = next_cursor {
         result.push(format!("cursor: {}", next_cursor));


### PR DESCRIPTION
Nexus shows an invalid event line. Turns out this is a bug that came with the postgres PR. A cursor was added to the response even if there is no next page. In this case, the cursor was empty like `cursor:`.

```
nexusd       | 2025-11-14T11:43:07.565563Z DEBUG nexus_watcher::service::processor:63: Polling new events from homeserver
nexusd       | 2025-11-14T11:43:07.565627Z DEBUG hyper_util::client::legacy::pool:269: reuse idle connection for ("https", 8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo)
nexusd       | 2025-11-14T11:43:07.566511Z DEBUG hyper_util::client::legacy::pool:395: pooling idle connection for ("https", 8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo)
nexusd       | 2025-11-14T11:43:07.566544Z DEBUG nexus_watcher::service::processor:85: Homeserver response lines ["cursor:"]
nexusd       | 2025-11-14T11:43:07.566551Z  INFO nexus_watcher::service::processor:46: Processing 1 event lines
nexusd       | 2025-11-14T11:43:07.566552Z DEBUG nexus_watcher::events:43: New event: cursor:
nexusd       | 2025-11-14T11:43:07.566554Z ERROR nexus_watcher::service::processor:118: InvalidEventLine: Malformed event line, cursor:
```

This PR fixes this by remove the cursor in case there is not next page.

FYI: @catch-21 
