### PR TITLE
feat: GET /signup_tokens/{token} resource

### DIFF
--- a/pubky-homeserver/src/client_server/app.rs
+++ b/pubky-homeserver/src/client_server/app.rs
@@ -29,7 +29,7 @@ use tower_http::cors::CorsLayer;
 use super::layers::{
     pubky_host::PubkyHostLayer, rate_limiter::RateLimiterLayer, trace::with_trace_layer,
 };
-use super::routes::{auth, events, root, tenants};
+use super::routes::{auth, events, root, signup_tokens, tenants};
 
 /// Errors that can occur when building a `HomeserverCore`.
 #[derive(Debug, thiserror::Error)]
@@ -214,7 +214,8 @@ impl Drop for ClientServer {
 fn base() -> Router<AppState> {
     Router::new()
         .route("/", get(root::handler))
-        .route("/signup", get(auth::check_signup_token).post(auth::signup))
+        .route("/signup", post(auth::signup))
+        .route("/signup_tokens/{token}", get(signup_tokens::get))
         .route("/session", post(auth::signin))
         // Events
         .route("/events/", get(events::feed))

--- a/pubky-homeserver/src/client_server/routes/auth.rs
+++ b/pubky-homeserver/src/client_server/routes/auth.rs
@@ -27,60 +27,11 @@ use tower_cookies::{
     Cookie, Cookies,
 };
 
-/// Check if a signup token is valid without consuming it.
-///
-/// Note: This endpoint uses RESTful status codes (404 Not Found, 410 Gone) for token errors,
-/// while POST /signup uses 401 Unauthorized. Keeping like this for backwards compatibility.
-pub async fn check_signup_token(
-    State(state): State<AppState>,
-    Query(params): Query<HashMap<String, String>>,
-) -> HttpResult<impl IntoResponse> {
-    if state.signup_mode != SignupMode::TokenRequired {
-        return Err(HttpError::new_with_message(
-            StatusCode::BAD_REQUEST,
-            "Signup tokens not required",
-        ));
-    }
-
-    // Extract and validate token format
-    let signup_token_param = params
-        .get("signup_token")
-        .ok_or(HttpError::new_with_message(
-            StatusCode::BAD_REQUEST,
-            "signup_token query parameter required",
-        ))?;
-    let signup_code_id = SignupCodeId::new(signup_token_param.clone()).map_err(|e| {
-        HttpError::new_with_message(
-            StatusCode::BAD_REQUEST,
-            format!("Invalid signup token format: {}", e),
-        )
-    })?;
-
-    // Check token exists in database
-    let code =
-        match SignupCodeRepository::get(&signup_code_id, &mut state.sql_db.pool().into()).await {
-            Ok(code) => code,
-            Err(sqlx::Error::RowNotFound) => {
-                return Err(HttpError::new_with_message(
-                    StatusCode::NOT_FOUND,
-                    "Token not found",
-                ));
-            }
-            Err(e) => return Err(e.into()),
-        };
-
-    if code.used_by.is_some() {
-        return Err(HttpError::new_with_message(
-            StatusCode::GONE,
-            "Token already used",
-        ));
-    }
-
-    // Return success with no-cache header to prevent callers from caching result
-    Ok((StatusCode::OK, [(header::CACHE_CONTROL, "no-store")], ""))
-}
-
 /// Creates a brand-new user if they do not exist, then logs them in by creating a session.
+///
+/// Note: This endpoint uses action-oriented path `/signup` which is not RESTful.
+/// Ideally would be eg `POST /users` in future.
+///
 /// 1) Check if signup tokens are required (signup mode is token_required).
 /// 2) Ensure the user *does not* already exist.
 /// 3) Create new user if needed.

--- a/pubky-homeserver/src/client_server/routes/mod.rs
+++ b/pubky-homeserver/src/client_server/routes/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod auth;
 pub(crate) mod events;
 pub(crate) mod root;
+pub(crate) mod signup_tokens;
 pub(crate) mod tenants;

--- a/pubky-homeserver/src/client_server/routes/signup_tokens.rs
+++ b/pubky-homeserver/src/client_server/routes/signup_tokens.rs
@@ -1,0 +1,79 @@
+//! Signup token resource endpoints.
+
+use crate::persistence::sql::signup_code::{SignupCodeId, SignupCodeRepository};
+use crate::shared::{HttpError, HttpResult};
+use crate::{client_server::AppState, SignupMode};
+use axum::{
+    extract::{Path, State},
+    http::{header, StatusCode},
+    response::IntoResponse,
+};
+
+/// Status of a signup token.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SignupTokenStatus {
+    /// Token exists and has not been used yet.
+    Valid,
+    /// Token has already been used.
+    Used,
+}
+
+/// Response body for GET /signup_tokens/{token}
+#[derive(serde::Serialize)]
+pub struct SignupTokenResponse {
+    /// Token status.
+    pub status: SignupTokenStatus,
+    /// When the token was created (ISO 8601 format)
+    pub created_at: String,
+}
+
+/// Get signup token status.
+///
+/// Returns the token's status and creation time.
+pub async fn get(
+    State(state): State<AppState>,
+    Path(token): Path<String>,
+) -> HttpResult<impl IntoResponse> {
+    if state.signup_mode != SignupMode::TokenRequired {
+        return Err(HttpError::new_with_message(
+            StatusCode::BAD_REQUEST,
+            "Signup tokens not required",
+        ));
+    }
+
+    let signup_code_id = SignupCodeId::new(token).map_err(|e| {
+        HttpError::new_with_message(
+            StatusCode::BAD_REQUEST,
+            format!("Invalid signup token format: {}", e),
+        )
+    })?;
+
+    let code =
+        match SignupCodeRepository::get(&signup_code_id, &mut state.sql_db.pool().into()).await {
+            Ok(code) => code,
+            Err(sqlx::Error::RowNotFound) => {
+                return Err(HttpError::new_with_message(
+                    StatusCode::NOT_FOUND,
+                    "Token not found",
+                ));
+            }
+            Err(e) => return Err(e.into()),
+        };
+
+    let status = if code.used_by.is_some() {
+        SignupTokenStatus::Used
+    } else {
+        SignupTokenStatus::Valid
+    };
+    let response = SignupTokenResponse {
+        status,
+        created_at: code.created_at.and_utc().to_rfc3339(),
+    };
+
+    Ok((
+        StatusCode::OK,
+        [(header::CACHE_CONTROL, "no-store")],
+        axum::Json(response),
+    ))
+}


### PR DESCRIPTION
Here we add a new 
```
GET /signup_tokens/{token}
```
which checks returns a signup token's `created_at` time and whether the token is used or not.

It returns:
- `200 OK` if token valid
- `400 Bad Request` if missing token, invalid format, or tokens not required (Homeserver not configured for signup tokens)
- `404 Not Found` if token doesn't exist