### PR TITLE
Fix default test DB URL

### DIFF
--- a/docs/DEV_TESTING_GUIDES.md
+++ b/docs/DEV_TESTING_GUIDES.md
@@ -20,7 +20,7 @@ This command creates a postgres container and also automatically creates the `pu
 
 ```toml
 [general]
-database_url = "postgres://postgres@postgres@localhost:5432/pubky_homeserver"
+database_url = "postgres://postgres:postgres@localhost:5432/pubky_homeserver"
 ```
 
 [pgadmin](https://www.pgadmin.org/) is a great explorer to inspect database values.
@@ -41,6 +41,6 @@ sudo -u postgres psql -c 'create database pubky_homeserver;'
 If compiled with the `testing` feature, `?pubky-test=true` can be added to the database url.
 This way, an empheral test database is created and dropped after the test.
 
-**Example** `postgres://postgres@postgres@localhost:5432/postgres?pubky-test=true` For each test, the homeserver will connect to the 
+**Example** `postgres://postgres:postgres@localhost:5432/postgres?pubky-test=true` For each test, the homeserver will connect to the
 specified database (postgres in this case) and create a new test database. With the `#[pubky_test_utils::test]` macro, the test database is
 dropped again after the test completes/panics.

--- a/pubky-homeserver/src/persistence/sql/connection_string.rs
+++ b/pubky-homeserver/src/persistence/sql/connection_string.rs
@@ -46,7 +46,7 @@ impl ConnectionString {
     /// This is a postgres database that is not real.
     /// It is used as an indicator for a empheral test database.
     pub fn default_test_db() -> Self {
-        Self::new("postgres://localhost:5432/postgres?pubky-test=true").unwrap()
+        Self::new("postgres://postgres:postgres@localhost:5432/postgres?pubky-test=true").unwrap()
     }
 
     /// Returns true if the connection string is for a test database.


### PR DESCRIPTION
This is a cherry-pick of #260.

This was originally merged into `dev-sep25`, but it seems to have gotten lost when `dev-sep25` got merged into `main`.