### PR TITLE
Bump Postgres from 17 to 18

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -46,7 +46,7 @@ jobs:
   test:
     services:
       postgres:
-        image: postgres:17-alpine          # official image
+        image: postgres:18-alpine          # official image
         env:
           POSTGRES_USER: test_user
           POSTGRES_PASSWORD: test_pass
@@ -155,7 +155,7 @@ jobs:
   wasm-test:
     services:
       postgres:
-        image: postgres:17-alpine          # official image
+        image: postgres:18-alpine          # official image
         env:
           POSTGRES_USER: test_user
           POSTGRES_PASSWORD: test_pass

--- a/docs/DEV_TESTING_GUIDES.md
+++ b/docs/DEV_TESTING_GUIDES.md
@@ -13,7 +13,7 @@ docker run --name postgres \
   -e POSTGRES_PASSWORD=postgres \
   -e POSTGRES_DB=pubky_homeserver \
   -p 5432:5432 \
-  -d postgres:17
+  -d postgres:18-alpine
 ```
 
 This command creates a postgres container and also automatically creates the `pubky_homeserver` database. Use this connection string in the homeserver config:

--- a/pubky-testnet/README.md
+++ b/pubky-testnet/README.md
@@ -13,7 +13,8 @@ docker run --name postgres \
   -e POSTGRES_USER=postgres \
   -e POSTGRES_PASSWORD=postgres \
   -e POSTGRES_DB=pubky_homeserver \
-  -p 5432:5432 -d postgres:17
+  -p 5432:5432 \
+  -d postgres:18-alpine
 
 # Run the testnet binary (all resources ephemeral). The environment variable must point to the postgres admin database.
 TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres' cargo run -p pubky-testnet


### PR DESCRIPTION
This PR bumps Postgres to the latest version, released on 25.09.2025.