### PR TITLE
fix(hs): Wrong event order in event endpoint

### DIFF
--- a/pubky-homeserver/src/persistence/files/events/events_repository.rs
+++ b/pubky-homeserver/src/persistence/files/events/events_repository.rs
@@ -2,7 +2,7 @@ use std::{fmt::Display, str::FromStr};
 
 use pubky_common::crypto::Hash;
 use pubky_common::timestamp::Timestamp;
-use sea_query::{Expr, Iden, LikeExpr, PostgresQueryBuilder, Query, SimpleExpr};
+use sea_query::{Expr, Iden, LikeExpr, Order, PostgresQueryBuilder, Query, SimpleExpr};
 use sea_query_binder::SqlxBinder;
 use sqlx::{
     postgres::PgRow,
@@ -284,6 +284,7 @@ impl EventRepository {
                 Expr::col((EVENT_TABLE, EventIden::User)).eq(Expr::col((USER_TABLE, UserIden::Id))),
             )
             .and_where(Expr::col((EVENT_TABLE, EventIden::Id)).gt(cursor.id()))
+            .order_by((EVENT_TABLE, EventIden::Id), Order::Asc)
             .limit(limit as u64)
             .to_owned();
         let (query, values) = statement.build_sqlx(PostgresQueryBuilder);


### PR DESCRIPTION
When calling the event endpoint, the endpoint would return the wrong cursor.

<img width="2272" height="474" alt="CleanShot 2025-12-01 at 09 33 47@2x" src="https://github.com/user-attachments/assets/996e50bd-c5b4-4090-be42-295b2cb5b89c" />

Turns out, the database query did not explicitly order the events by id. Therefore occasionally, a different event would snug in.
<img width="1508" height="612" alt="CleanShot 2025-12-01 at 09 34 49@2x" src="https://github.com/user-attachments/assets/66c9fb74-9842-49ac-ad7e-e56aab8744e0" />


This PR fixes this.