### PR TITLE
chore: Group `dependabot` PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,8 @@ updates:
       day: "tuesday"
     commit-message:
       prefix: "deps"
-    open-pull-requests-limit: 30
     rebase-strategy: "auto"
+    groups:
+      cargo-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR configures `dependabot` to group all update PRs into one, instead of a separate PR per dependency update.

Ideally this should be merged before #304.