### PR TITLE
docs: Improve pubky-testnet usage docs

### DIFF
--- a/pubky-testnet/README.md
+++ b/pubky-testnet/README.md
@@ -34,6 +34,8 @@ async fn main() {
 
 The first run will download PostgreSQL binaries (~50-100MB), which are cached for subsequent runs.
 
+> **Important**: If you have multiple tests, see [Sharing Embedded Postgres Across Tests](#sharing-embedded-postgres-across-tests) below.
+
 ### Option 2: External PostgreSQL
 
 If you prefer to use an external Postgres instance:
@@ -127,6 +129,79 @@ async fn main() {
     let http_relay = testnet.http_relay();
 }
 ```
+
+## Sharing Embedded Postgres Across Tests
+
+When using `embedded-postgres`, each call to `.with_embedded_postgres()` starts a **separate** PostgreSQL instance.
+
+The recommended pattern is to start **one** embedded postgres instance and share its connection string across all tests:
+
+```rust
+use pubky_testnet::EphemeralTestnet;
+use pubky_testnet::embedded_postgres::EmbeddedPostgres;
+use tokio::sync::OnceCell;
+
+// Shared embedded postgres instance for all tests in this module.
+// Started once, reused by every test via its connection string.
+static SHARED_PG: OnceCell<EmbeddedPostgres> = OnceCell::const_new();
+
+async fn shared_postgres() -> &'static EmbeddedPostgres {
+    SHARED_PG
+        .get_or_init(|| async {
+            EmbeddedPostgres::start()
+                .await
+                .expect("Failed to start embedded postgres")
+        })
+        .await
+}
+
+#[tokio::test]
+async fn test_one() {
+    let pg = shared_postgres().await;
+    let testnet = EphemeralTestnet::builder()
+        .postgres(pg.connection_string().unwrap())
+        .build()
+        .await
+        .unwrap();
+    // ... test code
+}
+
+#[tokio::test]
+async fn test_two() {
+    let pg = shared_postgres().await;
+    let testnet = EphemeralTestnet::builder()
+        .postgres(pg.connection_string().unwrap())
+        .build()
+        .await
+        .unwrap();
+    // ... test code
+}
+```
+
+Each testnet still gets its own ephemeral database within the shared PostgreSQL instance, so tests remain isolated.
+
+## Troubleshooting
+
+### GitHub Rate Limiting During Binary Download
+
+The embedded PostgreSQL binary is downloaded from GitHub releases. If multiple tests (or repeated test runs) try to download concurrently, you may hit GitHub's API rate limit (60 requests/hour for unauthenticated requests), causing errors like `403 Forbidden` or `rate limit exceeded`.
+
+**Solutions (try in order):**
+
+1. **Set a GitHub token** to raise the rate limit from 60 to 5,000 requests/hour:
+   ```bash
+   export GITHUB_TOKEN=ghp_your_personal_access_token
+   cargo test
+   ```
+   The token does not need any scopes — a classic PAT with no permissions works.
+
+2. **Run a single test first** to populate the cache before running the full suite.
+
+3. **Share one embedded postgres instance** across tests (see [Sharing Embedded Postgres Across Tests](#sharing-embedded-postgres-across-tests)).
+
+4. **Wait for the rate limit to reset** (1 hour from first rate-limited request), then retry with one of the above solutions.
+
+**Cache location:** `~/.cache/pubky-testnet/postgresql/` (Linux/macOS). If you suspect a corrupt cache, delete this directory and retry.
 
 ## Binary (Static Testnet)
 

--- a/pubky-testnet/src/embedded_postgres.rs
+++ b/pubky-testnet/src/embedded_postgres.rs
@@ -14,6 +14,37 @@ use std::time::Duration;
 /// including creating a test database and providing a connection string.
 ///
 /// The embedded Postgres is automatically stopped when this struct is dropped.
+///
+/// # Sharing Across Tests (Recommended)
+///
+/// Each `EmbeddedPostgres::start()` downloads and starts a **separate** PostgreSQL server.
+/// The recommended pattern is to start **one** instance and share its connection string:
+///
+/// ```ignore
+/// use pubky_testnet::embedded_postgres::EmbeddedPostgres;
+/// use tokio::sync::OnceCell;
+///
+/// static SHARED_PG: OnceCell<EmbeddedPostgres> = OnceCell::const_new();
+///
+/// async fn shared_postgres() -> &'static EmbeddedPostgres {
+///     SHARED_PG
+///         .get_or_init(|| async {
+///             EmbeddedPostgres::start().await.expect("Failed to start embedded postgres")
+///         })
+///         .await
+/// }
+///
+/// #[tokio::test]
+/// async fn my_test() {
+///     let pg = shared_postgres().await;
+///     let testnet = EphemeralTestnet::builder()
+///         .postgres(pg.connection_string().unwrap())
+///         .build()
+///         .await
+///         .unwrap();
+///     // Each testnet gets its own ephemeral database — tests remain isolated.
+/// }
+/// ```
 pub struct EmbeddedPostgres {
     pg: PostgreSQL,
     database_name: String,

--- a/pubky-testnet/src/ephemeral_testnet.rs
+++ b/pubky-testnet/src/ephemeral_testnet.rs
@@ -130,6 +130,13 @@ impl EphemeralTestnetBuilder {
     ///
     /// **Note**: Cannot be combined with `.postgres()`. If both are set, `build()` will
     /// return an error.
+    ///
+    /// # Multiple Tests
+    ///
+    /// Each call to `.with_embedded_postgres()` starts a separate PostgreSQL server.
+    /// If you have many tests, prefer starting one [`EmbeddedPostgres`](crate::embedded_postgres::EmbeddedPostgres)
+    /// instance and passing its connection string via `.postgres()` instead.
+    /// See [`EmbeddedPostgres`](crate::embedded_postgres::EmbeddedPostgres) docs for the recommended pattern.
     #[cfg(feature = "embedded-postgres")]
     pub fn with_embedded_postgres(mut self) -> Self {
         self.use_embedded_postgres = true;

--- a/pubky-testnet/src/lib.rs
+++ b/pubky-testnet/src/lib.rs
@@ -4,7 +4,7 @@ mod static_testnet;
 mod testnet;
 
 #[cfg(feature = "embedded-postgres")]
-mod embedded_postgres;
+pub mod embedded_postgres;
 pub use ephemeral_testnet::{EphemeralTestnet, EphemeralTestnetBuilder};
 pub use static_testnet::StaticTestnet;
 pub use testnet::Testnet;


### PR DESCRIPTION
 Instructions for sharing postgres instances in tests and some troubleshooting for if rate limits are hit