### PR TITLE
feat: Publish crates and npm package via Trusted Publisher auth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,20 +92,26 @@ jobs:
     name: Publish to crates.io
     needs: build-artifacts
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: auth
       - name: Install cargo-workspaces
         run: cargo install cargo-workspaces
       - name: Publish crates
         run: cargo ws publish --no-git-commit --publish-as-is
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
 
   publish-npm:
     name: Publish to npm
     needs: build-artifacts
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -118,6 +124,4 @@ jobs:
         run: |
           npm ci
           npm run build
-          npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          npm publish --provenance


### PR DESCRIPTION
Docs: 
- https://docs.npmjs.com/trusted-publishers
- https://crates.io/docs/trusted-publishing