### PR TITLE
refactor(common)!: normalize capabilities construction

### DIFF
--- a/pubky-common/src/auth.rs
+++ b/pubky-common/src/auth.rs
@@ -256,7 +256,7 @@ mod tests {
     #[test]
     fn expired() {
         let signer = Keypair::random();
-        let capabilities = Capabilities(vec![Capability::root()]);
+        let capabilities = Capabilities::from(vec![Capability::root()]);
 
         let verifier = AuthVerifier::default();
 
@@ -310,7 +310,7 @@ mod tests {
             version: 0,
             timestamp,
             public_key: signer.public_key(),
-            capabilities: Capabilities(vec![Capability::root()]),
+            capabilities: Capabilities::from(vec![Capability::root()]),
         };
 
         let serialized = token.serialize();
@@ -391,7 +391,7 @@ mod tests {
             version: 1,
             timestamp: Timestamp::now(),
             public_key: signer.public_key(),
-            capabilities: Capabilities(vec![Capability::root()]),
+            capabilities: Capabilities::from(vec![Capability::root()]),
         };
         let serialized = token.serialize();
 

--- a/pubky-common/src/capabilities.rs
+++ b/pubky-common/src/capabilities.rs
@@ -272,7 +272,7 @@ impl TryFrom<&str> for Capability {
 
         let scope = value[0..value.len() - actions_str.len() - 1].to_string();
 
-        Ok(Capability { scope, actions })
+        Ok(Self { scope, actions })
     }
 }
 
@@ -327,9 +327,30 @@ pub enum Error {
 /// bespoke encoder/decoder instead of serde.
 #[derive(Clone, Default, Debug, PartialEq, Eq)]
 #[must_use]
-pub struct Capabilities(pub Vec<Capability>);
+pub struct Capabilities(Vec<Capability>);
 
 impl Capabilities {
+    /// Return a normalized capability list.
+    ///
+    /// Normalization merges duplicate scopes, de-duplicates and sorts actions,
+    /// and removes capabilities already covered by broader capabilities.
+    ///
+    /// # Examples
+    /// ```
+    /// use pubky_common::capabilities::{Capability, Capabilities};
+    ///
+    /// let caps = Capabilities::from(vec![
+    ///     Capability::read("/pub/"),
+    ///     Capability::write("/pub/"),
+    ///     Capability::read("/pub/file.txt"),
+    /// ]);
+    ///
+    /// assert_eq!(caps.normalize().to_string(), "/pub/:rw");
+    /// ```
+    pub fn normalize(self) -> Self {
+        Self(normalize(self.0))
+    }
+
     /// Returns true if the list contains `capability`.
     pub fn contains(&self, capability: &Capability) -> bool {
         self.0.contains(capability)
@@ -350,37 +371,6 @@ impl Capabilities {
         self.0.iter()
     }
 
-    /// Parse capabilities from the `caps` query parameter.
-    ///
-    /// Expects a comma-separated list of capability strings, e.g.:
-    /// `?caps=/pub/my-cool-app/:rw,/foo:r`
-    ///
-    /// Invalid entries are ignored.
-    ///
-    /// # Examples
-    /// ```
-    /// # use url::Url;
-    /// # use pubky_common::capabilities::Capabilities;
-    /// let url = Url::parse("https://example/app?caps=/pub/my-cool-app/:rw,/foo:r").unwrap();
-    /// let caps = Capabilities::from_url(&url);
-    /// assert!(!caps.is_empty());
-    /// ```
-    pub fn from_url(url: &Url) -> Self {
-        // Get the first `caps` entry if present.
-        let value = url
-            .query_pairs()
-            .find_map(|(k, v)| (k == "caps").then(|| v.to_string()))
-            .unwrap_or_default();
-
-        // Parse comma-separated capabilities, skipping invalid pieces.
-        let caps = value
-            .split(',')
-            .filter_map(|s| Capability::try_from(s).ok())
-            .collect();
-
-        Capabilities(sanitize_caps(caps))
-    }
-
     /// Start a fluent builder for multiple capabilities.
     ///
     /// ```
@@ -392,6 +382,37 @@ impl Capabilities {
         CapsBuilder::default()
     }
 
+    /// Parse capabilities from the `caps` query parameter of `url`.
+    ///
+    /// Expects a comma-separated list of capability strings, e.g.:
+    /// `?caps=/pub/my-cool-app/:rw,/foo:r`
+    ///
+    /// Invalid entries are ignored.
+    ///
+    /// # Examples
+    /// ```
+    /// # use url::Url;
+    /// # use pubky_common::capabilities::Capabilities;
+    /// let url = Url::parse("https://example/app?caps=/pub/my-cool-app/:rw,/foo:r").unwrap();
+    /// let caps = Capabilities::from_caps_url(&url);
+    /// assert!(!caps.is_empty());
+    /// ```
+    pub fn from_caps_url(url: &Url) -> Self {
+        // Get the first `caps` entry if present.
+        let value = url
+            .query_pairs()
+            .find_map(|(k, v)| (k == "caps").then(|| v.to_string()))
+            .unwrap_or_default();
+
+        // Parse comma-separated capabilities, skipping invalid pieces.
+        let caps: Vec<_> = value
+            .split(',')
+            .filter_map(|s| Capability::try_from(s).ok())
+            .collect();
+
+        Self::from(caps)
+    }
+
     /// Borrow the inner capabilities as a slice without allocating.
     ///
     /// Constant-time; returns a view into the existing buffer.
@@ -400,7 +421,7 @@ impl Capabilities {
     /// ```
     /// use pubky_common::capabilities::{Capability, Capabilities};
     ///
-    /// let caps = Capabilities(vec![
+    /// let caps = Capabilities::from(vec![
     ///     Capability::read("/foo"),
     ///     Capability::write("/bar/"),
     /// ]);
@@ -410,23 +431,6 @@ impl Capabilities {
     #[inline]
     pub fn as_slice(&self) -> &[Capability] {
         &self.0
-    }
-
-    /// Clone the inner capabilities into an owned `Vec<Capability>`.
-    ///
-    /// Allocates and performs an `O(n)` clone of the elements. Use when
-    /// ownership is required by downstream APIs.
-    ///
-    /// ```
-    /// use pubky_common::capabilities::{Capability, Capabilities};
-    ///
-    /// let caps = Capabilities(vec![Capability::read("/")]);
-    /// let owned: Vec<Capability> = caps.to_vec();
-    /// assert_eq!(owned, vec![Capability::read("/")]);
-    /// ```
-    #[inline]
-    pub fn to_vec(&self) -> Vec<Capability> {
-        self.0.clone()
     }
 }
 
@@ -493,9 +497,9 @@ impl CapsBuilder {
         self
     }
 
-    /// Finalize and produce the [`Capabilities`] list.
+    /// Finalize and produce the normalized [`Capabilities`] list.
     pub fn finish(self) -> Capabilities {
-        Capabilities(sanitize_caps(self.caps))
+        Capabilities::from(self.caps).normalize()
     }
 }
 
@@ -523,21 +527,7 @@ impl TryFrom<&str> for Capabilities {
             };
         }
 
-        Ok(Capabilities(sanitize_caps(caps)))
-    }
-}
-
-/// Allow `Capabilities::from(&url)` using the default `caps` key.
-impl From<&Url> for Capabilities {
-    fn from(url: &Url) -> Self {
-        Capabilities::from_url(url)
-    }
-}
-
-/// Allow `Capabilities::from(url)` (by value) using the default `caps` key.
-impl From<Url> for Capabilities {
-    fn from(url: Url) -> Self {
-        Capabilities::from_url(&url)
+        Ok(Self::from(caps))
     }
 }
 
@@ -578,7 +568,7 @@ impl<'de> Deserialize<'de> for Capabilities {
             };
         }
 
