### PR TITLE
chore: set mdbook version explicitly

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,24 +17,24 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.cargo/bin/mdbook
-          key: ${{ runner.os }}-mdbook
+          key: ${{ runner.os }}-mdbook-0.5.1
 
       - name: Cache mdbook-mermaid installation
         uses: actions/cache@v3
         with:
-          path: ~/.cargo/bin/mdbook
-          key: ${{ runner.os }}-mdbook-mermaid
+          path: ~/.cargo/bin/mdbook-mermaid
+          key: ${{ runner.os }}-mdbook-mermaid-0.17.0
 
       - name: Install mdBook if not installed already
         run: |
           if [ ! -f ~/.cargo/bin/mdbook ]; then
-            cargo install mdbook
+            cargo install mdbook --version ^0.5
           fi
 
       - name: Install mdBook-mermaid if not installed already
         run: |
           if [ ! -f ~/.cargo/bin/mdbook-mermaid ]; then
-            cargo install mdbook-mermaid
+            cargo install mdbook-mermaid --version ^0.17
           fi
 
       - name: Cache mdBook build

--- a/docs/mdbook/book.toml
+++ b/docs/mdbook/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["nuh.dev"]
 language = "en"
-multilingual = false
 src = "src"
 title = "Pubky"
 


### PR DESCRIPTION
Cached mdbook is a different version to the latest which `cargo isntall mdbook` installs. This PR sets consistent behavior between pipeline and local builds.

The motivation for this was to resolve these failures were seeing on merge - https://github.com/pubky/pubky-core/actions/runs/19637265165/job/56231021650