### PR TITLE
feat: Make admin server optional

### DIFF
--- a/e2e/src/tests/auth.rs
+++ b/e2e/src/tests/auth.rs
@@ -57,7 +57,10 @@ async fn disabled_user() {
     );
 
     // Disable the user via admin API
-    let admin_socket = server.admin_server().listen_socket();
+    let admin_socket = server
+        .admin_server()
+        .expect("admin server should be enabled")
+        .listen_socket();
     let admin_client = PubkyHttpClient::new().unwrap();
 
     // Disable the user
@@ -328,7 +331,12 @@ async fn signup_with_token() {
     );
 
     // 3. Call the admin endpoint to generate a valid signup token.
-    let valid_token = server.admin_server().create_signup_token().await.unwrap();
+    let valid_token = server
+        .admin_server()
+        .expect("admin server should be enabled")
+        .create_signup_token()
+        .await
+        .unwrap();
 
     // 4. Now signup with the valid token. Expect success and a session back.
     let session = signer

--- a/e2e/src/tests/metrics.rs
+++ b/e2e/src/tests/metrics.rs
@@ -50,7 +50,7 @@ async fn metrics_comprehensive() {
     use eventsource_stream::Eventsource;
     use futures::StreamExt;
 
-    use pubky_testnet::pubky_homeserver::{ConfigToml, MetricsToml, MockDataDir};
+    use pubky_testnet::pubky_homeserver::{ConfigToml, MockDataDir};
     use std::net::SocketAddr;
 
     // TODO: Modify pubky_testnet to optionally take a custom Config
@@ -58,9 +58,8 @@ async fn metrics_comprehensive() {
     testnet.create_http_relay().await.unwrap();
 
     let mut config = ConfigToml::default_test_config();
-    config.metrics = Some(MetricsToml {
-        listen_socket: SocketAddr::from(([127, 0, 0, 1], 0)),
-    });
+    config.metrics.enabled = true;
+    config.metrics.listen_socket = SocketAddr::from(([127, 0, 0, 1], 0));
     let mock_dir = MockDataDir::new(config, Some(Keypair::from_secret_key(&[0; 32]))).unwrap();
 
     // Extract values we need before getting SDK to avoid borrow conflicts

--- a/pubky-homeserver/config.sample.toml
+++ b/pubky-homeserver/config.sample.toml
@@ -83,6 +83,9 @@ type = "file_system"
 # type = "in_memory"
 
 [admin]
+# Enable or disable the admin server
+enabled = true
+
 # The port number to run the admin HTTP (clear text) server on.
 # Used for admin requests from the admin UI.
 # If this API is every exposed to the public internet, make sure to add a HTTPS cert.
@@ -90,6 +93,14 @@ listen_socket = "127.0.0.1:6288"
 
 # The password for the admin user to access the admin UI.
 admin_password = "admin"
+
+[metrics]
+# Enable or disable the metrics server
+enabled = true
+
+# The socket address to run the metrics HTTP server on. It exposes Prometheus metrics at the /metrics endpoint.
+# It should be isolated from the public network and only accessible to monitoring systems.
+listen_socket = "127.0.0.1:6289"
 
 [pkdns]
 # The public IP address of the homeserver pubky_drive_api to be advertised on the DHT.
@@ -145,9 +156,3 @@ level = "info"
 # Per-module log levels overrides the global log level for specific modules.
 # Useful for suppressing logs from external dependencies or increasing verbosity for debugging.
 module_levels = ["pubky_homeserver=debug", "tower_http=debug"]
-
-[metrics]
-# The socket address to run the metrics HTTP server on. It exposes Prometheus metrics at the /metrics endpoint.
-# It should be isolated from the public network and only accessible to monitoring systems.
-# If the [metrics] section is not present, the metrics server will not be started.
-listen_socket = "127.0.0.1:6289"

--- a/pubky-homeserver/src/data_directory/config.default.toml
+++ b/pubky-homeserver/src/data_directory/config.default.toml
@@ -12,8 +12,13 @@ rate_limits = []
 type = "file_system"
 
 [admin]
+enabled = true
 listen_socket = "127.0.0.1:6288"
 admin_password = "admin"
+
+[metrics]
+enabled = false
+listen_socket = "127.0.0.1:6289"
 
 [pkdns]
 public_ip = "127.0.0.1"

--- a/pubky-homeserver/src/data_directory/config_toml.rs
+++ b/pubky-homeserver/src/data_directory/config_toml.rs
@@ -66,9 +66,19 @@ pub struct DriveToml {
     pub rate_limits: Vec<PathLimit>,
 }
 
+fn default_true() -> bool {
+    true
+}
+
+/// Admin server configuration
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct AdminToml {
+    /// Enable or disable the admin server
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Socket address for the admin HTTP server
     pub listen_socket: SocketAddr,
+    /// Password for admin authentication
     pub admin_password: String,
 }
 
@@ -88,9 +98,16 @@ pub struct LoggingToml {
     pub module_levels: Vec<TargetLevel>,
 }
 
+fn default_false() -> bool {
+    false
+}
+
 /// Metrics server configuration
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct MetricsToml {
+    /// Enable or disable the metrics server. Default: false
+    #[serde(default = "default_false")]
+    pub enabled: bool,
     /// Socket address for Prometheus metrics endpoint. Should be isolated from public network.
     pub listen_socket: SocketAddr,
 }
@@ -104,10 +121,10 @@ pub struct ConfigToml {
     pub drive: DriveToml,
     /// Storage configuration. Files can be stored in a file system, in memory, or in a Google bucket.
     pub storage: StorageConfigToml,
-    /// Administrative API settings (listen socket and password).
+    /// Administrative API configuration.
     pub admin: AdminToml,
-    /// Metrics server configuration. If None, metrics server will not be started.
-    pub metrics: Option<MetricsToml>,
+    /// Metrics server configuration.
+    pub metrics: MetricsToml,
     /// Peer‐to‐peer DHT / PKDNS settings (public endpoints, bootstrap, relays).
     pub pkdns: PkdnsToml,
     /// Logging configuration. If provided, the homeserver instance attempts to init
@@ -195,6 +212,7 @@ impl ConfigToml {
         // Use ephemeral ports (0) so parallel tests don't collide.
         config.drive.icann_listen_socket = SocketAddr::from(([127, 0, 0, 1], 0));
         config.drive.pubky_listen_socket = SocketAddr::from(([127, 0, 0, 1], 0));
+        config.admin.enabled = true;
         config.admin.listen_socket = SocketAddr::from(([127, 0, 0, 1], 0));
         config.pkdns.icann_domain =
             Some(Domain::from_str("localhost").expect("localhost is a valid domain"));

--- a/pubky-homeserver/src/data_directory/mod.rs
+++ b/pubky-homeserver/src/data_directory/mod.rs
@@ -12,7 +12,7 @@ mod signup_mode;
 pub mod storage_config;
 
 mod log_level;
-pub use config_toml::{ConfigReadError, ConfigToml, LoggingToml, MetricsToml};
+pub use config_toml::{AdminToml, ConfigReadError, ConfigToml, LoggingToml, MetricsToml};
 pub use data_dir::DataDir;
 pub use domain::Domain;
 pub use domain_port::DomainPort;

--- a/pubky-homeserver/src/main.rs
+++ b/pubky-homeserver/src/main.rs
@@ -47,10 +47,12 @@ async fn main() -> Result<()> {
         "Homeserver Pubky TLS listening on {}",
         server.client_server().pubky_tls_ip_url_ring()
     );
-    tracing::info!(
-        "Admin server listening on http://{}",
-        server.admin_server().listen_socket()
-    );
+    if let Some(admin_server) = server.admin_server() {
+        tracing::info!(
+            "Admin server listening on http://{}",
+            admin_server.listen_socket()
+        );
+    }
     if let Some(metrics_server) = server.metrics_server() {
         tracing::info!(
             "Metrics server listening on http://{}",

--- a/pubky-homeserver/src/metrics_server/app.rs
+++ b/pubky-homeserver/src/metrics_server/app.rs
@@ -45,14 +45,7 @@ impl MetricsServer {
     /// Run the metrics server.
     pub async fn start(context: &AppContext) -> Result<Self, MetricsServerBuildError> {
         let metrics = context.metrics.clone();
-        let socket = context
-            .config_toml
-            .metrics
-            .as_ref()
-            .ok_or_else(|| {
-                MetricsServerBuildError::Server(anyhow::anyhow!("Metrics configuration not found"))
-            })?
-            .listen_socket;
+        let socket = context.config_toml.metrics.listen_socket;
         let app = create_app(metrics);
         let listener = std::net::TcpListener::bind(socket)
             .map_err(|e| MetricsServerBuildError::Server(e.into()))?;

--- a/pubky-testnet/src/main.rs
+++ b/pubky-testnet/src/main.rs
@@ -43,10 +43,15 @@ async fn main() -> Result<()> {
         "Homeserver Pubky HTTPS: {}",
         testnet.homeserver_app().pubky_url()
     );
-    tracing::info!(
-        "Homeserver admin: http://{}",
-        testnet.homeserver_app().admin_server().listen_socket()
-    );
+    if let Some(admin_server) = testnet.homeserver_app().admin_server() {
+        tracing::info!("Homeserver admin: http://{}", admin_server.listen_socket());
+    }
+    if let Some(metrics_server) = testnet.homeserver_app().metrics_server() {
+        tracing::info!(
+            "Homeserver metrics: http://{}",
+            metrics_server.listen_socket()
+        );
+    }
 
     tokio::signal::ctrl_c().await?;
     drop(testnet); // Drop the testnet to trigger the drop of the homeserver and all databases.


### PR DESCRIPTION
This change requires `admin` and `metrics` server to be enabled/disabled explicitly in the config. In doing so it adds the ability to disabled admin server. 
These changes are backwards compatible with old configs.