### PR TITLE
chore: Fix release pipeline - Pin pubky_test_utils

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -58,6 +58,32 @@ jobs:
       - name: Lint wasm crate (wasm32)
         run: cargo clippy -p pubky-wasm --target wasm32-unknown-unknown -- -D warnings
 
+  helper-crates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: 1.89
+          components: rustfmt, clippy
+          override: true
+      - name: Cache
+        uses: Swatinem/rust-cache@v2
+      - name: Check excluded helper crates
+        run: |
+          set -e
+          for manifest in \
+            test_utils/drop_db_helper/Cargo.toml \
+            test_utils/test_macro/Cargo.toml \
+            test_utils/pubky_test/Cargo.toml
+          do
+            cargo fmt --check --manifest-path "$manifest"
+            cargo clippy --manifest-path "$manifest" --all-targets -- -D warnings
+            cargo test --manifest-path "$manifest"
+          done
+
   test:
     services:
       postgres:

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target/
+test_utils/**/Cargo.lock
 ./storage
 .continuerules
 .cursorrules

--- a/.scripts/set-version.sh
+++ b/.scripts/set-version.sh
@@ -1,16 +1,13 @@
 #!/bin/bash
 
 # -------------------------------------------------------------------------------------------------
-# This script sets the version of release-tracked members of the workspace.
+# This script sets the version of all members of the workspace.
 # It also updates the inner member dependency versions.
-# The pubky_test_utils helper crates stay pinned to the published 0.1.0 API.
 # -------------------------------------------------------------------------------------------------
 
 set -e # fail the script if any command fails
 set -u # fail the script if any variable is not set
 set -o pipefail # fail the script if any pipe command fails
-
-PINNED_TEST_UTILS_VERSION="0.1.0"
 
 # Check if cargo-set-version is installed
 if ! cargo --list | grep -q "set-version"; then
@@ -19,76 +16,6 @@ if ! cargo --list | grep -q "set-version"; then
   echo "  cargo install cargo-set-version"
   exit 1
 fi
-
-if ! command -v python3 >/dev/null 2>&1; then
-  echo "Error: python3 is not installed but required."
-  exit 1
-fi
-
-
-# TODO: Because cargo set-version updates all member dependency versions to the new version, we need to pin the pubky_test_utils helper crates back to 0.1.0 after running it.
-# This is a bit hacky but allows us to keep the helper crates at their published versions so we don't have to publish new versions of them every time we want to update the version of the workspace members that depend on them.
-pin_test_utils_versions() {
-  echo "Pinning pubky_test_utils helper crates to $PINNED_TEST_UTILS_VERSION..."
-  python3 - "$PINNED_TEST_UTILS_VERSION" <<'PY'
-from pathlib import Path
-import re
-import sys
-
-version = sys.argv[1]
-
-# These helper crates are already published and consumed as 0.1.0.
-# Keep their local path+version dependencies aligned with crates.io so packaging
-# published crates resolves them from the registry without publishing new helper versions.
-package_manifests = [
-    "test_utils/drop_db_helper/Cargo.toml",
-    "test_utils/test_macro/Cargo.toml",
-    "test_utils/pubky_test/Cargo.toml",
-]
-
-dependency_manifests = {
-    "pubky-homeserver/Cargo.toml": ["pubky_test_utils"],
-    "pubky-testnet/Cargo.toml": ["pubky_test_utils"],
-    "test_utils/test_macro/Cargo.toml": ["pubky_test_utils_drop_db_helper"],
-    "test_utils/pubky_test/Cargo.toml": [
-        "pubky_test_utils_macro",
-        "pubky_test_utils_drop_db_helper",
-    ],
-}
-
-def replace_once(text, pattern, replacement, path, description):
-    updated, count = re.subn(pattern, replacement, text, count=1, flags=re.MULTILINE)
-    if count != 1:
-        raise SystemExit(f"failed to update {description} in {path}")
-    return updated
-
-for manifest in package_manifests:
-    path = Path(manifest)
-    text = path.read_text()
-    text = replace_once(
-        text,
-        r'^version = "[^"]+"',
-        f'version = "{version}"',
-        path,
-        "package version",
-    )
-    path.write_text(text)
-
-for manifest, dependency_names in dependency_manifests.items():
-    path = Path(manifest)
-    text = path.read_text()
-    for dependency_name in dependency_names:
-        pattern = rf'({re.escape(dependency_name)}\s*=\s*\{{[^}}]*\bversion\s*=\s*)"[^"]+"'
-        text = replace_once(
-            text,
-            pattern,
-            lambda match: f'{match.group(1)}"{version}"',
-            path,
-            f"{dependency_name} dependency version",
-        )
-    path.write_text(text)
-PY
-}
 
 
 # Check if the version is provided
