### PR TITLE
feat: signup_count metric

### DIFF
--- a/e2e/src/tests/metrics.rs
+++ b/e2e/src/tests/metrics.rs
@@ -242,6 +242,7 @@ async fn metrics_comprehensive() {
         "event_stream_db_query_duration_ms",
         "event_stream_active_connections",
         "event_stream_connection_duration_ms",
+        "signup_count",
     ];
 
     for metric in all_expected_metrics {
@@ -252,4 +253,11 @@ async fn metrics_comprehensive() {
             final_metrics
         );
     }
+
+    // Verify signup_count reflects exactly 2 signups (keypair1 and keypair2)
+    assert!(
+        final_metrics.contains("signup_count_total{otel_scope_name=\"pubky_homeserver\"} 2"),
+        "Should have exactly 2 signups recorded, metrics:\n{}",
+        final_metrics
+    );
 }

--- a/pubky-homeserver/src/client_server/routes/auth.rs
+++ b/pubky-homeserver/src/client_server/routes/auth.rs
@@ -73,7 +73,7 @@ pub async fn signup(
     }
 
     // 3) If signup_mode == token_required, require & validate a `signup_token` param.
-    if state.signup_mode == SignupMode::TokenRequired {
+    let user = if state.signup_mode == SignupMode::TokenRequired {
         let signup_token_param = params
             .get("signup_token")
             .ok_or(HttpError::new_with_message(
@@ -124,19 +124,19 @@ pub async fn signup(
 
         // 4) Create the new user record with the token's limits.
         let limits = code.quota();
-        let user = state
+        state
             .user_service
             .create_user(public_key, &limits, tx)
-            .await?;
-        return create_session_and_cookie(&state, cookies, &host, &user, token.capabilities())
-            .await;
-    }
+            .await?
+    } else {
+        // 4) Create the new user record (open signup, no token).
+        state
+            .user_service
+            .create_user(public_key, &UserQuota::default(), tx)
+            .await?
+    };
 
-    // 4) Create the new user record (open signup, no token).
-    let user = state
-        .user_service
-        .create_user(public_key, &UserQuota::default(), tx)
-        .await?;
+    state.metrics.record_signup();
 
     // 5) Create session & set cookie
     create_session_and_cookie(&state, cookies, &host, &user, token.capabilities()).await

--- a/pubky-homeserver/src/metrics_server/routes/metrics.rs
+++ b/pubky-homeserver/src/metrics_server/routes/metrics.rs
@@ -16,6 +16,7 @@ pub const EVENT_STREAM_BROADCAST_LAGGED_COUNT: &str = "event_stream_broadcast_la
 pub const EVENT_STREAM_BROADCAST_HALF_FULL_COUNT: &str = "event_stream_broadcast_half_full_count";
 pub const EVENT_STREAM_ACTIVE_CONNECTIONS: &str = "event_stream_active_connections";
 pub const EVENT_STREAM_CONNECTION_DURATION: &str = "event_stream_connection_duration_ms";
+pub const SIGNUP_COUNT: &str = "signup_count";
 
 #[derive(Clone, Debug)]
 pub struct Metrics {
@@ -27,6 +28,7 @@ pub struct Metrics {
     event_stream_broadcast_half_full_count: Counter<u64>,
     event_stream_active_connections: UpDownCounter<i64>,
     event_stream_connection_duration: Histogram<f64>,
+    signup_count: Counter<u64>,
 }
 
 impl Metrics {
@@ -66,6 +68,11 @@ impl Metrics {
             .with_boundaries(vec![10.0, 100.0, 1_000.0, 10_000.0, 100_000.0])
             .build();
 
+        let signup_count = meter
+            .u64_counter(SIGNUP_COUNT)
+            .with_description("Total number of successful signups")
+            .build();
+
         Ok(Self {
             registry: Arc::new(registry),
             _provider: Arc::new(provider),
@@ -75,6 +82,7 @@ impl Metrics {
             event_stream_broadcast_half_full_count,
             event_stream_active_connections,
             event_stream_connection_duration,
+            signup_count,
         })
     }
 
@@ -111,6 +119,12 @@ impl Metrics {
     pub fn record_connection_closed(&self, duration_ms: u128) {
         self.event_stream_connection_duration
             .record(duration_ms as f64, &[]);
+    }
+
+    // === signup metrics ===
+
+    pub fn record_signup(&self) {
+        self.signup_count.add(1, &[]);
     }
 
     /// Render Prometheus metrics in text format
@@ -166,6 +180,7 @@ mod tests {
         metrics.record_broadcast_lagged();
         metrics.record_broadcast_half_full();
         metrics.record_connection_closed(30);
+        metrics.record_signup();
 
         let output = metrics.render().expect("Failed to render metrics");
 
@@ -207,6 +222,12 @@ mod tests {
             output.contains(EVENT_STREAM_CONNECTION_DURATION),
             "Missing {} in: {}",
             EVENT_STREAM_CONNECTION_DURATION,
+            output
+        );
+        assert!(
+            output.contains(SIGNUP_COUNT),
+            "Missing {} in: {}",
+            SIGNUP_COUNT,
             output
         );
     }


### PR DESCRIPTION
Adds a signup counter to `/metrics` for prometheus alerting. This is primarily for catching low-tiered user signup spam.