### PR TITLE
chore: DRY up auth approval for signup deeplinks

### DIFF
--- a/pubky-sdk/bindings/js/pkg/tests/auth.ts
+++ b/pubky-sdk/bindings/js/pkg/tests/auth.ts
@@ -98,6 +98,45 @@ test("Auth: 3rd party signin", async (t) => {
   t.end();
 });
 
+test("Auth: direct signup deeplink", async (t) => {
+  const sdk = Pubky.testnet();
+
+  const signer = sdk.signer(Keypair.random());
+  const deeplink = `pubkyauth://signup?hs=${HOMESERVER_PUBLICKEY.z32()}`;
+
+  await signer.approveAuthRequest(deeplink);
+
+  const session = await signer.signin();
+  t.equal(
+    session.info.publicKey.z32(),
+    signer.publicKey.z32(),
+    "session belongs to expected user",
+  );
+
+  t.end();
+});
+
+test("Auth: direct signup deeplink with token", async (t) => {
+  const sdk = Pubky.testnet();
+
+  const signupToken = await createSignupToken();
+  const signer = sdk.signer(Keypair.random());
+  const deeplink = `pubkyauth://signup?hs=${HOMESERVER_PUBLICKEY.z32()}&st=${encodeURIComponent(
+    signupToken,
+  )}`;
+
+  await signer.approveAuthRequest(deeplink);
+
+  const session = await signer.signin();
+  t.equal(
+    session.info.publicKey.z32(),
+    signer.publicKey.z32(),
+    "session belongs to expected user",
+  );
+
+  t.end();
+});
+
 test("startAuthFlow: rejects malformed capabilities; normalizes valid; allows empty", async (t) => {
   const sdk = Pubky.testnet(); // uses local testnet mapping so URLs are resolvable in-node
 

--- a/pubky-sdk/bindings/js/pkg/tests/deep_links.ts
+++ b/pubky-sdk/bindings/js/pkg/tests/deep_links.ts
@@ -36,12 +36,19 @@ test("signup deep link valid", async (t) => {
   const deepLink = SignupDeepLink.parse(url);
   t.equal(deepLink.capabilities, "/pub/pubky.app/:rw");
   t.equal(deepLink.baseRelayUrl, TESTNET_HTTP_RELAY);
-  t.deepEqual(deepLink.secret, new Uint8Array([146, 169, 220, 120, 67, 32, 172, 212, 12, 255, 24, 180, 234, 132, 23, 140, 13, 220, 36, 117, 255, 69, 9, 176, 212, 22, 58, 36, 77, 91, 177, 239]));
+  t.deepEqual(
+    deepLink.secret,
+    new Uint8Array([
+      146, 169, 220, 120, 67, 32, 172, 212, 12, 255, 24, 180, 234, 132, 23,
+      140, 13, 220, 36, 117, 255, 69, 9, 176, 212, 22, 58, 36, 77, 91, 177,
+      239,
+    ]),
+  );
   t.equal(deepLink.homeserver.z32(), HOMESERVER_PUBLICKEY.z32());
   t.equal(deepLink.signupToken, "1234567890");
 
-  t.equal(deepLink.toString(), url);
+  const expectedUrl = "pubkyauth://signup?hs=8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo&st=1234567890&relay=http://localhost:15412/link&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&caps=/pub/pubky.app/:rw";
+  t.equal(deepLink.toString(), expectedUrl);
 
   t.end();
 });
-

--- a/pubky-sdk/bindings/js/src/actors/deep_links/signup.rs
+++ b/pubky-sdk/bindings/js/src/actors/deep_links/signup.rs
@@ -31,13 +31,15 @@ impl SignupDeepLink {
     }
 
     #[wasm_bindgen(js_name = "baseRelayUrl", getter)]
-    pub fn base_relay_url(&self) -> String {
-        self.0.relay().to_string()
+    pub fn base_relay_url(&self) -> Option<String> {
+        self.0.relay().map(|relay| relay.to_string())
     }
 
     #[wasm_bindgen(getter)]
-    pub fn secret(&self) -> Uint8Array {
-        Uint8Array::from(self.0.secret().as_ref())
+    pub fn secret(&self) -> Option<Uint8Array> {
+        self.0
+            .secret()
+            .map(|secret| Uint8Array::from(secret.as_ref()))
     }
 
     #[wasm_bindgen(getter)]

--- a/pubky-sdk/src/actors/auth/http_relay_link_channel.rs
+++ b/pubky-sdk/src/actors/auth/http_relay_link_channel.rs
@@ -120,7 +120,7 @@ impl HttpRelayLinkChannel {
             {
                 return Ok(None);
             }
-            let poll_timeout = timeout.map(|t| t - start.elapsed());
+            let poll_timeout = timeout.and_then(|t| t.checked_sub(start.elapsed()));
             match self.poll_once(client, poll_timeout).await {
                 Ok(response) => {
                     cross_log!(

--- a/pubky-sdk/src/actors/signer/auth.rs
+++ b/pubky-sdk/src/actors/signer/auth.rs
@@ -33,10 +33,6 @@ impl PubkySigner {
     /// - Returns [`crate::errors::Error::Authentication`] if the `pubkyauth://` URL is malformed or missing required parameters.
     /// - Returns [`crate::errors::Error::Authentication`] if the secret cannot be decoded or has the wrong length.
     /// - Propagates transport failures when posting to the relay or if the relay responds with a non-success status.
-    #[allow(
-        clippy::cognitive_complexity,
-        reason = "Approving a flow requires a fixed sequence of validation steps kept together for clarity"
-    )]
     pub async fn approve_auth(&self, pubkyauth_url: impl AsRef<str>) -> Result<()> {
         let deep_link = DeepLink::from_str(pubkyauth_url.as_ref())
             .map_err(|e| AuthError::Validation(format!("Invalid pubkyauth URL: {e}")))?;


### PR DESCRIPTION
Low priority
This PR changes:
- Parse `pubkyauth` URLs once and route signup vs relay auth from a single path.
- Decrease complexity of some functions and remove the clippy `allow` for high cognitive complexity.
- Reuse shared token-posting helper for relay flows (signup / signin).
- Explicitly support direct signup deeplinks (no relay/secret) without duplicating logic.
- Updated canonical ordering of the `params` from mandatory first (`hs`) to optional last (`st`...) and the test expectation strings.
- The `caps` param is now not enforced. By `PubkyAuth` standard an `AuthToken` with no capabilities is used to "authenticate" (prove identity). When some capabilities are requested, then it is used to "authorize" (give access to that scope). Previously `caps` were always enforce to exist.
- The parsing logic now enforces relay and secret pairing: if one is present without the other, parsing fails.