### PR TITLE
chore: v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1452,7 +1452,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "bytes",
  "eventsource-stream",
@@ -3936,7 +3936,7 @@ checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "pubky"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64 0.22.1",
  "cookie",
@@ -3963,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-common"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "argon2",
  "base32",
@@ -3984,7 +3984,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-core-examples"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4003,7 +4003,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-homeserver"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-dropper",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-testnet"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4107,7 +4107,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-wasm"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64 0.22.1",
  "console_log",
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "pubky_test_utils"
-version = "0.1.0"
+version = "0.8.0"
 dependencies = [
  "pubky_test_utils_drop_db_helper",
  "pubky_test_utils_macro",
@@ -4140,14 +4140,14 @@ dependencies = [
 
 [[package]]
 name = "pubky_test_utils_drop_db_helper"
-version = "0.1.0"
+version = "0.8.0"
 dependencies = [
  "sqlx",
 ]
 
 [[package]]
 name = "pubky_test_utils_macro"
-version = "0.1.0"
+version = "0.8.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -2,12 +2,12 @@
 name = "e2e"
 edition.workspace = true
 rust-version.workspace = true
-version = "0.7.0"
+version = "0.8.0"
 publish = false
 
 [dependencies]
-pubky-testnet = { path = "../pubky-testnet" , version = "0.7.0" }
-pubky-common = { path = "../pubky-common" , version = "0.7.0" }
+pubky-testnet = { path = "../pubky-testnet" , version = "0.8.0" }
+pubky-common = { path = "../pubky-common" , version = "0.8.0" }
 tokio = { workspace = true, features = ["full", "test-util"] }
 tracing-subscriber.workspace = true
 pkarr = { workspace = true }

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky-core-examples"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false
@@ -50,9 +50,9 @@ futures-util = "0.3.31"
 anyhow.workspace = true
 base64 = "0.22.1"
 clap = { version = "4.6.0", features = ["derive"] }
-pubky = { path = "../../pubky-sdk" , version = "0.7.0" }
-pubky-testnet = { path = "../../pubky-testnet" , version = "0.7.0" }
-pubky-common = { path = "../../pubky-common" , version = "0.7.0" }
+pubky = { path = "../../pubky-sdk" , version = "0.8.0" }
+pubky-testnet = { path = "../../pubky-testnet" , version = "0.8.0" }
+pubky-common = { path = "../../pubky-common" , version = "0.8.0" }
 reqwest.workspace = true
 rpassword = "7.4.0"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/pubky-common/Cargo.toml
+++ b/pubky-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubky-common"
 description = "Types and struct in common between Pubky client and homeserver"
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/pubky-homeserver/Cargo.toml
+++ b/pubky-homeserver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubky-homeserver"
 description = "Pubky core's homeserver."
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -33,7 +33,7 @@ futures-util = "0.3.31"
 hex = "0.4.3"
 httpdate = "1.0.3"
 pkarr = { workspace = true, features = ["default", "dht", "tls"] }
-pubky-common = { path = "../pubky-common" , version = "0.7.0" }
+pubky-common = { path = "../pubky-common" , version = "0.8.0" }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1"
 tokio = { workspace = true, features = ["full"] }
@@ -83,7 +83,7 @@ async-trait = "0.1"
 async-dropper = { version = "0.3", features = ["tokio", "simple"] }
 async-stream = "0.3"
 uuid = { version = "1.7.0", features = ["v4"] }
-pubky_test_utils = { path = "../test_utils/pubky_test", version = "0.1.0" }
+pubky_test_utils = { path = "../test_utils/pubky_test", version = "0.8.0" }
 opentelemetry = "0.29"
 opentelemetry_sdk = { version = "0.29", features = ["rt-tokio", "metrics"] }
 opentelemetry-prometheus = "0.29"

--- a/pubky-sdk/Cargo.toml
+++ b/pubky-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubky"
 description = "Pubky SDK"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version.workspace = true
 authors = [
@@ -29,7 +29,7 @@ default = []
 json = ["dep:serde", "reqwest/json"]
 
 [dependencies]
-pubky-common = { path = "../pubky-common" , version = "0.7.0" }
+pubky-common = { path = "../pubky-common" , version = "0.8.0" }
 thiserror.workspace = true
 eventsource-stream = "0.2.3"
 url.workspace = true
@@ -59,7 +59,7 @@ wasm-bindgen-futures = "0.4.50"
 futures-lite = { version = "2.6.0", default-features = false }
 
 [dev-dependencies]
-pubky-testnet = { path = "../pubky-testnet" , version = "0.7.0" } # used in docstring tests
+pubky-testnet = { path = "../pubky-testnet" , version = "0.8.0" } # used in docstring tests
 httpmock = "0.7"
 http-relay = { workspace = true, features = ["server", "link-compat"] }
 

--- a/pubky-sdk/bindings/js/Cargo.toml
+++ b/pubky-sdk/bindings/js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky-wasm"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2024"
 rust-version.workspace = true
 description = "Pubky-Core Client WASM bindings"
@@ -41,8 +41,8 @@ serde-wasm-bindgen = "0.6"
 tsify = "0.5.5"
 pubky = { path = "../../../pubky-sdk", default-features = false, features = [
     "json",
-] , version = "0.7.0" }
-pubky-common = { path = "../../../pubky-common" , version = "0.7.0" }
+] , version = "0.8.0" }
+pubky-common = { path = "../../../pubky-common" , version = "0.8.0" }
 pkarr = { workspace = true, default-features = false }
 web-sys = { version = "0.3.77", default-features = false, features = [
     "Request",

--- a/pubky-sdk/bindings/js/pkg/package-lock.json
+++ b/pubky-sdk/bindings/js/pkg/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@synonymdev/pubky",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@synonymdev/pubky",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "fetch-cookie": "^3.0.1"

--- a/pubky-sdk/bindings/js/pkg/package.json
+++ b/pubky-sdk/bindings/js/pkg/package.json
@@ -2,7 +2,7 @@
   "name": "@synonymdev/pubky",
   "type": "module",
   "description": "Pubky client",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/pubky-testnet/Cargo.toml
+++ b/pubky-testnet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubky-testnet"
 description = "A local test network for Pubky Core development."
-version = "0.7.0"
+version = "0.8.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -20,12 +20,12 @@ tokio = { workspace = true, features = ["full"] }
 tracing-subscriber.workspace = true
 url.workspace = true
 
-pubky = { path = "../pubky-sdk", features = ["json"] , version = "0.7.0" }
-pubky-common = { path = "../pubky-common" , version = "0.7.0" }
+pubky = { path = "../pubky-sdk", features = ["json"] , version = "0.8.0" }
+pubky-common = { path = "../pubky-common" , version = "0.8.0" }
 pubky-homeserver = { path = "../pubky-homeserver", default-features = false, features = [
     "testing",
-] , version = "0.7.0" }
-pubky_test_utils = { path = "../test_utils/pubky_test", version = "0.1.0" }
+] , version = "0.8.0" }
+pubky_test_utils = { path = "../test_utils/pubky_test", version = "0.8.0" }
 # External http-relay: server + link-compat, no persist/cli (in-memory storage for tests)
 http-relay = { workspace = true, features = ["server", "link-compat"] }
 tempfile = "3.19.1"

--- a/test_utils/drop_db_helper/Cargo.toml
+++ b/test_utils/drop_db_helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky_test_utils_drop_db_helper"
-version = "0.1.0"
+version = "0.8.0"
 description = "Do not use on its own. Use pubky_test_utils instead."
 keywords = ["pubky", "test", "utilities", "drop", "database"]
 categories = ["testing"]

--- a/test_utils/pubky_test/Cargo.toml
+++ b/test_utils/pubky_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky_test_utils"
-version = "0.1.0"
+version = "0.8.0"
 description = "Test utilities for Pubky Core testing"
 keywords = ["pubky", "test", "utilities"]
 categories = ["testing"]
@@ -13,5 +13,5 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-pubky_test_utils_macro = { path = "../test_macro", version = "0.1.0" }
-pubky_test_utils_drop_db_helper = { path = "../drop_db_helper", version = "0.1.0" }
+pubky_test_utils_macro = { path = "../test_macro", version = "0.8.0" }
+pubky_test_utils_drop_db_helper = { path = "../drop_db_helper", version = "0.8.0" }

--- a/test_utils/test_macro/Cargo.toml
+++ b/test_utils/test_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky_test_utils_macro"
-version = "0.1.0"
+version = "0.8.0"
 description = "Do not use on its own. Use pubky_test_utils instead."
 keywords = ["pubky", "test", "utilities", "macro"]
 categories = ["testing"]
@@ -19,7 +19,7 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
-pubky_test_utils_drop_db_helper = { path = "../drop_db_helper", version = "0.1.0" }
+pubky_test_utils_drop_db_helper = { path = "../drop_db_helper", version = "0.8.0" }
 proc-macro-crate = "3.5.0"
 
 


### PR DESCRIPTION
Big release!

## What's Changed

Important: LMDB support has been dropped. Use Postgres from now on. If you have to migrate, use v0.7.0 first before you upgrade to v0.8.0. 


* **BREAKING CHANGE** feat!(hs): Remove LMDB by @SeverinAlexB in https://github.com/pubky/pubky-core/pull/357
* feat(homeserver): Horizontally scalable SSE Events by @86667 in https://github.com/pubky/pubky-core/pull/303
* feat(sdk): Add resumeAuthFlow to recover auth flows after page refresh by @tipogi in https://github.com/pubky/pubky-core/pull/355
* feat: native SDK fallback to ICANN when PubkyTLS direct endpoint is unreachable by @SHAcollision in https://github.com/pubky/pubky-core/pull/352
* feat(homeserver): Per user rate limits by @86667 in https://github.com/pubky/pubky-core/pull/363
* feat: signup_count metric by @86667 in https://github.com/pubky/pubky-core/pull/379
* feat(examples): Improve write abilities by @86667 in https://github.com/pubky/pubky-core/pull/382
* feat(homeserver): UserQuota option allowed_write_paths by @86667 in https://github.com/pubky/pubky-core/pull/381
* fix(homeserver): Serialise event inserts to prevent poll loop from skipping events by @86667 in https://github.com/pubky/pubky-core/pull/358
* fix(testnet): testnet port binding by @SeverinAlexB in https://github.com/pubky/pubky-core/pull/362
* fix(homeserver): apply burst to request rate limits by @andrei-21 in https://github.com/pubky/pubky-core/pull/383
* fix(auth): Check actual version byte by @andrei-21 in https://github.com/pubky/pubky-core/pull/370
* fix(sdk): lock wasm-pack install so that it uses the exact dependency versions from wasm-pack's lockfile by @86667 in https://github.com/pubky/pubky-core/pull/371
* build: symlink `LICENSE` for wasm-pack packaging by @andrei-21 in https://github.com/pubky/pubky-core/pull/372
* test: add unit test to verify actual behavior on quota excess by @andrei-21 in https://github.com/pubky/pubky-core/pull/374
* deps: bump the cargo-dependencies group across 1 directory with 9 updates by @dependabot[bot] in https://github.com/pubky/pubky-core/pull/359
* refactor(common)!: normalize capabilities construction by @andrei-21 in https://github.com/pubky/pubky-core/pull/375
* refactor(homeserver): Move pkarr republisher and add docs by @86667 in https://github.com/pubky/pubky-core/pull/351
* ci(wasm): install wasm-pack from prebuilt binary by @andrei-21 in https://github.com/pubky/pubky-core/pull/385
* ci: fix worflow yaml by @andrei-21 in https://github.com/pubky/pubky-core/pull/386
* refactor(homeserver): use nonzero burst quota values by @andrei-21 in https://github.com/pubky/pubky-core/pull/387
* chore: pkarr v6 by @dzdidi and @ok300 in https://github.com/pubky/pubky-core/pull/380