### PR TITLE
fix: Macos mainline tests binding to 127.0.0.1

### DIFF
--- a/pkarr-republisher/src/multi_republisher.rs
+++ b/pkarr-republisher/src/multi_republisher.rs
@@ -206,7 +206,10 @@ mod tests {
 
     #[tokio::test]
     async fn single_key_republish_success() {
-        let dht = pkarr::mainline::Testnet::new_unseeded(3).unwrap();
+        let dht = pkarr::mainline::Testnet::builder(3)
+            .seeded(false)
+            .build()
+            .unwrap();
         let mut pkarr_builder = pkarr::ClientBuilder::default();
         pkarr_builder.bootstrap(&dht.bootstrap).no_relays();
         let pkarr_client = pkarr_builder.clone().build().unwrap();
@@ -229,7 +232,10 @@ mod tests {
 
     #[tokio::test]
     async fn single_key_republish_insufficient() {
-        let dht = pkarr::mainline::Testnet::new_unseeded(3).unwrap();
+        let dht = pkarr::mainline::Testnet::builder(3)
+            .seeded(false)
+            .build()
+            .unwrap();
         let mut pkarr_builder = pkarr::ClientBuilder::default();
         pkarr_builder.bootstrap(&dht.bootstrap).no_relays();
         let pkarr_client = pkarr_builder.clone().build().unwrap();

--- a/pkarr-republisher/src/publisher.rs
+++ b/pkarr-republisher/src/publisher.rs
@@ -256,7 +256,10 @@ mod tests {
 
     #[tokio::test]
     async fn single_key_republish_success() {
-        let dht = pkarr::mainline::Testnet::new_unseeded(3).unwrap();
+        let dht = pkarr::mainline::Testnet::builder(3)
+            .seeded(false)
+            .build()
+            .unwrap();
         let mut pkarr_builder = pkarr::ClientBuilder::default();
         pkarr_builder.bootstrap(&dht.bootstrap).no_relays();
         let pkarr_client = pkarr_builder.clone().build().unwrap();
@@ -276,7 +279,10 @@ mod tests {
 
     #[tokio::test]
     async fn single_key_republish_insufficient() {
-        let dht = pkarr::mainline::Testnet::new_unseeded(3).unwrap();
+        let dht = pkarr::mainline::Testnet::builder(3)
+            .seeded(false)
+            .build()
+            .unwrap();
         let mut pkarr_builder = pkarr::ClientBuilder::default();
         pkarr_builder.bootstrap(&dht.bootstrap).no_relays();
         let pkarr_client = pkarr_builder.clone().build().unwrap();
@@ -303,7 +309,7 @@ mod tests {
 
     #[tokio::test]
     async fn retry_delay() {
-        let dht = pkarr::mainline::Testnet::new(3).unwrap();
+        let dht = pkarr::mainline::Testnet::builder(3).build().unwrap();
         let mut pkarr_builder = pkarr::ClientBuilder::default();
         pkarr_builder.bootstrap(&dht.bootstrap).no_relays();
         let pkarr_client = pkarr_builder.clone().build().unwrap();

--- a/pkarr-republisher/src/republisher.rs
+++ b/pkarr-republisher/src/republisher.rs
@@ -268,7 +268,7 @@ mod tests {
 
     #[tokio::test]
     async fn single_key_republish_success() {
-        let dht = pkarr::mainline::Testnet::new(1).unwrap();
+        let dht = pkarr::mainline::Testnet::builder(1).build().unwrap();
         let mut pkarr_builder = pkarr::ClientBuilder::default();
         pkarr_builder
             .no_default_network()
@@ -291,7 +291,7 @@ mod tests {
 
     #[tokio::test]
     async fn single_key_republish_missing() {
-        let dht = pkarr::mainline::Testnet::new(1).unwrap();
+        let dht = pkarr::mainline::Testnet::builder(1).build().unwrap();
         let mut pkarr_builder = pkarr::ClientBuilder::default();
         pkarr_builder.bootstrap(&dht.bootstrap).no_relays();
         let pkarr_client = pkarr_builder.clone().build().unwrap();
@@ -312,7 +312,7 @@ mod tests {
 
     #[tokio::test]
     async fn retry_delay() {
-        let dht = pkarr::mainline::Testnet::new(1).unwrap();
+        let dht = pkarr::mainline::Testnet::builder(1).build().unwrap();
         let mut pkarr_builder = pkarr::ClientBuilder::default();
         pkarr_builder.bootstrap(&dht.bootstrap).no_relays();
         let pkarr_client = pkarr_builder.clone().build().unwrap();
@@ -342,7 +342,7 @@ mod tests {
 
     #[tokio::test]
     async fn republish_retry_missing() {
-        let dht = pkarr::mainline::Testnet::new(1).unwrap();
+        let dht = pkarr::mainline::Testnet::builder(1).build().unwrap();
         let mut pkarr_builder = pkarr::ClientBuilder::default();
         pkarr_builder.bootstrap(&dht.bootstrap).no_relays();
         let pkarr_client = pkarr_builder.clone().build().unwrap();
@@ -366,7 +366,7 @@ mod tests {
 
     #[tokio::test]
     async fn republish_with_condition_fail() {
-        let dht = pkarr::mainline::Testnet::new(1).unwrap();
+        let dht = pkarr::mainline::Testnet::builder(1).build().unwrap();
         let mut pkarr_builder = pkarr::ClientBuilder::default();
         pkarr_builder.bootstrap(&dht.bootstrap).no_relays();
         let pkarr_client = pkarr_builder.clone().build().unwrap();
@@ -390,7 +390,7 @@ mod tests {
 
     #[tokio::test]
     async fn republish_with_condition_success() {
-        let dht = pkarr::mainline::Testnet::new(1).unwrap();
+        let dht = pkarr::mainline::Testnet::builder(1).build().unwrap();
         let mut pkarr_builder = pkarr::ClientBuilder::default();
         pkarr_builder.bootstrap(&dht.bootstrap).no_relays();
         let pkarr_client = pkarr_builder.clone().build().unwrap();

--- a/pubky-testnet/src/testnet.rs
+++ b/pubky-testnet/src/testnet.rs
@@ -32,7 +32,7 @@ pub struct Testnet {
 impl Testnet {
     /// Run a new testnet with a local DHT.
     pub async fn new() -> Result<Self> {
-        let dht = pkarr::mainline::Testnet::new(2)?;
+        let dht = pkarr::mainline::Testnet::builder(2).build()?;
         let testnet = Self {
             dht,
             pkarr_relays: vec![],
@@ -52,7 +52,7 @@ impl Testnet {
     pub async fn new_with_custom_postgres(
         postgres_connection_string: ConnectionString,
     ) -> Result<Self> {
-        let dht = pkarr::mainline::Testnet::new(2)?;
+        let dht = pkarr::mainline::Testnet::builder(2).build()?;
         let testnet: Testnet = Self {
             dht,
             pkarr_relays: vec![],


### PR DESCRIPTION
Mainline DHT tests would bind to `0.0.0.0` previously. This still works on Linux but fails on MacOS since the Tahoe update. This PR binds the tests to `127.0.0.1.` and therefore fixes this issue.