### PR TITLE
Feat: Use http scheme not only for localhost but for ip address also

### DIFF
--- a/pubky-common/src/constants.rs
+++ b/pubky-common/src/constants.rs
@@ -15,7 +15,7 @@ pub mod reserved_param_keys {
 ///
 /// These hosts need an explicit [`reserved_param_keys::HTTP_PORT`] in their
 /// SVCB record so clients know which port to connect to over HTTP.
-/// 
+///
 /// TODO: This should live in pkarr crate with all other SVCB/HTTPS record logic.
 pub fn requires_http_port(domain: &str) -> bool {
     domain == "localhost" || domain.parse::<IpAddr>().is_ok()

--- a/pubky-common/src/constants.rs
+++ b/pubky-common/src/constants.rs
@@ -1,10 +1,24 @@
 //! Constants used across Pubky.
 
+use std::net::IpAddr;
+
 /// [Reserved param keys](https://www.rfc-editor.org/rfc/rfc9460#name-initial-contents) for HTTPS Resource Records
 pub mod reserved_param_keys {
     /// HTTPS (RFC 9460) record's private param key, used to inform browsers
-    /// about the HTTP port to use when the domain is localhost.
+    /// about the HTTP port to use on domains that cannot obtain TLS certificates
+    /// (localhost, bare IP addresses).
     pub const HTTP_PORT: u16 = 65280;
+}
+
+/// Returns `true` when the domain cannot obtain a TLS certificate and must
+/// use plain HTTP instead — i.e. `localhost` or a bare IP address.
+///
+/// These hosts need an explicit [`reserved_param_keys::HTTP_PORT`] in their
+/// SVCB record so clients know which port to connect to over HTTP.
+/// 
+/// TODO: This should live in pkarr crate with all other SVCB/HTTPS record logic.
+pub fn requires_http_port(domain: &str) -> bool {
+    domain == "localhost" || domain.parse::<IpAddr>().is_ok()
 }
 
 /// Local test network's hardcoded port numbers for local development.

--- a/pubky-homeserver/src/republishers/key_republisher.rs
+++ b/pubky-homeserver/src/republishers/key_republisher.rs
@@ -12,6 +12,7 @@ use anyhow::Result;
 use pkarr::dns::Name;
 use pkarr::errors::PublishError;
 use pkarr::{dns::rdata::SVCB, SignedPacket};
+use pubky_common::constants::requires_http_port;
 
 use crate::app_context::AppContext;
 use tokio::task::JoinHandle;
@@ -147,18 +148,12 @@ pub fn create_signed_packet(
         let mut svcb = SVCB::new(10, root_name.clone());
 
         let http_port_be_bytes = public_icann_http_port.to_be_bytes();
-
-        // Check if the domain is "localhost" OR a valid IP address, for testnets sometimes it could be useful to use an ip address
-        let domain_str = domain.0.as_str();
-        let is_local_or_ip = domain_str == "localhost" || domain_str.parse::<IpAddr>().is_ok();
-
-        if is_local_or_ip {
+        if requires_http_port(&domain.0) {
             svcb.set_param(
                 pubky_common::constants::reserved_param_keys::HTTP_PORT,
                 &http_port_be_bytes,
             )?;
         }
-
         svcb.target = domain.0.as_str().try_into()?;
         signed_packet_builder = signed_packet_builder.https(root_name.clone(), svcb, 60 * 60);
     }

--- a/pubky-homeserver/src/republishers/key_republisher.rs
+++ b/pubky-homeserver/src/republishers/key_republisher.rs
@@ -147,12 +147,18 @@ pub fn create_signed_packet(
         let mut svcb = SVCB::new(10, root_name.clone());
 
         let http_port_be_bytes = public_icann_http_port.to_be_bytes();
-        if domain.0 == "localhost" {
+
+        // Check if the domain is "localhost" OR a valid IP address, for testnets sometimes it cloud be usefull to use an ip address
+        let domain_str = domain.0.as_str();
+        let is_local_or_ip = domain_str == "localhost" || domain_str.parse::<IpAddr>().is_ok();
+
+        if is_local_or_ip {
             svcb.set_param(
                 pubky_common::constants::reserved_param_keys::HTTP_PORT,
                 &http_port_be_bytes,
             )?;
         }
+
         svcb.target = domain.0.as_str().try_into()?;
         signed_packet_builder = signed_packet_builder.https(root_name.clone(), svcb, 60 * 60);
     }

--- a/pubky-homeserver/src/republishers/key_republisher.rs
+++ b/pubky-homeserver/src/republishers/key_republisher.rs
@@ -148,7 +148,7 @@ pub fn create_signed_packet(
 
         let http_port_be_bytes = public_icann_http_port.to_be_bytes();
 
-        // Check if the domain is "localhost" OR a valid IP address, for testnets sometimes it cloud be usefull to use an ip address
+        // Check if the domain is "localhost" OR a valid IP address, for testnets sometimes it could be useful to use an ip address
         let domain_str = domain.0.as_str();
         let is_local_or_ip = domain_str == "localhost" || domain_str.parse::<IpAddr>().is_ok();
 

--- a/pubky-sdk/src/client/http_targets/wasm.rs
+++ b/pubky-sdk/src/client/http_targets/wasm.rs
@@ -1,5 +1,7 @@
 //! HTTP methods that support `https://` with Pkarr domains, including `_pubky.<pk>` URLs
 
+use std::net::IpAddr;
+
 use crate::PublicKey;
 use crate::errors::{PkarrError, RequestError, Result};
 use crate::{PubkyHttpClient, cross_log};

--- a/pubky-sdk/src/client/http_targets/wasm.rs
+++ b/pubky-sdk/src/client/http_targets/wasm.rs
@@ -131,7 +131,7 @@ impl PubkyHttpClient {
 
     fn apply_endpoint_to_url(&self, url: &mut Url, endpoint: &Endpoint) -> Result<()> {
         let is_testnet_domain = endpoint.domain().is_some_and(|domain| {
-            if domain == "localhost" {
+            if domain == "localhost" || domain.parse::<IpAddr>().is_ok() {
                 return true;
             }
             if let Some(test_host) = &self.testnet_host {

--- a/pubky-sdk/src/client/http_targets/wasm.rs
+++ b/pubky-sdk/src/client/http_targets/wasm.rs
@@ -1,7 +1,5 @@
 //! HTTP methods that support `https://` with Pkarr domains, including `_pubky.<pk>` URLs
 
-use std::net::IpAddr;
-
 use crate::PublicKey;
 use crate::errors::{PkarrError, RequestError, Result};
 use crate::{PubkyHttpClient, cross_log};
@@ -133,7 +131,7 @@ impl PubkyHttpClient {
 
     fn apply_endpoint_to_url(&self, url: &mut Url, endpoint: &Endpoint) -> Result<()> {
         let is_testnet_domain = endpoint.domain().is_some_and(|domain| {
-            if domain == "localhost" || domain.parse::<IpAddr>().is_ok() {
+            if pubky_common::constants::requires_http_port(domain) {
                 return true;
             }
             if let Some(test_host) = &self.testnet_host {


### PR DESCRIPTION
Problem: Not it is not possible to run testnet on vms, because if you set the `icann_domain` to vm's ip the `https` scheme will be used.

Currently the the `http` scheme is used only for hardcoded `localhost`, this is not flexible. 

I suggest to also to check if domain is a valid IP address and if so apply the `http` scheme as a quick fix.

I think the proper solution would be - use flag for `homeserver` like `icann_protocol` this flag will be published to `pkarr` like it's done now with `public_icann_http_port`. And get this value on resolve, without any hardcoded values.
 I didn't implement this solution, because not sure if it's the right one.
So, @SeverinAlexB @86667 @SHAcollision  wanna hear your ideas on that topic, and implement the one you decided the best. 