### PR TITLE
feat(wasm): add methods for browser session persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2241,7 +2241,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -4113,7 +4113,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]
@@ -4785,6 +4785,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",
@@ -4794,6 +4795,7 @@ dependencies = [
  "tokio-stream",
  "tracing",
  "url",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -5796,6 +5798,15 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.4",
 ]
 
 [[package]]

--- a/pubky-sdk/bindings/js/pkg/README.md
+++ b/pubky-sdk/bindings/js/pkg/README.md
@@ -157,6 +157,20 @@ const caps = session.info.capabilities; // -> string[] permissions and paths
 const storage = session.storage; // -> This User's storage API (absolute paths)
 ```
 
+**Persist a session across tab refreshes (browser)**
+
+```js
+// Save the session snapshot (no secrets inside; relies on the HTTP-only cookie).
+const snapshot = session.export();
+localStorage.setItem("pubky-session", snapshot);
+
+// Later (after a reload), rehydrate using the browser's stored cookie.
+const restored = await pubky.restoreSession(localStorage.getItem("pubky-session")!);
+```
+
+> The exported string contains only public session metadata. The browser must keep the
+> HTTP-only cookie alive for the restored session to remain authenticated.
+
 **Approve a pubkyauth request URL**
 
 ```js

--- a/pubky-sdk/bindings/js/src/pubky.rs
+++ b/pubky-sdk/bindings/js/src/pubky.rs
@@ -2,6 +2,7 @@ use wasm_bindgen::prelude::*;
 
 use crate::actors::{
     auth_flow::{AuthFlow, AuthFlowKind},
+    session::Session,
     signer::Signer,
     storage::PublicStorage,
 };
@@ -148,5 +149,22 @@ impl Pubky {
     #[wasm_bindgen(getter)]
     pub fn client(&self) -> Client {
         Client(self.0.client().clone())
+    }
+
+    /// Restore a session from a previously exported snapshot, using this instance's client.
+    ///
+    /// This does **not** read or write any secrets. It revalidates the session metadata with
+    /// the server using the browser-managed HTTP-only cookie that must still be present.
+    ///
+    /// @param {string} exported A string produced by `session.export()`.
+    /// @returns {Promise<Session>}
+    /// A rehydrated session bound to this SDK's HTTP client.
+    ///
+    /// @example
+    /// const restored = await pubky.restoreSession(localStorage.getItem("pubky-session")!);
+    #[wasm_bindgen(js_name = "restoreSession")]
+    pub async fn restore_session(&self, exported: String) -> JsResult<Session> {
+        let session = pubky::PubkySession::import(&exported, Some(self.0.client().clone())).await?;
+        Ok(Session(session))
     }
 }


### PR DESCRIPTION
Reported by @afterburn and @tipogi it seems the WASM SDK is missing a method to re-hydratate an existing session in the browser. This PR fixes it:

- Added WASM-only session export/import helpers that serialize public `SessionInfo` and revalidate using the browser-managed cookie for rehydration after refreshes.
- Exposed `Session.export()` and `pubky.restoreSession()` in the JS bindings and documented that only metadata is serialized while the HTTP-only cookie remains the browser’s responsibility.
- Added a JS test that round-trips a session export to confirm access persists via the retained cookie.