-        Ok(Capabilities(sanitize_caps(caps)))
+        Ok(Self::from(caps))
     }
 }
 
@@ -603,7 +593,7 @@ fn scope_covers(parent: &str, child: &str) -> bool {
     child.starts_with(parent)
 }
 
-fn sanitize_caps(caps: Vec<Capability>) -> Vec<Capability> {
+fn normalize(caps: Vec<Capability>) -> Vec<Capability> {
     let mut merged: Vec<Capability> = Vec::new();
 
     for mut cap in caps {
@@ -750,7 +740,9 @@ mod tests {
     #[test]
     fn parse_from_string_list() {
         // From a comma-separated string:
-        let parsed = Capabilities::try_from("/:rw,/pub/my-cool-app/:r").unwrap();
+        let parsed = Capabilities::try_from("/:rw,/pub/my-cool-app/:r")
+            .unwrap()
+            .normalize();
         let built = Capabilities::builder()
             .read_write("/") // "/:rw"
             .read("/pub/my-cool-app/") // "/pub/my-cool-app/:r"
@@ -763,15 +755,15 @@ mod tests {
     fn parse_errors_are_informative() {
         // Invalid scope (doesn't start with '/'):
         let e = Capability::try_from("not/abs:rw").unwrap_err();
-        assert!(matches!(e, Error::InvalidScope));
+        assert_eq!(e, Error::InvalidScope);
 
         // Invalid format (missing ':'):
         let e = Capability::try_from("/pub/my.app").unwrap_err();
-        assert!(matches!(e, Error::InvalidFormat));
+        assert_eq!(e, Error::InvalidFormat);
 
         // Invalid action:
         let e = Capability::try_from("/pub/my.app:rx").unwrap_err();
-        assert!(matches!(e, Error::InvalidAction));
+        assert_eq!(e, Error::InvalidAction);
     }
 
     #[test]
@@ -780,7 +772,8 @@ mod tests {
             .read_write("/pub/example.com/")
             .read_write("/pub/example.com/")
             .write("/pub/example.com/subfolder")
-            .finish();
+            .finish()
+            .normalize();
 
         assert_eq!(caps.to_string(), "/pub/example.com/:rw");
     }
@@ -790,7 +783,8 @@ mod tests {
         let parsed = Capabilities::try_from(
             "/pub/example.com/:rw,/pub/example.com/:rw,/pub/example.com/subfolder:w",
         )
-        .unwrap();
+        .unwrap()
+        .normalize();
 
         let caps = Capabilities::builder()
             .read_write("/pub/example.com/")
@@ -806,7 +800,7 @@ mod tests {
             "https://example.test?caps=/pub/example.com/:rw,/pub/example.com/documents:w",
         )
         .unwrap();
-        let caps = Capabilities::from_url(&url);
+        let caps = Capabilities::from_caps_url(&url).normalize();
 
         assert_eq!(caps.to_string(), "/pub/example.com/:rw");
     }
@@ -816,7 +810,20 @@ mod tests {
         let caps = Capabilities::builder()
             .read("/pub/example.com/")
             .write("/pub/example.com/")
-            .finish();
+            .finish()
+            .normalize();
+
+        assert_eq!(caps.to_string(), "/pub/example.com/:rw");
+    }
+
+    #[test]
+    fn capabilities_normalize_dedups_from_vec() {
+        let caps = Capabilities::from(vec![
+            Capability::read_write("/pub/example.com/"),
+            Capability::write("/pub/example.com/subfolder"),
+            Capability::read("/pub/example.com/"),
+        ])
+        .normalize();
 
         assert_eq!(caps.to_string(), "/pub/example.com/:rw");
     }

--- a/pubky-common/src/session.rs
+++ b/pubky-common/src/session.rs
@@ -36,7 +36,7 @@ impl SessionInfo {
             version: 0,
             public_key: public_key.clone(),
             created_at: Timestamp::now().as_u64(),
-            capabilities: capabilities.to_vec(),
+            capabilities: capabilities.into(),
             user_agent: user_agent.as_deref().unwrap_or("").to_string(),
             name: user_agent.as_deref().unwrap_or("").to_string(),
         }
@@ -69,7 +69,7 @@ impl SessionInfo {
 
     /// Set this session's capabilities.
     pub fn set_capabilities(&mut self, capabilities: Capabilities) -> &mut Self {
-        self.capabilities = capabilities.to_vec();
+        self.capabilities = capabilities.into();
 
         self
     }
@@ -125,7 +125,7 @@ mod tests {
 
         let session = SessionInfo {
             user_agent: "foo".to_string(),
-            capabilities: capabilities.to_vec(),
+            capabilities: capabilities.into(),
             created_at: 0,
             public_key,
             version: 0,

--- a/pubky-sdk/bindings/js/src/wrappers/capabilities.rs
+++ b/pubky-sdk/bindings/js/src/wrappers/capabilities.rs
@@ -27,7 +27,7 @@ fn normalize_and_collect(input: &str) -> (String, Vec<String>) {
         }
     }
 
-    let normalized = Capabilities(valid).to_string(); // normalizes action order (:rw)
+    let normalized = Capabilities::from(valid).normalize().to_string();
     (normalized, invalid)
 }
 

--- a/pubky-sdk/src/actors/signer/auth.rs
+++ b/pubky-sdk/src/actors/signer/auth.rs
@@ -43,7 +43,7 @@ impl PubkySigner {
         cross_log!(info, "Approving auth flow via relay {relay}");
 
         // 2) Build token with requested capabilities parsed from URL
-        let capabilities = Capabilities::from(&pubkyauth_url);
+        let capabilities = Capabilities::from_caps_url(&pubkyauth_url).normalize();
         cross_log!(
             info,
             "Signing capabilities {:?} for auth approval",


### PR DESCRIPTION
Keep capability lists canonical by deduplicating repeated scopes and removing entries covered by broader capabilities.

BREAKING CHANGE: `Capabilities(vec![...])` construction, `to_vec()`, and `from_url()` were removed. Use `Capabilities::from(vec![...])` or `Capabilities::builder()` to construct values, `Into<Vec<Capability>>` for owned access, and `(&url).into()` for URL parsing instead.

Closes #232.