### PR TITLE
fix: pubky-testnet readme local cargo test

### DIFF
--- a/pubky-testnet/README.md
+++ b/pubky-testnet/README.md
@@ -15,9 +15,13 @@ For testing without a separate Postgres installation, enable the `embedded-postg
 pubky-testnet = { version = "0.6", features = ["embedded-postgres"] }
 ```
 
-```rust
+```rust,no_run
+# #[cfg(not(feature = "embedded-postgres"))]
+# fn main() {}
+# #[cfg(feature = "embedded-postgres")]
 use pubky_testnet::EphemeralTestnet;
 
+# #[cfg(feature = "embedded-postgres")]
 #[tokio::main]
 async fn main() {
     let testnet = EphemeralTestnet::builder()


### PR DESCRIPTION
`cargo test` would fail locally because the code example in `pubky-testnet/README.md` requires the `embedded-postgres` feature which is not enabled when just running `cargo test`. This PR fixes this problem.