### PR TITLE
feat: Examples use embedded postgres by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4016,7 +4016,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-core-examples"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/examples/rust/0-logging/README.md
+++ b/examples/rust/0-logging/README.md
@@ -2,8 +2,27 @@
 
 Learn how to enable verbose tracing for the Pubky SDK before performing a simple storage roundtrip.
 
+## Usage
+
+By default, this example uses embedded PostgreSQL for a fully self-contained setup. The first run downloads PostgreSQL binaries (~50-100MB), which are cached for subsequent runs.
+
 ```bash
 cargo run --bin logging -- --level debug
 ```
 
-The example spins up an ephemeral local testnet, so no additional services are required.
+### Using an external PostgreSQL instance
+
+If you prefer to use your own PostgreSQL instance:
+
+```bash
+# Uses postgres://postgres:postgres@localhost:5432/postgres by default
+cargo run --bin logging -- --level debug --external-postgres
+```
+
+You can specify a custom connection via the `TEST_PUBKY_CONNECTION_STRING` environment variable:
+
+```bash
+TEST_PUBKY_CONNECTION_STRING=postgres://user:pass@localhost:5432/mydb?pubky-test=true cargo run --bin logging -- --level debug --external-postgres
+```
+
+The `?pubky-test=true` parameter indicates that an ephemeral test database should be created.

--- a/examples/rust/0-logging/main.rs
+++ b/examples/rust/0-logging/main.rs
@@ -15,16 +15,32 @@ struct Cli {
     /// Maximum tracing verbosity to enable: error|warn|info|debug|trace
     #[arg(long, default_value_t = LevelFilter::INFO, value_parser = clap::value_parser!(LevelFilter))]
     level: LevelFilter,
+
+    /// Use an external PostgreSQL instance instead of embedded postgres.
+    /// Connects to TEST_PUBKY_CONNECTION_STRING env var if set,
+    /// otherwise defaults to postgres://postgres:postgres@localhost:5432/postgres
+    #[arg(long)]
+    external_postgres: bool,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    let Cli { level } = Cli::parse();
-    init_tracing(level);
-    info!(%level, "Tracing initialized");
+    let cli = Cli::parse();
+    init_tracing(cli.level);
+    info!(level = %cli.level, "Tracing initialized");
 
     info!("Starting ephemeral testnet");
-    let testnet = EphemeralTestnet::builder().build().await?;
+    #[allow(unused_mut)]
+    let mut builder = EphemeralTestnet::builder();
+
+    #[cfg(feature = "embedded-postgres")]
+    let builder = if !cli.external_postgres {
+        builder.with_embedded_postgres()
+    } else {
+        builder
+    };
+
+    let testnet = builder.build().await?;
     let pubky = testnet.sdk()?;
     let homeserver = testnet.homeserver_app();
 
@@ -38,7 +54,7 @@ async fn main() -> Result<()> {
 
     let timestamp = SystemTime::now().duration_since(UNIX_EPOCH)?.as_millis();
     let path = format!("/pub/logging.example/{timestamp}.txt");
-    let body = format!("Tracing level {} at {timestamp}", level);
+    let body = format!("Tracing level {} at {timestamp}", cli.level);
     info!(%path, "Writing sample data");
     session.storage().put(&path, body).await?;
 

--- a/examples/rust/1-testnet/README.md
+++ b/examples/rust/1-testnet/README.md
@@ -1,9 +1,28 @@
 # Testnet example
 
-You can use this example to learn how to locally test your Pubky App fully offline using [pubky-testnet](https://crates.io/crates/pubky-testnet)
+You can use this example to learn how to locally test your Pubky App fully offline using [pubky-testnet](https://crates.io/crates/pubky-testnet).
 
 ## Usage
+
+By default, this example uses embedded PostgreSQL for a fully self-contained setup. The first run downloads PostgreSQL binaries (~50-100MB), which are cached for subsequent runs.
 
 ```bash
 cargo run --bin testnet
 ```
+
+### Using an external PostgreSQL instance
+
+If you prefer to use your own PostgreSQL instance, use the `--external-postgres` flag:
+
+```bash
+# Uses postgres://postgres:postgres@localhost:5432/postgres by default
+cargo run --bin testnet -- --external-postgres
+```
+
+You can specify a custom connection via the `TEST_PUBKY_CONNECTION_STRING` environment variable:
+
+```bash
+TEST_PUBKY_CONNECTION_STRING=postgres://user:pass@localhost:5432/mydb?pubky-test=true cargo run --bin testnet -- --external-postgres
+```
+
+The `?pubky-test=true` parameter indicates that an ephemeral test database should be created.

--- a/examples/rust/1-testnet/main.rs
+++ b/examples/rust/1-testnet/main.rs
@@ -1,9 +1,32 @@
+use clap::Parser;
 use pubky_testnet::{pubky::Keypair, EphemeralTestnet};
+
+#[derive(Parser)]
+struct Args {
+    /// Use an external PostgreSQL instance instead of embedded postgres.
+    /// Connects to TEST_PUBKY_CONNECTION_STRING env var if set,
+    /// otherwise defaults to postgres://postgres:postgres@localhost:5432/postgres
+    #[arg(long)]
+    external_postgres: bool,
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    #[allow(unused_variables)]
+    let args = Args::parse();
+
     // Spin up ephemeral DHT + homeserver with minimal config
-    let testnet = EphemeralTestnet::builder().build().await?;
+    #[allow(unused_mut)]
+    let mut builder = EphemeralTestnet::builder();
+
+    #[cfg(feature = "embedded-postgres")]
+    let builder = if !args.external_postgres {
+        builder.with_embedded_postgres()
+    } else {
+        builder
+    };
+
+    let testnet = builder.build().await?;
     let homeserver = testnet.homeserver_app();
 
     // Intantiate a Pubky SDK wrapper that uses this testnet's preconfigured client for transport

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky-core-examples"
-version = "0.6.0"
+version = "0.7.0"
 edition.workspace = true
 publish = false
 
@@ -36,13 +36,17 @@ path = "./6-auth_flow_signup/authenticator.rs"
 name = "events_stream"
 path = "./7-events_stream/main.rs"
 
+[features]
+default = ["embedded-postgres"]
+embedded-postgres = ["pubky-testnet/embedded-postgres"]
+
 [dependencies]
 futures-util = "0.3.31"
 anyhow.workspace = true
 base64 = "0.22.1"
 clap = { version = "4.5.48", features = ["derive"] }
 pubky = { path = "../../pubky-sdk", version = "0.6.0" }
-pubky-testnet = { path = "../../pubky-testnet" }
+pubky-testnet = { path = "../../pubky-testnet", version = "0.7.2" }
 pubky-common = { path = "../../pubky-common", version = "0.6.0" }
 reqwest.workspace = true
 rpassword = "7.4.0"


### PR DESCRIPTION
This allows logging and testnet examples to be run without requiring a Postgres setup. 