### PR TITLE
Fix README code block

### DIFF
--- a/pubky-homeserver/README.md
+++ b/pubky-homeserver/README.md
@@ -52,7 +52,7 @@ async fn main() -> anyhow::Result<()> {
   let mock_dir = DataDirMock::new(config, None).unwrap(); 
   let app = HomeserverApp::run_with_data_dir_mock(mock_dir).await.unwrap();
 }
-
+```
 
 Run the `HomeserverCore` only without the admin server.
 


### PR DESCRIPTION
Fixed a code block which had no ending 3-tick-marker.