@@ -123,7 +50,6 @@ echo "Updating pubky-sdk package.json version to $NEW_VERSION..."
 # cargo set-version also updates the inner member dependency versions.
 echo "Setting the version of all rust members of the workspace to $NEW_VERSION..."
 cargo set-version "$NEW_VERSION"
-pin_test_utils_versions
 
 
 

--- a/.scripts/set-version.sh
+++ b/.scripts/set-version.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 
 # -------------------------------------------------------------------------------------------------
-# This script sets the version of all members of the workspace.
+# This script sets the version of release-tracked members of the workspace.
 # It also updates the inner member dependency versions.
+# The pubky_test_utils helper crates stay pinned to the published 0.1.0 API.
 # -------------------------------------------------------------------------------------------------
 
 set -e # fail the script if any command fails
 set -u # fail the script if any variable is not set
 set -o pipefail # fail the script if any pipe command fails
+
+PINNED_TEST_UTILS_VERSION="0.1.0"
 
 # Check if cargo-set-version is installed
 if ! cargo --list | grep -q "set-version"; then
@@ -17,9 +20,76 @@ if ! cargo --list | grep -q "set-version"; then
   exit 1
 fi
 
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "Error: python3 is not installed but required."
+  exit 1
+fi
+
+pin_test_utils_versions() {
+  echo "Pinning pubky_test_utils helper crates to $PINNED_TEST_UTILS_VERSION..."
+  python3 - "$PINNED_TEST_UTILS_VERSION" <<'PY'
+from pathlib import Path
+import re
+import sys
+
+version = sys.argv[1]
+
+# These helper crates are already published and consumed as 0.1.0.
+# Keep their local path+version dependencies aligned with crates.io so packaging
+# published crates resolves them from the registry without publishing new helper versions.
+package_manifests = [
+    "test_utils/drop_db_helper/Cargo.toml",
+    "test_utils/test_macro/Cargo.toml",
+    "test_utils/pubky_test/Cargo.toml",
+]
+
+dependency_manifests = {
+    "pubky-homeserver/Cargo.toml": ["pubky_test_utils"],
+    "pubky-testnet/Cargo.toml": ["pubky_test_utils"],
+    "test_utils/test_macro/Cargo.toml": ["pubky_test_utils_drop_db_helper"],
+    "test_utils/pubky_test/Cargo.toml": [
+        "pubky_test_utils_macro",
+        "pubky_test_utils_drop_db_helper",
+    ],
+}
+
+def replace_once(text, pattern, replacement, path, description):
+    updated, count = re.subn(pattern, replacement, text, count=1, flags=re.MULTILINE)
+    if count != 1:
+        raise SystemExit(f"failed to update {description} in {path}")
+    return updated
+
+for manifest in package_manifests:
+    path = Path(manifest)
+    text = path.read_text()
+    text = replace_once(
+        text,
+        r'^version = "[^"]+"',
+        f'version = "{version}"',
+        path,
+        "package version",
+    )
+    path.write_text(text)
+
+for manifest, dependency_names in dependency_manifests.items():
+    path = Path(manifest)
+    text = path.read_text()
+    for dependency_name in dependency_names:
+        pattern = rf'({re.escape(dependency_name)}\s*=\s*\{{[^}}]*\bversion\s*=\s*)"[^"]+"'
+        text = replace_once(
+            text,
+            pattern,
+            lambda match: f'{match.group(1)}"{version}"',
+            path,
+            f"{dependency_name} dependency version",
+        )
+    path.write_text(text)
+PY
+}
+
 
 # Check if the version is provided
