### PR TITLE
fix(homeserver): apply burst to request rate limits

### DIFF
--- a/e2e/src/tests/rate_limiting.rs
+++ b/e2e/src/tests/rate_limiting.rs
@@ -5,7 +5,7 @@ use pubky_testnet::pubky::{
 };
 use pubky_testnet::{
     pubky_homeserver::{
-        quota_config::{GlobPattern, LimitKey, LimitKeyType, PathLimit},
+        quota_config::{GlobPattern, HttpMethod, LimitKey, LimitKeyType, PathLimit},
         ConfigToml, SignupMode,
     },
     EphemeralTestnet,
@@ -17,21 +17,23 @@ async fn test_limit_signin_get_session() {
     let mut config = ConfigToml::default_test_config();
     config.drive.rate_limits = vec![
         // Limit sign-ins: POST /session by IP
-        PathLimit::new(
-            GlobPattern::new("/session"),
-            Method::POST,
-            "1r/m".parse().unwrap(),
-            LimitKeyType::Ip,
-            None,
-        ),
+        PathLimit {
+            path: GlobPattern::new("/session"),
+            method: HttpMethod(Method::POST),
+            quota: "1r/m".parse().unwrap(),
+            key: LimitKeyType::Ip,
+            burst: None,
+            whitelist: Vec::new(),
+        },
         // Limit session fetch/validate: GET /session by User
-        PathLimit::new(
-            GlobPattern::new("/session"),
-            Method::GET,
-            "1r/m".parse().unwrap(),
-            LimitKeyType::User,
-            None,
-        ),
+        PathLimit {
+            path: GlobPattern::new("/session"),
+            method: HttpMethod(Method::GET),
+            quota: "1r/m".parse().unwrap(),
+            key: LimitKeyType::User,
+            burst: None,
+            whitelist: Vec::new(),
+        },
     ];
 
     let testnet = EphemeralTestnet::builder()
@@ -81,13 +83,14 @@ async fn test_limit_signin_get_session_whitelist() {
 
     // Rate-limit GET /session by user, but whitelist `whitelisted_pubkey`
     let mut config = ConfigToml::default_test_config();
-    let mut limit = PathLimit::new(
-        GlobPattern::new("/session"),
-        Method::GET,
-        "1r/m".parse().unwrap(),
-        LimitKeyType::User,
-        None,
-    );
+    let mut limit = PathLimit {
+        path: GlobPattern::new("/session"),
+        method: HttpMethod(Method::GET),
+        quota: "1r/m".parse().unwrap(),
+        key: LimitKeyType::User,
+        burst: None,
+        whitelist: Vec::new(),
+    };
     limit
         .whitelist
         .push(LimitKey::User(whitelisted_pubkey.clone()));
@@ -137,13 +140,14 @@ async fn test_limit_signin_get_session_whitelist() {
 async fn test_limit_events() {
     // Rate-limit GET /events/ by IP
     let mut config = ConfigToml::default_test_config();
-    config.drive.rate_limits = vec![PathLimit::new(
-        GlobPattern::new("/events/"),
-        Method::GET,
-        "1r/m".parse().unwrap(),
-        LimitKeyType::Ip,
-        None,
-    )];
+    config.drive.rate_limits = vec![PathLimit {
+        path: GlobPattern::new("/events/"),
+        method: HttpMethod(Method::GET),
+        quota: "1r/m".parse().unwrap(),
+        key: LimitKeyType::Ip,
+        burst: None,
+        whitelist: Vec::new(),
+    }];
 
     let testnet = EphemeralTestnet::builder()
         .config(config)
@@ -289,13 +293,14 @@ async fn test_limit_signup_tokens() {
     // Configure with token-required signup mode and rate limit on signup_tokens
     let mut config = ConfigToml::default_test_config();
     config.general.signup_mode = SignupMode::TokenRequired;
-    config.drive.rate_limits = vec![PathLimit::new(
-        GlobPattern::new("/signup_tokens/*"),
-        Method::GET,
-        "1r/m".parse().unwrap(),
-        LimitKeyType::Ip,
-        None,
-    )];
+    config.drive.rate_limits = vec![PathLimit {
+        path: GlobPattern::new("/signup_tokens/*"),
+        method: HttpMethod(Method::GET),
+        quota: "1r/m".parse().unwrap(),
+        key: LimitKeyType::Ip,
+        burst: None,
+        whitelist: Vec::new(),
+    }];
 
     let testnet = EphemeralTestnet::builder()
         .config(config)

--- a/pubky-common/src/events.rs
+++ b/pubky-common/src/events.rs
@@ -155,9 +155,7 @@ mod tests {
     #[test]
     fn event_type_content_hash() {
         let hash = Hash::from_bytes([1; 32]);
-        let put = EventType::Put {
-            content_hash: hash.clone(),
-        };
+        let put = EventType::Put { content_hash: hash };
         let del = EventType::Delete;
 
         assert_eq!(put.content_hash(), Some(&hash));

--- a/pubky-homeserver/src/client_server/app.rs
+++ b/pubky-homeserver/src/client_server/app.rs
@@ -44,13 +44,10 @@ pub enum ClientServerBuildError {
     PubkyTlsServer(anyhow::Error),
     /// Failed to convert the data directory to an AppContext.
     #[error("AppContext conversion error: {0}")]
-    AppContext(AppContextConversionError),
-}
-
-impl From<AppContextConversionError> for ClientServerBuildError {
-    fn from(error: AppContextConversionError) -> Self {
-        ClientServerBuildError::AppContext(error)
-    }
+    AppContext(#[from] AppContextConversionError),
+    /// Failed to build request-count rate limit layer.
+    #[error("Request-count rate limit configuration error: {0}")]
+    RequestRateLimits(String),
 }
 
 /// A Pubky homeserver with ICANN HTTP and Pubky TLS servers.
@@ -94,7 +91,7 @@ impl ClientServer {
 
     /// Start homeserver services with the given application context.
     pub async fn start(context: AppContext) -> std::result::Result<Self, ClientServerBuildError> {
-        let router = Self::create_router(&context);
+        let router = Self::create_router(&context)?;
 
         let (icann_http_handle, icann_http_socket) =
             Self::start_icann_http_server(&context, router.clone())
@@ -113,7 +110,9 @@ impl ClientServer {
         })
     }
 
-    pub(crate) fn create_router(context: &AppContext) -> Router {
+    pub(crate) fn create_router(
+        context: &AppContext,
+    ) -> std::result::Result<Router, ClientServerBuildError> {
         let state = AppState {
             verifier: AuthVerifier::default(),
             sql_db: context.sql_db.clone(),
@@ -124,7 +123,7 @@ impl ClientServer {
             user_service: context.user_service.clone(),
             default_storage_mb: context.config_toml.storage.default_quota_mb,
         };
-        super::create_app(state.clone(), context)
+        super::create_app(state.clone(), context).map_err(ClientServerBuildError::RequestRateLimits)
     }
 
     /// Start the ICANN HTTP server
@@ -222,7 +221,10 @@ fn base() -> Router<AppState> {
     // TODO: maybe add to a separate router (drive router?).
 }
 
-pub fn create_app(state: AppState, context: &AppContext) -> Router {
+pub fn create_app(state: AppState, context: &AppContext) -> std::result::Result<Router, String> {
+    let request_rate_limit_layer =
+        RequestRateLimitLayer::from_path_limits(context.config_toml.drive.rate_limits.clone())?;
+
     let app = base()
         .merge(tenants::router(state.clone()))
         .layer(CorsLayer::very_permissive())
@@ -230,13 +232,11 @@ pub fn create_app(state: AppState, context: &AppContext) -> Router {
             context.user_service.clone(),
             context.config_toml.default_quotas.clone(),
         ))
-        .layer(RequestRateLimitLayer::new(
-            context.config_toml.drive.rate_limits.clone(),
-        ))
+        .layer(request_rate_limit_layer)
         .layer(CookieManagerLayer::new())
         .layer(PubkyHostLayer)
         .with_state(state);
 
     // Apply trace and pubky host layers to the complete router.
-    with_trace_layer(app)
+    Ok(with_trace_layer(app))
 }

--- a/pubky-homeserver/src/client_server/app.rs
+++ b/pubky-homeserver/src/client_server/app.rs
@@ -123,7 +123,7 @@ impl ClientServer {
             user_service: context.user_service.clone(),
             default_storage_mb: context.config_toml.storage.default_quota_mb,
         };
-        super::create_app(state.clone(), context).map_err(ClientServerBuildError::RequestRateLimits)
+        super::create_app(state.clone(), context)
     }
 
     /// Start the ICANN HTTP server
@@ -221,9 +221,13 @@ fn base() -> Router<AppState> {
     // TODO: maybe add to a separate router (drive router?).
 }
 
-pub fn create_app(state: AppState, context: &AppContext) -> std::result::Result<Router, String> {
+pub fn create_app(
+    state: AppState,
+    context: &AppContext,
+) -> std::result::Result<Router, ClientServerBuildError> {
     let request_rate_limit_layer =
-        RequestRateLimitLayer::from_path_limits(context.config_toml.drive.rate_limits.clone())?;
+        RequestRateLimitLayer::from_path_limits(context.config_toml.drive.rate_limits.clone())
+            .map_err(ClientServerBuildError::RequestRateLimits)?;
 
     let app = base()
         .merge(tenants::router(state.clone()))

--- a/pubky-homeserver/src/client_server/layers/rate_limiter/limiter_pool.rs
+++ b/pubky-homeserver/src/client_server/layers/rate_limiter/limiter_pool.rs
@@ -84,8 +84,8 @@ pub(super) struct LimitTuple {
 }
 
 impl LimitTuple {
-    pub fn new(path_limit: PathLimit) -> Self {
-        let quota: Quota = path_limit.clone().into();
+    pub fn new(path_limit: PathLimit) -> Result<Self, String> {
+        let quota = Quota::try_from(path_limit.clone())?;
         let limiter = Arc::new(RateLimiter::keyed(quota));
 
         // Forget keys that are not used anymore. This is to prevent memory leaks.
@@ -104,10 +104,10 @@ impl LimitTuple {
             }
         });
 
-        Self {
+        Ok(Self {
             limit: path_limit,
             limiter,
-        }
+        })
     }
 
     /// Extract the key from the request.

--- a/pubky-homeserver/src/client_server/layers/rate_limiter/mod.rs
+++ b/pubky-homeserver/src/client_server/layers/rate_limiter/mod.rs
@@ -31,7 +31,7 @@ mod tests {
     use crate::client_server::layers::pubky_host::PubkyHostLayer;
     use crate::data_directory::quota_config::BandwidthQuota;
     use crate::persistence::sql::SqlDb;
-    use crate::quota_config::{GlobPattern, LimitKeyType, PathLimit};
+    use crate::quota_config::{GlobPattern, HttpMethod, LimitKeyType, PathLimit};
     use crate::services::user_service::UserService;
     use crate::shared::HttpResult;
 
@@ -62,7 +62,10 @@ mod tests {
             .route("/upload", post(upload_handler))
             .route("/download", get(download_handler))
             .layer(BandwidthQuotaLimitLayer::new(user_service, defaults))
-            .layer(RequestRateLimitLayer::new(path_limits))
+            .layer(
+                RequestRateLimitLayer::from_path_limits(path_limits)
+                    .expect("valid test request-count rate limit"),
+            )
             .layer(CookieManagerLayer::new())
             .layer(PubkyHostLayer);
 
@@ -93,13 +96,14 @@ mod tests {
         let db = SqlDb::test().await;
         let user_service = UserService::new(db);
 
-        let path_limit = PathLimit::new(
-            GlobPattern::new("/upload"),
-            Method::POST,
-            "1r/m".parse().unwrap(),
-            LimitKeyType::Ip,
-            None,
-        );
+        let path_limit = PathLimit {
+            path: GlobPattern::new("/upload"),
+            method: HttpMethod(Method::POST),
+            quota: "1r/m".parse().unwrap(),
+            key: LimitKeyType::Ip,
+            burst: None,
+            whitelist: Vec::new(),
+        };
 
         let rate: BandwidthQuota = "1kb/s".parse().unwrap();
         let defaults = crate::DefaultQuotasToml {
@@ -152,13 +156,14 @@ mod tests {
         let db = SqlDb::test().await;
         let user_service = UserService::new(db);
 
-        let path_limit = PathLimit::new(
-            GlobPattern::new("/download"),
-            Method::GET,
-            "1r/m".parse().unwrap(),
-            LimitKeyType::Ip,
-            None,
-        );
+        let path_limit = PathLimit {
+            path: GlobPattern::new("/download"),
+            method: HttpMethod(Method::GET),
+            quota: "1r/m".parse().unwrap(),
+            key: LimitKeyType::Ip,
+            burst: None,
+            whitelist: Vec::new(),
+        };
 
         let defaults = crate::DefaultQuotasToml {
             unauthenticated_ip_rate_read: Some("1kb/s".parse().unwrap()),

--- a/pubky-homeserver/src/client_server/layers/rate_limiter/request_rate_limit.rs
+++ b/pubky-homeserver/src/client_server/layers/rate_limiter/request_rate_limit.rs
@@ -26,27 +26,26 @@ use super::limiter_pool::LimitTuple;
 /// cannot be extracted.
 #[derive(Debug, Clone)]
 pub struct RequestRateLimitLayer {
-    limits: Vec<PathLimit>,
+    limits: Vec<LimitTuple>,
 }
 
 impl RequestRateLimitLayer {
-    pub fn new(path_limits: Vec<PathLimit>) -> Self {
-        if path_limits.is_empty() {
+    pub fn from_path_limits(limits: Vec<PathLimit>) -> Result<Self, String> {
+        if limits.is_empty() {
             tracing::info!("No path-based request-count rate limits configured ([[drive.rate_limits]] is empty).");
         } else {
-            let limits_str = path_limits
+            let limits_str = limits
                 .iter()
                 .map(|limit| format!("\"{limit}\""))
-                .collect::<Vec<String>>();
-            tracing::info!(
-                "Path-based rate limits configured: {}",
-                limits_str.join(", ")
-            );
+                .collect::<Vec<_>>()
+                .join(", ");
+            tracing::info!("Path-based rate limits configured: {limits_str}");
         }
-
-        Self {
-            limits: path_limits,
-        }
+        let limits = limits
+            .into_iter()
+            .map(LimitTuple::new)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self { limits })
     }
 }
 
@@ -54,11 +53,7 @@ impl<S> Layer<S> for RequestRateLimitLayer {
     type Service = RequestRateLimitMiddleware<S>;
 
     fn layer(&self, inner: S) -> Self::Service {
-        let limits = self
-            .limits
-            .iter()
-            .map(|path| LimitTuple::new(path.clone()))
-            .collect();
+        let limits = self.limits.clone();
         RequestRateLimitMiddleware { inner, limits }
     }
 }
@@ -158,7 +153,7 @@ mod tests {
     use tower_cookies::CookieManagerLayer;
 
     use crate::client_server::layers::pubky_host::PubkyHostLayer;
-    use crate::quota_config::{GlobPattern, LimitKeyType};
+    use crate::quota_config::{GlobPattern, HttpMethod, LimitKeyType};
     use crate::shared::HttpResult;
 
     use super::*;
@@ -176,7 +171,10 @@ mod tests {
         let app = Router::new()
             .route("/upload", post(upload_handler))
             .route("/download", get(download_handler))
-            .layer(RequestRateLimitLayer::new(config))
+            .layer(
+                RequestRateLimitLayer::from_path_limits(config)
+                    .expect("valid test request-count rate limit"),
+            )
             .layer(CookieManagerLayer::new())
             .layer(PubkyHostLayer);
 
@@ -202,13 +200,14 @@ mod tests {
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_limit_parallel_requests_with_ip_key() {
-        let path_limit = PathLimit::new(
-            GlobPattern::new("/upload"),
-            Method::POST,
-            "1r/m".parse().unwrap(),
-            LimitKeyType::Ip,
-            None,
-        );
+        let path_limit = PathLimit {
+            path: GlobPattern::new("/upload"),
+            method: HttpMethod(Method::POST),
+            quota: "1r/m".parse().unwrap(),
+            key: LimitKeyType::Ip,
+            burst: None,
+            whitelist: Vec::new(),
+        };
         let socket = start_server(vec![path_limit]).await;
 
         fn send_request(socket: SocketAddr) -> JoinHandle<Response> {
@@ -233,13 +232,14 @@ mod tests {
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_limit_parallel_requests_with_user_key() {
-        let path_limit = PathLimit::new(
-            GlobPattern::new("/upload"),
-            Method::POST,
-            "1r/m".parse().unwrap(),
-            LimitKeyType::User,
-            None,
-        );
+        let path_limit = PathLimit {
+            path: GlobPattern::new("/upload"),
+            method: HttpMethod(Method::POST),
+            quota: "1r/m".parse().unwrap(),
+            key: LimitKeyType::User,
+            burst: None,
+            whitelist: Vec::new(),
+        };
         let socket = start_server(vec![path_limit]).await;
 
         fn send_request(socket: SocketAddr, user_pubkey: PublicKey) -> JoinHandle<Response> {
@@ -277,13 +277,14 @@ mod tests {
 
     #[test]
     fn test_path_limit_accepts_request_count_quota() {
-        let limit = PathLimit::new(
-            GlobPattern::new("/session"),
-            Method::POST,
-            "10r/m".parse().unwrap(),
-            LimitKeyType::Ip,
-            None,
-        );
+        let limit = PathLimit {
+            path: GlobPattern::new("/session"),
+            method: HttpMethod(Method::POST),
+            quota: "10r/m".parse().unwrap(),
+            key: LimitKeyType::Ip,
+            burst: None,
+            whitelist: Vec::new(),
+        };
         assert!(limit.validate().is_ok());
     }
 }

--- a/pubky-homeserver/src/client_server/routes/tenants/read.rs
+++ b/pubky-homeserver/src/client_server/routes/tenants/read.rs
@@ -272,7 +272,7 @@ mod tests {
     pub async fn create_environment(
     ) -> anyhow::Result<(AppContext, Router, TestServer, PublicKey, String)> {
         let context = AppContext::test().await;
-        let router = ClientServer::create_router(&context);
+        let router = ClientServer::create_router(&context)?;
         let server = axum_test::TestServer::new(router.clone()).unwrap();
 
         let keypair = Keypair::random();

--- a/pubky-homeserver/src/data_directory/quota_config/bandwidth_quota.rs
+++ b/pubky-homeserver/src/data_directory/quota_config/bandwidth_quota.rs
@@ -36,8 +36,7 @@ impl BandwidthQuota {
         let rate_unit_mult = self.unit.multiplier().get();
         let rate_cells = NonZeroU32::new(self.rate.get() * rate_unit_mult)
             .expect("always non-zero: rate and multiplier are non-zero");
-        let time_unit = Duration::from_secs(self.time_unit.multiplier_in_seconds().get() as u64);
-        let replenish_1_per = time_unit / rate_cells.get();
+        let replenish_1_per = Duration::from(self.time_unit) / rate_cells.get();
         let base = governor::Quota::with_period(replenish_1_per)
             .expect("always non-zero: replenish_1_per is non-zero");
 

--- a/pubky-homeserver/src/data_directory/quota_config/path_limit.rs
+++ b/pubky-homeserver/src/data_directory/quota_config/path_limit.rs
@@ -1,5 +1,4 @@
 use super::{limit_key::LimitKey, GlobPattern, HttpMethod, LimitKeyType, RequestCountQuota};
-use axum::http::Method;
 use serde::{Deserialize, Serialize};
 use serde_valid::Validate;
 use std::num::NonZeroU32;
@@ -32,27 +31,9 @@ pub struct PathLimit {
 }
 
 impl PathLimit {
-    /// Create a new path limit.
-    pub fn new(
-        path: GlobPattern,
-        method: Method,
-        quota: RequestCountQuota,
-        key: LimitKeyType,
-        burst: Option<NonZeroU32>,
-    ) -> Self {
-        Self {
-            path,
-            method: HttpMethod(method),
-            quota,
-            key,
-            burst,
-            whitelist: vec![],
-        }
-    }
-
     /// Check if the key is whitelisted.
     pub fn is_whitelisted(&self, key: &LimitKey) -> bool {
-        self.whitelist.iter().any(|k| k == key)
+        self.whitelist.contains(key)
     }
 
     /// Validate the path limit.
@@ -60,8 +41,7 @@ impl PathLimit {
         if let Some(k) = self.whitelist.iter().find(|k| k.get_type() != self.key) {
             let should_type = self.key.to_string();
             let is_type = k.get_type().to_string();
-            let msg = format!("Whitelist key type mismatch for '{k}'. Expected type '{should_type}' but got '{is_type}'. Full path limit: {self}");
-            return Err(anyhow::anyhow!(msg));
+            anyhow::bail!("Whitelist key type mismatch for '{k}'. Expected type '{should_type}' but got '{is_type}'. Full path limit: {self}");
         }
         Ok(())
     }
@@ -71,8 +51,8 @@ impl std::fmt::Display for PathLimit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let burst_str = self
             .burst
-            .map(|b| format!(" burst {}", b))
-            .unwrap_or("".to_string());
+            .map(|b| format!(" burst {b}"))
+            .unwrap_or_default();
         write!(
             f,
             "{} {}: {}{burst_str} by {}.whitelist: {:?}",
@@ -81,13 +61,16 @@ impl std::fmt::Display for PathLimit {
     }
 }
 
-impl From<PathLimit> for governor::Quota {
-    fn from(value: PathLimit) -> Self {
-        let quota: governor::Quota = value.quota.into();
-        if let Some(burst) = value.burst {
-            quota.allow_burst(burst);
-        }
-        quota
+impl TryFrom<PathLimit> for governor::Quota {
+    type Error = String;
+
+    fn try_from(value: PathLimit) -> Result<Self, Self::Error> {
+        let quota = Self::try_from(value.quota)?;
+        let quota = match value.burst {
+            Some(burst) => quota.allow_burst(burst),
+            None => quota,
+        };
+        Ok(quota)
     }
 }
 
@@ -98,19 +81,21 @@ mod tests {
         str::FromStr,
     };
 
+    use axum::http::Method;
     use pubky_common::crypto::Keypair;
 
     use super::*;
 
     #[test]
     fn test_validate_path_limit() {
-        let mut limit = PathLimit::new(
-            GlobPattern::new("*"),
-            Method::GET,
-            RequestCountQuota::from_str("10r/s").unwrap(),
-            LimitKeyType::Ip,
-            None,
-        );
+        let mut limit = PathLimit {
+            path: GlobPattern::new("*"),
+            method: HttpMethod(Method::GET),
+            quota: RequestCountQuota::from_str("10r/s").unwrap(),
+            key: LimitKeyType::Ip,
+            burst: None,
+            whitelist: Vec::new(),
+        };
         assert!(limit.validate().is_ok());
         limit
             .whitelist
@@ -120,5 +105,23 @@ mod tests {
             .whitelist
             .push(LimitKey::User(Keypair::random().public_key()));
         assert!(limit.validate().is_err());
+    }
+
+    #[test]
+    fn test_converts_to_governor_quota_with_burst_override() {
+        let burst = NonZeroU32::new(3).unwrap();
+        let limit = PathLimit {
+            path: GlobPattern::new("/session"),
+            method: HttpMethod(Method::POST),
+            quota: RequestCountQuota::from_str("10r/s").unwrap(),
+            key: LimitKeyType::Ip,
+            burst: Some(burst),
+            whitelist: Vec::new(),
+        };
+
+        assert_eq!(
+            governor::Quota::try_from(limit).unwrap(),
+            governor::Quota::per_second(NonZeroU32::new(10).unwrap()).allow_burst(burst)
+        );
     }
 }

--- a/pubky-homeserver/src/data_directory/quota_config/request_count_quota.rs
+++ b/pubky-homeserver/src/data_directory/quota_config/request_count_quota.rs
@@ -16,14 +16,20 @@ pub struct RequestCountQuota {
     pub time_unit: TimeUnit,
 }
 
-impl From<RequestCountQuota> for governor::Quota {
-    fn from(value: RequestCountQuota) -> Self {
-        let time_unit = Duration::from_secs(value.time_unit.multiplier_in_seconds().get() as u64);
-        let replenish_1_per = time_unit / value.rate.get();
+impl TryFrom<RequestCountQuota> for governor::Quota {
+    type Error = String;
 
-        let base_quota = governor::Quota::with_period(replenish_1_per)
-            .expect("always non-zero: replenish_1_per is non-zero");
-        base_quota.allow_burst(value.rate)
+    fn try_from(value: RequestCountQuota) -> Result<Self, Self::Error> {
+        let replenish_1_per = Duration::from(value.time_unit) / value.rate.get();
+        let quota = governor::Quota::with_period(replenish_1_per)
+            .ok_or_else(|| {
+                format!(
+                    "Request-count quota rate '{}' is too high",
+                    value.rate.get()
+                )
+            })?
+            .allow_burst(value.rate);
+        Ok(quota)
     }
 }
 
@@ -37,23 +43,16 @@ impl FromStr for RequestCountQuota {
     type Err = String;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let parts: Vec<&str> = s.split('/').collect();
-        if parts.len() != 2 {
-            return Err(format!(
-                "Invalid request-count quota format: '{s}', expected {{count}}r/{{time}}"
-            ));
-        }
-
-        let rate_with_unit = parts[0];
-        let time_unit = TimeUnit::from_str(parts[1])?;
-
-        let rate_str = rate_with_unit
+        let (rate_with_unit, time_unit) = s.split_once('/').ok_or_else(|| {
+            format!("Invalid request-count quota format: '{s}', expected {{count}}r/{{time}}")
+        })?;
+        let rate = rate_with_unit
             .strip_suffix('r')
-            .ok_or_else(|| format!("Request-count quota must end with 'r': '{rate_with_unit}'"))?;
-
-        let rate = rate_str
+            .ok_or_else(|| format!("Request-count quota must end with 'r': '{rate_with_unit}'"))?
             .parse::<NonZeroU32>()
-            .map_err(|_| format!("Failed to parse rate from '{rate_str}'"))?;
+            .map_err(|_| format!("Failed to parse rate from '{s}'"))?;
+
+        let time_unit = TimeUnit::from_str(time_unit)?;
 
         Ok(RequestCountQuota { rate, time_unit })
     }
@@ -99,15 +98,22 @@ mod tests {
     fn test_converts_to_governor_quota() {
         let q: RequestCountQuota = "5r/s".parse().unwrap();
         assert_eq!(
-            governor::Quota::from(q),
+            governor::Quota::try_from(q).unwrap(),
             governor::Quota::per_second(NonZeroU32::new(5).unwrap())
         );
 
         let q: RequestCountQuota = "5r/m".parse().unwrap();
         assert_eq!(
-            governor::Quota::from(q),
+            governor::Quota::try_from(q).unwrap(),
             governor::Quota::per_minute(NonZeroU32::new(5).unwrap())
         );
+    }
+
+    #[test]
+    fn test_rejects_rate_that_would_create_zero_replenish_period() {
+        let q = RequestCountQuota::from_str("4294967295r/s").unwrap();
+        let err = governor::Quota::try_from(q).unwrap_err();
+        assert!(err.contains("too high"), "error: {err}");
     }
 
     #[test]

--- a/pubky-homeserver/src/data_directory/quota_config/time_unit.rs
+++ b/pubky-homeserver/src/data_directory/quota_config/time_unit.rs
@@ -1,4 +1,4 @@
-use std::num::NonZeroU32;
+use std::time::Duration;
 
 /// The time unit of the quota.
 ///
@@ -7,7 +7,7 @@ use std::num::NonZeroU32;
 /// - "m" -> minute
 /// - "h" -> hour
 /// - "d" -> day
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TimeUnit {
     /// Second
     Second,
@@ -21,16 +21,13 @@ pub enum TimeUnit {
 
 impl std::fmt::Display for TimeUnit {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "{}",
-            match self {
-                TimeUnit::Second => "s",
-                TimeUnit::Minute => "m",
-                TimeUnit::Hour => "h",
-                TimeUnit::Day => "d",
-            }
-        )
+        let unit = match self {
+            TimeUnit::Second => "s",
+            TimeUnit::Minute => "m",
+            TimeUnit::Hour => "h",
+            TimeUnit::Day => "d",
+        };
+        write!(f, "{unit}")
     }
 }
 
@@ -43,23 +40,18 @@ impl std::str::FromStr for TimeUnit {
             "m" => Ok(TimeUnit::Minute),
             "h" => Ok(TimeUnit::Hour),
             "d" => Ok(TimeUnit::Day),
-            _ => Err(format!("Invalid time unit: {}", s)),
+            _ => Err(format!("Invalid time unit: {s}")),
         }
     }
 }
 
-const SECONDS_PER_MINUTE: u32 = 60;
-const SECONDS_PER_HOUR: u32 = 60 * 60;
-const SECONDS_PER_DAY: u32 = 24 * 60 * 60;
-
-impl TimeUnit {
-    /// Returns the number of seconds for each unit
-    pub const fn multiplier_in_seconds(&self) -> NonZeroU32 {
-        match self {
-            TimeUnit::Second => NonZeroU32::new(1).expect("non-zero"),
-            TimeUnit::Minute => NonZeroU32::new(SECONDS_PER_MINUTE).expect("non-zero"),
-            TimeUnit::Hour => NonZeroU32::new(SECONDS_PER_HOUR).expect("non-zero"),
-            TimeUnit::Day => NonZeroU32::new(SECONDS_PER_DAY).expect("non-zero"),
+impl From<TimeUnit> for Duration {
+    fn from(time_unit: TimeUnit) -> Self {
+        match time_unit {
+            TimeUnit::Second => Duration::from_secs(1),
+            TimeUnit::Minute => Duration::from_secs(60),
+            TimeUnit::Hour => Duration::from_secs(60 * 60),
+            TimeUnit::Day => Duration::from_secs(24 * 60 * 60),
         }
     }
 }


### PR DESCRIPTION
Add coverage for PathLimit conversion to governor quotas with explicit
burst overrides.

Store prepared request rate limit tuples in the layer and propagate
invalid quota configuration errors during app creation.
