### PR TITLE
Testnet: Fix chosen timeout for client builder

### DIFF
--- a/pubky-testnet/src/testnet.rs
+++ b/pubky-testnet/src/testnet.rs
@@ -194,7 +194,7 @@ impl Testnet {
             }
             // 100ms timeout for requests. This makes methods like `resolve_most_recent` fast
             // because it doesn't need to wait the default 2s which would slow down the tests.
-            builder.request_timeout(Duration::from_millis(2000));
+            builder.request_timeout(Duration::from_millis(100));
             builder
         });
 


### PR DESCRIPTION
The comment just above it describes why the timeout is set to 100ms for tests, but the line setting it uses 2000ms.

This PR aligns the configured value with the one described by the comment.

The CI tests are not particularly faster, but when running different scenarios locally (like user signup), the faster reaction time is noticeable.