### PR TITLE
feat(hs): postgres tls support

### DIFF
--- a/pubky-homeserver/Cargo.toml
+++ b/pubky-homeserver/Cargo.toml
@@ -67,7 +67,7 @@ dav-server-opendalfs = "0.6.2"
 dav-server = "0.8.0"
 sea-query = { version = "0.32.6", features = [ "with-chrono", "postgres-array" ]}
 sea-query-binder = { version = "0.7.0", features = [ "with-chrono", "runtime-tokio", "sqlx-postgres", "postgres-array" ] }
-sqlx = { version = "0.8.6", features = [ "runtime-tokio", "postgres", "chrono" ] }
+sqlx = { version = "0.8.6", features = [ "runtime-tokio", "postgres", "chrono", "tls-native-tls" ] }
 async-trait = "0.1"
 async-dropper = { version = "0.3", features = [ "tokio", "simple" ] }
 async-stream = "0.3"


### PR DESCRIPTION
Adds support for encrypted postgres connections with TLS. This was missing so far. See https://www.postgresql.org/docs/current/libpq-ssl.html

FYI @catch-21 