### PR TITLE
fix: Fix crate naming issue preventing `dependabot` runs

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -150,7 +150,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Cargo check examples
         run: |
-          cargo check -p examples --all-features --bins
+          cargo check -p pubky-core-examples --all-features --bins
 
   wasm-test:
     services:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1476,25 +1476,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "examples"
-version = "0.6.0"
-dependencies = [
- "anyhow",
- "base64 0.22.1",
- "clap",
- "futures-util",
- "pubky",
- "pubky-common",
- "pubky-testnet",
- "reqwest",
- "rpassword",
- "tokio",
- "tracing",
- "tracing-subscriber",
- "url",
-]
-
-[[package]]
 name = "fast-glob"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3639,6 +3620,25 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.17",
+ "url",
+]
+
+[[package]]
+name = "pubky-core-examples"
+version = "0.6.0"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "clap",
+ "futures-util",
+ "pubky",
+ "pubky-common",
+ "pubky-testnet",
+ "reqwest",
+ "rpassword",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
  "url",
 ]
 

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "examples"
+name = "pubky-core-examples"
 version = "0.6.0"
 edition.workspace = true
 publish = false


### PR DESCRIPTION
The dependabot scheduled jobs were failing[^1] with:

> Dependabot can't resolve your Rust dependency files
> ...
> the binary target name examples is forbidden, it conflicts with cargo's build directory names

The package in `examples/rust/Cargo.toml` had `name = "examples"`, which conflicts with Cargo's reserved build directory names (`examples`, `target`, `tests`, `benches`, etc.). Dependabot's Cargo version enforces this restriction, causing it to fail when parsing the workspace manifest.

This PR addresses this issue by renaming the package from `examples` to `pubky-core-examples` in `examples/rust/Cargo.toml`.

[^1]: See job logs at https://github.com/pubky/pubky-core/network/updates