-NEW_VERSION=$1
+NEW_VERSION=${1:-}
 if [ -z "$NEW_VERSION" ]; then
   echo "Error: New version not specified."
   echo "Usage: $0 <new_version>"
@@ -49,7 +119,8 @@ echo "Updating pubky-sdk package.json version to $NEW_VERSION..."
 # Set the version of all rust members of the workspace
 # cargo set-version also updates the inner member dependency versions.
 echo "Setting the version of all rust members of the workspace to $NEW_VERSION..."
-cargo set-version $NEW_VERSION
+cargo set-version "$NEW_VERSION"
+pin_test_utils_versions
 
 
 

--- a/.scripts/set-version.sh
+++ b/.scripts/set-version.sh
@@ -25,6 +25,9 @@ if ! command -v python3 >/dev/null 2>&1; then
   exit 1
 fi
 
+
+# TODO: Because cargo set-version updates all member dependency versions to the new version, we need to pin the pubky_test_utils helper crates back to 0.1.0 after running it.
+# This is a bit hacky but allows us to keep the helper crates at their published versions so we don't have to publish new versions of them every time we want to update the version of the workspace members that depend on them.
 pin_test_utils_versions() {
   echo "Pinning pubky_test_utils helper crates to $PINNED_TEST_UTILS_VERSION..."
   python3 - "$PINNED_TEST_UTILS_VERSION" <<'PY'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4132,7 +4132,7 @@ dependencies = [
 
 [[package]]
 name = "pubky_test_utils"
-version = "0.8.0"
+version = "0.1.0"
 dependencies = [
  "pubky_test_utils_drop_db_helper",
  "pubky_test_utils_macro",
@@ -4140,14 +4140,14 @@ dependencies = [
 
 [[package]]
 name = "pubky_test_utils_drop_db_helper"
-version = "0.8.0"
+version = "0.1.0"
 dependencies = [
  "sqlx",
 ]
 
 [[package]]
 name = "pubky_test_utils_macro"
-version = "0.8.0"
+version = "0.1.0"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4154,7 +4154,6 @@ dependencies = [
  "pubky_test_utils_drop_db_helper",
  "quote",
  "syn 2.0.117",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,10 +3,12 @@ members = [
   "pubky-*",
   "pubky-sdk/bindings/js",
   "e2e",
+  "examples/rust",
+]
+exclude = [
   "test_utils/test_macro",
   "test_utils/drop_db_helper",
   "test_utils/pubky_test",
-  "examples/rust",
 ]
 default-members = [
   "pubky-common",

--- a/pubky-homeserver/Cargo.toml
+++ b/pubky-homeserver/Cargo.toml
@@ -83,7 +83,7 @@ async-trait = "0.1"
 async-dropper = { version = "0.3", features = ["tokio", "simple"] }
 async-stream = "0.3"
 uuid = { version = "1.7.0", features = ["v4"] }
-pubky_test_utils = { path = "../test_utils/pubky_test", version = "0.8.0" }
+pubky_test_utils = { path = "../test_utils/pubky_test", version = "0.1.0" }
 opentelemetry = "0.29"
 opentelemetry_sdk = { version = "0.29", features = ["rt-tokio", "metrics"] }
 opentelemetry-prometheus = "0.29"

--- a/pubky-testnet/Cargo.toml
+++ b/pubky-testnet/Cargo.toml
@@ -25,7 +25,7 @@ pubky-common = { path = "../pubky-common" , version = "0.8.0" }
 pubky-homeserver = { path = "../pubky-homeserver", default-features = false, features = [
     "testing",
 ] , version = "0.8.0" }
-pubky_test_utils = { path = "../test_utils/pubky_test", version = "0.8.0" }
+pubky_test_utils = { path = "../test_utils/pubky_test", version = "0.1.0" }
 # External http-relay: server + link-compat, no persist/cli (in-memory storage for tests)
 http-relay = { workspace = true, features = ["server", "link-compat"] }
 tempfile = "3.19.1"

--- a/test_utils/drop_db_helper/Cargo.toml
+++ b/test_utils/drop_db_helper/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 description = "Do not use on its own. Use pubky_test_utils instead."
 keywords = ["pubky", "test", "utilities", "drop", "database"]
 categories = ["testing"]
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
-repository.workspace = true
+edition = "2021"
+rust-version = "1.89"
+authors = []
+license = "MIT"
+homepage = "https://github.com/pubky/pubky-core"
+repository = "https://github.com/pubky/pubky-core"
 publish = false
 
 [dependencies]

--- a/test_utils/drop_db_helper/Cargo.toml
+++ b/test_utils/drop_db_helper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky_test_utils_drop_db_helper"
-version = "0.8.0"
+version = "0.1.0"
 description = "Do not use on its own. Use pubky_test_utils instead."
 keywords = ["pubky", "test", "utilities", "drop", "database"]
 categories = ["testing"]

--- a/test_utils/pubky_test/Cargo.toml
+++ b/test_utils/pubky_test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky_test_utils"
-version = "0.8.0"
+version = "0.1.0"
 description = "Test utilities for Pubky Core testing"
 keywords = ["pubky", "test", "utilities"]
 categories = ["testing"]
@@ -13,5 +13,5 @@ repository.workspace = true
 publish = false
 
 [dependencies]
-pubky_test_utils_macro = { path = "../test_macro", version = "0.8.0" }
-pubky_test_utils_drop_db_helper = { path = "../drop_db_helper", version = "0.8.0" }
+pubky_test_utils_macro = { path = "../test_macro", version = "0.1.0" }
+pubky_test_utils_drop_db_helper = { path = "../drop_db_helper", version = "0.1.0" }

--- a/test_utils/pubky_test/Cargo.toml
+++ b/test_utils/pubky_test/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 description = "Test utilities for Pubky Core testing"
 keywords = ["pubky", "test", "utilities"]
 categories = ["testing"]
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
-repository.workspace = true
+edition = "2021"
+rust-version = "1.89"
+authors = []
+license = "MIT"
+homepage = "https://github.com/pubky/pubky-core"
+repository = "https://github.com/pubky/pubky-core"
 publish = false
 
 [dependencies]

--- a/test_utils/test_macro/Cargo.toml
+++ b/test_utils/test_macro/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 description = "Do not use on its own. Use pubky_test_utils instead."
 keywords = ["pubky", "test", "utilities", "macro"]
 categories = ["testing"]
-edition.workspace = true
-rust-version.workspace = true
-authors.workspace = true
-license.workspace = true
-homepage.workspace = true
-repository.workspace = true
+edition = "2021"
+rust-version = "1.89"
+authors = []
+license = "MIT"
+homepage = "https://github.com/pubky/pubky-core"
+repository = "https://github.com/pubky/pubky-core"
 publish = false
 
 [lib]
@@ -24,4 +24,4 @@ proc-macro-crate = "3.5.0"
 
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["full"] }
+tokio = { version = "1.49.0", features = ["full"] }

--- a/test_utils/test_macro/Cargo.toml
+++ b/test_utils/test_macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky_test_utils_macro"
-version = "0.8.0"
+version = "0.1.0"
 description = "Do not use on its own. Use pubky_test_utils instead."
 keywords = ["pubky", "test", "utilities", "macro"]
 categories = ["testing"]
@@ -19,7 +19,7 @@ proc-macro = true
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "2.0", features = ["full"] }
-pubky_test_utils_drop_db_helper = { path = "../drop_db_helper", version = "0.8.0" }
+pubky_test_utils_drop_db_helper = { path = "../drop_db_helper", version = "0.1.0" }
 proc-macro-crate = "3.5.0"
 
 


### PR DESCRIPTION
The `set-version.sh` script would also bump the `pubky_test_utils` lib which doesn't need changing, making the release [GH Action fail](https://github.com/pubky/pubky-core/actions/runs/26103862112). This PR undos the version bump and excludes these helper crates from being version bumped by excluding them from the workspace.

It's a bit of a hack but I don't have time to redo the whole script at the moment.