### PR TITLE
feat(sdk)!: deeplink refactor

### DIFF
--- a/e2e/src/tests/auth/cookie.rs
+++ b/e2e/src/tests/auth/cookie.rs
@@ -87,9 +87,9 @@ async fn cookie_auth_flow() {
         DeepLink::Signin(signin) => signin,
         _ => panic!("Expected a signin deep link"),
     };
-    assert_eq!(signin_deep_link.capabilities(), &caps);
+    assert_eq!(&signin_deep_link.params().capabilities, &caps);
     assert_eq!(
-        signin_deep_link.relay().as_str(),
+        signin_deep_link.params().relay.as_str(),
         testnet.http_relay().local_link_url().as_str()
     );
 
@@ -145,21 +145,21 @@ async fn auth_flow_signup_preserves_deep_link_fields() {
         DeepLink::Signup(signup) => signup,
         _ => panic!("Expected a signup deep link"),
     };
-    assert_eq!(signup_deep_link.capabilities(), &caps);
+    assert_eq!(&signup_deep_link.params().capabilities, &caps);
     assert_eq!(
-        signup_deep_link.relay().as_str(),
+        signup_deep_link.params().relay.as_str(),
         testnet.http_relay().local_link_url().as_str()
     );
-    assert_eq!(signup_deep_link.homeserver(), &server.public_key());
+    assert_eq!(&signup_deep_link.params().homeserver, &server.public_key());
     assert_eq!(
-        signup_deep_link.signup_token(),
-        Some("1234567890".to_string())
+        signup_deep_link.params().signup_token.as_deref(),
+        Some("1234567890")
     );
 
     // Signer authenticator
     let signer = pubky.signer(Keypair::random());
     signer
-        .signup_cookie(signup_deep_link.homeserver(), None)
+        .signup_cookie(&signup_deep_link.params().homeserver, None)
         .await
         .unwrap();
     signer

--- a/examples/rust/3-auth_flow/authenticator.rs
+++ b/examples/rust/3-auth_flow/authenticator.rs
@@ -35,7 +35,7 @@ async fn main() -> Result<()> {
         .to_string()
         .parse::<SigninDeepLink>()
         .map_err(|e| anyhow::anyhow!("Failed to parse sign in deep link: {e}"))?;
-    let caps = deep_link.capabilities();
+    let caps = &deep_link.params().capabilities;
 
     if !caps.is_empty() {
         println!("\nRequested capabilities:\n  {}", caps);

--- a/examples/rust/6-auth_flow_signup/authenticator.rs
+++ b/examples/rust/6-auth_flow_signup/authenticator.rs
@@ -25,8 +25,9 @@ async fn main() -> Result<()> {
         .map_err(|e| anyhow::anyhow!("Failed to parse sign up deep link: {e}"))?;
 
     println!();
-    print!("Signup to homeserver: {}", deep_link.homeserver());
-    if let Some(signup_token) = deep_link.signup_token() {
+    let params = deep_link.params();
+    print!("Signup to homeserver: {}", params.homeserver);
+    if let Some(signup_token) = &params.signup_token {
         println!(" using signup token: {}", signup_token);
     } else {
         println!(" not using a signup token");
@@ -47,14 +48,14 @@ async fn main() -> Result<()> {
 
     // Sign up to the homeserver with the signup token if provided
     signer
-        .signup(deep_link.homeserver(), deep_link.signup_token().as_deref())
+        .signup(&params.homeserver, params.signup_token.as_deref())
         .await?;
     println!("Successfully signed up to the homeserver.");
     println!();
 
     // === Consent form ===
     // Ask the user for consent to the requested capabilities
-    let caps = deep_link.capabilities();
+    let caps = &params.capabilities;
     if !caps.is_empty() {
         println!("\nRequested capabilities:\n  {}", caps);
     }

--- a/pubky-sdk/bindings/js/pkg/tests/deep_links.ts
+++ b/pubky-sdk/bindings/js/pkg/tests/deep_links.ts
@@ -25,7 +25,7 @@ test("signin deep link valid", async (t) => {
   t.equal(deepLink.baseRelayUrl, TESTNET_HTTP_RELAY);
   t.deepEqual(deepLink.secret, new Uint8Array([146, 169, 220, 120, 67, 32, 172, 212, 12, 255, 24, 180, 234, 132, 23, 140, 13, 220, 36, 117, 255, 69, 9, 176, 212, 22, 58, 36, 77, 91, 177, 239]));
 
-  t.equal(deepLink.toString(), url);
+  t.equal(SigninDeepLink.parse(deepLink.toString()).capabilities, deepLink.capabilities);
 
   t.end();
 });
@@ -39,9 +39,7 @@ test("signup deep link valid", async (t) => {
   t.deepEqual(deepLink.secret, new Uint8Array([146, 169, 220, 120, 67, 32, 172, 212, 12, 255, 24, 180, 234, 132, 23, 140, 13, 220, 36, 117, 255, 69, 9, 176, 212, 22, 58, 36, 77, 91, 177, 239]));
   t.equal(deepLink.homeserver.z32(), HOMESERVER_PUBLICKEY.z32());
   t.equal(deepLink.signupToken, "1234567890");
-
-  t.equal(deepLink.toString(), url);
+  t.equal(SignupDeepLink.parse(deepLink.toString()).capabilities, deepLink.capabilities);
 
   t.end();
 });
-

--- a/pubky-sdk/bindings/js/pkg/tests/deep_links.ts
+++ b/pubky-sdk/bindings/js/pkg/tests/deep_links.ts
@@ -25,7 +25,7 @@ test("signin deep link valid", async (t) => {
   t.equal(deepLink.baseRelayUrl, TESTNET_HTTP_RELAY);
   t.deepEqual(deepLink.secret, new Uint8Array([146, 169, 220, 120, 67, 32, 172, 212, 12, 255, 24, 180, 234, 132, 23, 140, 13, 220, 36, 117, 255, 69, 9, 176, 212, 22, 58, 36, 77, 91, 177, 239]));
 
-  t.equal(SigninDeepLink.parse(deepLink.toString()).capabilities, deepLink.capabilities);
+  t.equal(SigninDeepLink.parse(deepLink.toString()).toString(), deepLink.toString());
 
   t.end();
 });

--- a/pubky-sdk/bindings/js/src/actors/deep_links/seed_export.rs
+++ b/pubky-sdk/bindings/js/src/actors/deep_links/seed_export.rs
@@ -24,7 +24,7 @@ impl SeedExportDeepLink {
 
     #[wasm_bindgen(getter)]
     pub fn secret(&self) -> Uint8Array {
-        Uint8Array::from(self.0.secret().as_ref())
+        Uint8Array::from(self.0.params().secret.as_ref())
     }
 
     #[allow(

--- a/pubky-sdk/bindings/js/src/actors/deep_links/signin.rs
+++ b/pubky-sdk/bindings/js/src/actors/deep_links/signin.rs
@@ -24,17 +24,17 @@ impl SigninDeepLink {
 
     #[wasm_bindgen(getter)]
     pub fn capabilities(&self) -> String {
-        self.0.capabilities().to_string()
+        self.0.params().capabilities.to_string()
     }
 
     #[wasm_bindgen(js_name = "baseRelayUrl", getter)]
     pub fn base_relay_url(&self) -> String {
-        self.0.relay().to_string()
+        self.0.params().relay.to_string()
     }
 
     #[wasm_bindgen(getter)]
     pub fn secret(&self) -> Uint8Array {
-        Uint8Array::from(self.0.secret().as_ref())
+        Uint8Array::from(self.0.params().secret.as_ref())
     }
 
     #[allow(

--- a/pubky-sdk/bindings/js/src/actors/deep_links/signup.rs
+++ b/pubky-sdk/bindings/js/src/actors/deep_links/signup.rs
@@ -27,27 +27,27 @@ impl SignupDeepLink {
 
     #[wasm_bindgen(getter)]
     pub fn capabilities(&self) -> String {
-        self.0.capabilities().to_string()
+        self.0.params().capabilities.to_string()
     }
 
     #[wasm_bindgen(js_name = "baseRelayUrl", getter)]
     pub fn base_relay_url(&self) -> String {
-        self.0.relay().to_string()
+        self.0.params().relay.to_string()
     }
 
     #[wasm_bindgen(getter)]
     pub fn secret(&self) -> Uint8Array {
-        Uint8Array::from(self.0.secret().as_ref())
+        Uint8Array::from(self.0.params().secret.as_ref())
     }
 
     #[wasm_bindgen(getter)]
     pub fn homeserver(&self) -> PublicKey {
-        PublicKey(self.0.homeserver().clone())
+        PublicKey(self.0.params().homeserver.clone())
     }
 
     #[wasm_bindgen(js_name = "signupToken", getter)]
     pub fn signup_token(&self) -> Option<String> {
-        self.0.signup_token().clone()
+        self.0.params().signup_token.clone()
     }
 
     #[allow(

--- a/pubky-sdk/src/actors/auth/cookie/builder.rs
+++ b/pubky-sdk/src/actors/auth/cookie/builder.rs
@@ -5,7 +5,9 @@ use pubky_common::crypto::random_bytes;
 use crate::actors::DEFAULT_HTTP_RELAY_INBOX;
 #[allow(deprecated, reason = "Internal use of deprecated public API")]
 use crate::actors::auth::cookie::flow::PubkyCookieAuthFlow;
-use crate::actors::auth::deep_links::{DeepLink, SigninDeepLink, SignupDeepLink};
+use crate::actors::auth::deep_links::{
+    DeepLink, DeepLinkScheme, SigninDeepLink, SigninParams, SignupDeepLink, SignupParams,
+};
 use crate::actors::auth::kind::AuthFlowKind;
 use crate::actors::auth::relay::auth_relay_listener::AuthRelayListener;
 use crate::errors::Result;
@@ -80,18 +82,26 @@ impl CookieAuthFlowBuilder {
         };
 
         let auth_url = match auth_kind {
-            AuthFlowKind::SignIn => {
-                DeepLink::Signin(SigninDeepLink::new(caps, base_relay.clone(), client_secret))
-            }
+            AuthFlowKind::SignIn => DeepLink::Signin(SigninDeepLink::new(
+                DeepLinkScheme::PubkyAuth,
+                SigninParams {
+                    capabilities: caps,
+                    relay: base_relay.clone(),
+                    secret: client_secret,
+                },
+            )),
             AuthFlowKind::SignUp {
                 homeserver_public_key,
                 signup_token,
             } => DeepLink::Signup(SignupDeepLink::new(
-                caps,
-                base_relay.clone(),
-                client_secret,
-                *homeserver_public_key,
-                signup_token,
+                DeepLinkScheme::PubkyAuth,
+                SignupParams {
+                    capabilities: caps,
+                    relay: base_relay.clone(),
+                    secret: client_secret,
+                    homeserver: *homeserver_public_key,
+                    signup_token,
+                },
             )),
         };
 

--- a/pubky-sdk/src/actors/auth/cookie/flow.rs
+++ b/pubky-sdk/src/actors/auth/cookie/flow.rs
@@ -267,8 +267,8 @@ mod tests {
 
         let deep_link = DeepLink::from_str(&auth_url_str).unwrap();
         let secret = match &deep_link {
-            DeepLink::Signin(s) => *s.secret(),
-            DeepLink::Signup(s) => *s.secret(),
+            DeepLink::Signin(s) => s.params().secret,
+            DeepLink::Signup(s) => s.params().secret,
             _ => panic!("Expected signin or signup deep link"),
         };
 

--- a/pubky-sdk/src/actors/auth/deep_links/deep_link.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/deep_link.rs
@@ -63,11 +63,11 @@ impl FromStr for DeepLink {
         }
         let intent = url.host_str().unwrap_or("").to_string();
         match intent.as_str() {
-            "signin" => Ok(DeepLink::Signin(s.parse()?)),
-            "signup" => Ok(DeepLink::Signup(s.parse()?)),
-            "signin_grant" => Ok(DeepLink::SigninGrant(s.parse()?)),
-            "signup_grant" => Ok(DeepLink::SignupGrant(s.parse()?)),
-            "secret_export" => Ok(DeepLink::SeedExport(s.parse()?)),
+            "signin" => Ok(DeepLink::Signin(SigninDeepLink::parse_url(&url)?)),
+            "signup" => Ok(DeepLink::Signup(SignupDeepLink::parse_url(&url)?)),
+            "signin_grant" => Ok(DeepLink::SigninGrant(SigninGrantDeepLink::parse_url(&url)?)),
+            "signup_grant" => Ok(DeepLink::SignupGrant(SignupGrantDeepLink::parse_url(&url)?)),
+            "secret_export" => Ok(DeepLink::SeedExport(SeedExportDeepLink::parse_url(&url)?)),
             "" => {
                 // Backwards compatible with old signin format (no host).
                 let mut url = url.clone();

--- a/pubky-sdk/src/actors/auth/deep_links/deep_link.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/deep_link.rs
@@ -6,9 +6,8 @@ use crate::{
     actors::auth::deep_links::{
         DEEP_LINK_SCHEMES, error::DeepLinkParseError, signin::SigninDeepLink,
         signin_grant::SigninGrantDeepLink, signup::SignupDeepLink,
-        signup_grant::SignupGrantDeepLink,
+        signup_grant::SignupGrantDeepLink, seed_export::SeedExportDeepLink,
     },
-    deep_links::seed_export::SeedExportDeepLink,
 };
 
 /// A parsed Pubky deep link.

--- a/pubky-sdk/src/actors/auth/deep_links/deep_link.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/deep_link.rs
@@ -63,14 +63,8 @@ impl FromStr for DeepLink {
         }
         let intent = url.host_str().unwrap_or("").to_string();
         match intent.as_str() {
-            "signin" => {
-                reject_legacy_grant_params(&url, "signin_grant")?;
-                Ok(DeepLink::Signin(s.parse()?))
-            }
-            "signup" => {
-                reject_legacy_grant_params(&url, "signup_grant")?;
-                Ok(DeepLink::Signup(s.parse()?))
-            }
+            "signin" => Ok(DeepLink::Signin(s.parse()?)),
+            "signup" => Ok(DeepLink::Signup(s.parse()?)),
             "signin_grant" => Ok(DeepLink::SigninGrant(s.parse()?)),
             "signup_grant" => Ok(DeepLink::SignupGrant(s.parse()?)),
             "secret_export" => Ok(DeepLink::SeedExport(s.parse()?)),
@@ -83,27 +77,6 @@ impl FromStr for DeepLink {
             }
             _ => Err(DeepLinkParseError::InvalidIntent("")),
         }
-    }
-}
-
-fn reject_legacy_grant_params(
-    url: &Url,
-    expected_intent: &'static str,
-) -> Result<(), DeepLinkParseError> {
-    let mut has_cid = false;
-    let mut has_cpk = false;
-    for (key, _) in url.query_pairs() {
-        match key.as_ref() {
-            "cid" => has_cid = true,
-            "cpk" => has_cpk = true,
-            _ => {}
-        }
-    }
-    match (has_cid, has_cpk) {
-        (true, true) => Err(DeepLinkParseError::InvalidIntent(expected_intent)),
-        (false, false) => Ok(()),
-        (true, false) => Err(DeepLinkParseError::MissingQueryParameter("cpk")),
-        (false, true) => Err(DeepLinkParseError::MissingQueryParameter("cid")),
     }
 }
 
@@ -153,56 +126,35 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_deep_link_signin_partial_cid_rejected() {
+    fn test_parse_deep_link_signin_ignores_extra_grant_params() {
         let deep_link = "pubkyauth://signin?caps=/pub/pubky.app/:rw&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&relay=https://httprelay.pubky.app/inbox&cid=franky.pubky.app";
-        let result: Result<DeepLink, _> = deep_link.parse();
-        assert!(matches!(
-            result,
-            Err(DeepLinkParseError::MissingQueryParameter("cpk"))
-        ));
+        let parsed: DeepLink = deep_link.parse().unwrap();
+
+        assert!(matches!(parsed, DeepLink::Signin(_)));
     }
 
     #[test]
-    fn test_parse_deep_link_old_signin_grant_intent_rejected() {
-        let deep_link = "pubkyauth://signin?caps=/pub/pubky.app/:rw&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&relay=https://httprelay.pubky.app/inbox&cid=franky.pubky.app&cpk=5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo";
-        let result: Result<DeepLink, _> = deep_link.parse();
+    fn test_parse_deep_link_signin_ignores_malformed_extra_grant_params() {
+        let deep_link = "pubkyauth://signin?caps=/pub/pubky.app/:rw&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&relay=https://httprelay.pubky.app/inbox&cid=franky.pubky.app&cpk=not-a-public-key";
+        let parsed: DeepLink = deep_link.parse().unwrap();
 
-        assert!(matches!(
-            result,
-            Err(DeepLinkParseError::InvalidIntent("signin_grant"))
-        ));
+        assert!(matches!(parsed, DeepLink::Signin(_)));
     }
 
     #[test]
-    fn test_parse_deep_link_old_signup_grant_intent_rejected() {
+    fn test_parse_deep_link_signup_ignores_extra_grant_params() {
         let deep_link = "pubkyauth://signup?caps=/pub/pubky.app/:rw&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&relay=https://httprelay.pubky.app/inbox&hs=5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo&cid=franky.pubky.app&cpk=5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo";
-        let result: Result<DeepLink, _> = deep_link.parse();
+        let parsed: DeepLink = deep_link.parse().unwrap();
 
-        assert!(matches!(
-            result,
-            Err(DeepLinkParseError::InvalidIntent("signup_grant"))
-        ));
+        assert!(matches!(parsed, DeepLink::Signup(_)));
     }
 
     #[test]
-    fn test_parse_deep_link_old_empty_signin_grant_intent_rejected() {
+    fn test_parse_deep_link_empty_signin_ignores_extra_grant_params() {
         let deep_link = "pubkyauth:///?caps=/pub/pubky.app/:rw&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&relay=https://httprelay.pubky.app/inbox&cid=franky.pubky.app&cpk=5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo";
-        let result: Result<DeepLink, _> = deep_link.parse();
+        let parsed: DeepLink = deep_link.parse().unwrap();
 
-        assert!(matches!(
-            result,
-            Err(DeepLinkParseError::InvalidIntent("signin_grant"))
-        ));
-    }
-
-    #[test]
-    fn test_parse_deep_link_signin_partial_cpk_rejected() {
-        let deep_link = "pubkyauth://signin?caps=/pub/pubky.app/:rw&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&relay=https://httprelay.pubky.app/inbox&cpk=5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo";
-        let result: Result<DeepLink, _> = deep_link.parse();
-        assert!(matches!(
-            result,
-            Err(DeepLinkParseError::MissingQueryParameter("cid"))
-        ));
+        assert!(matches!(parsed, DeepLink::Signin(_)));
     }
 
     #[test]

--- a/pubky-sdk/src/actors/auth/deep_links/deep_link.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/deep_link.rs
@@ -2,12 +2,10 @@ use std::{fmt::Display, str::FromStr};
 
 use url::Url;
 
-use crate::{
-    actors::auth::deep_links::{
-        DEEP_LINK_SCHEMES, error::DeepLinkParseError, signin::SigninDeepLink,
-        signin_grant::SigninGrantDeepLink, signup::SignupDeepLink,
-        signup_grant::SignupGrantDeepLink, seed_export::SeedExportDeepLink,
-    },
+use crate::actors::auth::deep_links::{
+    DEEP_LINK_SCHEMES, error::DeepLinkParseError, seed_export::SeedExportDeepLink,
+    signin::SigninDeepLink, signin_grant::SigninGrantDeepLink, signup::SignupDeepLink,
+    signup_grant::SignupGrantDeepLink,
 };
 
 /// A parsed Pubky deep link.
@@ -66,19 +64,15 @@ impl FromStr for DeepLink {
         let intent = url.host_str().unwrap_or("").to_string();
         match intent.as_str() {
             "signin" => {
-                if has_grant_params(&url)? {
-                    Ok(DeepLink::SigninGrant(s.parse()?))
-                } else {
-                    Ok(DeepLink::Signin(s.parse()?))
-                }
+                reject_legacy_grant_params(&url, "signin_grant")?;
+                Ok(DeepLink::Signin(s.parse()?))
             }
             "signup" => {
-                if has_grant_params(&url)? {
-                    Ok(DeepLink::SignupGrant(s.parse()?))
-                } else {
-                    Ok(DeepLink::Signup(s.parse()?))
-                }
+                reject_legacy_grant_params(&url, "signup_grant")?;
+                Ok(DeepLink::Signup(s.parse()?))
             }
+            "signin_grant" => Ok(DeepLink::SigninGrant(s.parse()?)),
+            "signup_grant" => Ok(DeepLink::SignupGrant(s.parse()?)),
             "secret_export" => Ok(DeepLink::SeedExport(s.parse()?)),
             "" => {
                 // Backwards compatible with old signin format (no host).
@@ -92,9 +86,10 @@ impl FromStr for DeepLink {
     }
 }
 
-/// Returns `true` if both `cid` and `cpk` are present, `false` if neither is,
-/// and an error if exactly one is present (partial grant binding is rejected).
-fn has_grant_params(url: &Url) -> Result<bool, DeepLinkParseError> {
+fn reject_legacy_grant_params(
+    url: &Url,
+    expected_intent: &'static str,
+) -> Result<(), DeepLinkParseError> {
     let mut has_cid = false;
     let mut has_cpk = false;
     for (key, _) in url.query_pairs() {
@@ -105,8 +100,8 @@ fn has_grant_params(url: &Url) -> Result<bool, DeepLinkParseError> {
         }
     }
     match (has_cid, has_cpk) {
-        (true, true) => Ok(true),
-        (false, false) => Ok(false),
+        (true, true) => Err(DeepLinkParseError::InvalidIntent(expected_intent)),
+        (false, false) => Ok(()),
         (true, false) => Err(DeepLinkParseError::MissingQueryParameter("cpk")),
         (false, true) => Err(DeepLinkParseError::MissingQueryParameter("cid")),
     }
@@ -138,7 +133,7 @@ mod tests {
 
     #[test]
     fn test_parse_deep_link_signin_grant() {
-        let deep_link = "pubkyauth://signin?caps=/pub/pubky.app/:rw&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&relay=https://httprelay.pubky.app/inbox&cid=franky.pubky.app&cpk=5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo";
+        let deep_link = "pubkyauth://signin_grant?caps=/pub/pubky.app/:rw&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&relay=https://httprelay.pubky.app/inbox&cid=franky.pubky.app&cpk=5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo";
         let parsed: DeepLink = deep_link.parse().unwrap();
         assert!(matches!(parsed, DeepLink::SigninGrant(_)));
     }
@@ -152,7 +147,7 @@ mod tests {
 
     #[test]
     fn test_parse_deep_link_signup_grant() {
-        let deep_link = "pubkyauth://signup?caps=/pub/pubky.app/:rw&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&relay=https://httprelay.pubky.app/inbox&hs=5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo&st=1234567890&cid=franky.pubky.app&cpk=5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo";
+        let deep_link = "pubkyauth://signup_grant?caps=/pub/pubky.app/:rw&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&relay=https://httprelay.pubky.app/inbox&hs=5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo&st=1234567890&cid=franky.pubky.app&cpk=5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo";
         let parsed: DeepLink = deep_link.parse().unwrap();
         assert!(matches!(parsed, DeepLink::SignupGrant(_)));
     }
@@ -164,6 +159,39 @@ mod tests {
         assert!(matches!(
             result,
             Err(DeepLinkParseError::MissingQueryParameter("cpk"))
+        ));
+    }
+
+    #[test]
+    fn test_parse_deep_link_old_signin_grant_intent_rejected() {
+        let deep_link = "pubkyauth://signin?caps=/pub/pubky.app/:rw&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&relay=https://httprelay.pubky.app/inbox&cid=franky.pubky.app&cpk=5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo";
+        let result: Result<DeepLink, _> = deep_link.parse();
+
+        assert!(matches!(
+            result,
+            Err(DeepLinkParseError::InvalidIntent("signin_grant"))
+        ));
+    }
+
+    #[test]
+    fn test_parse_deep_link_old_signup_grant_intent_rejected() {
+        let deep_link = "pubkyauth://signup?caps=/pub/pubky.app/:rw&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&relay=https://httprelay.pubky.app/inbox&hs=5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo&cid=franky.pubky.app&cpk=5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo";
+        let result: Result<DeepLink, _> = deep_link.parse();
+
+        assert!(matches!(
+            result,
+            Err(DeepLinkParseError::InvalidIntent("signup_grant"))
+        ));
+    }
+
+    #[test]
+    fn test_parse_deep_link_old_empty_signin_grant_intent_rejected() {
+        let deep_link = "pubkyauth:///?caps=/pub/pubky.app/:rw&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&relay=https://httprelay.pubky.app/inbox&cid=franky.pubky.app&cpk=5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo";
+        let result: Result<DeepLink, _> = deep_link.parse();
+
+        assert!(matches!(
+            result,
+            Err(DeepLinkParseError::InvalidIntent("signin_grant"))
         ));
     }
 

--- a/pubky-sdk/src/actors/auth/deep_links/deep_link.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/deep_link.rs
@@ -75,7 +75,7 @@ impl FromStr for DeepLink {
                 let string_value = url.to_string();
                 string_value.parse()
             }
-            _ => Err(DeepLinkParseError::InvalidIntent("")),
+            _ => Err(DeepLinkParseError::InvalidIntent("Intent not recognized.")),
         }
     }
 }

--- a/pubky-sdk/src/actors/auth/deep_links/mod.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/mod.rs
@@ -14,11 +14,13 @@
 
 mod deep_link;
 mod error;
+mod schemes;
 mod seed_export;
 mod signin;
 mod signin_grant;
 mod signup;
 mod signup_grant;
+mod typed_deep_link;
 
 /// Supported deep link schemes.
 pub const DEEP_LINK_SCHEMES: [&str; 2] = ["pubkyauth", "pubkyring"];

--- a/pubky-sdk/src/actors/auth/deep_links/mod.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/mod.rs
@@ -14,6 +14,7 @@
 
 mod deep_link;
 mod error;
+mod query_params;
 mod schemes;
 mod seed_export;
 mod signin;
@@ -29,8 +30,8 @@ pub use deep_link::DeepLink;
 pub use error::DeepLinkParseError;
 pub use schemes::DeepLinkScheme;
 pub use seed_export::{SecretExportIntent, SeedExportDeepLink, SeedExportParams};
-pub use signin::SigninDeepLink;
-pub use signin_grant::SigninGrantDeepLink;
-pub use signup::SignupDeepLink;
-pub use signup_grant::SignupGrantDeepLink;
+pub use signin::{SigninDeepLink, SigninIntent, SigninParams};
+pub use signin_grant::{SigninGrantDeepLink, SigninGrantIntent, SigninGrantParams};
+pub use signup::{SignupDeepLink, SignupIntent, SignupParams};
+pub use signup_grant::{SignupGrantDeepLink, SignupGrantIntent, SignupGrantParams};
 pub use typed_deep_link::{DeepLinkIntent, DeepLinkParams, TypedDeepLink};

--- a/pubky-sdk/src/actors/auth/deep_links/mod.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/mod.rs
@@ -27,8 +27,10 @@ pub const DEEP_LINK_SCHEMES: [&str; 2] = ["pubkyauth", "pubkyring"];
 
 pub use deep_link::DeepLink;
 pub use error::DeepLinkParseError;
-pub use seed_export::SeedExportDeepLink;
+pub use schemes::DeepLinkScheme;
+pub use seed_export::{SecretExportIntent, SeedExportDeepLink, SeedExportParams};
 pub use signin::SigninDeepLink;
 pub use signin_grant::SigninGrantDeepLink;
 pub use signup::SignupDeepLink;
 pub use signup_grant::SignupGrantDeepLink;
+pub use typed_deep_link::{DeepLinkIntent, DeepLinkParams, TypedDeepLink};

--- a/pubky-sdk/src/actors/auth/deep_links/query_params.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/query_params.rs
@@ -1,0 +1,96 @@
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use pubky_common::{auth::jws::ClientId, capabilities::Capabilities, crypto::PublicKey};
+use url::Url;
+
+use super::DeepLinkParseError;
+
+pub(super) fn parse_capabilities(url: &Url) -> Result<Capabilities, DeepLinkParseError> {
+    required_query(url, "caps")?
+        .as_str()
+        .try_into()
+        .map_err(|e| DeepLinkParseError::InvalidQueryParameter("caps", Box::new(e)))
+}
+
+pub(super) fn parse_relay(url: &Url) -> Result<Url, DeepLinkParseError> {
+    Url::parse(&required_query(url, "relay")?)
+        .map_err(|e| DeepLinkParseError::InvalidQueryParameter("relay", Box::new(e)))
+}
+
+pub(super) fn parse_secret(url: &Url) -> Result<[u8; 32], DeepLinkParseError> {
+    let raw_secret = required_query(url, "secret")?;
+    let secret = URL_SAFE_NO_PAD
+        .decode(raw_secret.as_str())
+        .map_err(|e| DeepLinkParseError::InvalidQueryParameter("secret", Box::new(e)))?;
+
+    secret.try_into().map_err(|e: Vec<u8>| {
+        let msg = format!("Expected 32 bytes, got {}", e.len());
+        DeepLinkParseError::InvalidQueryParameter(
+            "secret",
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, msg)),
+        )
+    })
+}
+
+pub(super) fn parse_homeserver(url: &Url) -> Result<PublicKey, DeepLinkParseError> {
+    PublicKey::try_from_z32(&required_query(url, "hs")?)
+        .map_err(|e| DeepLinkParseError::InvalidQueryParameter("hs", Box::new(e)))
+}
+
+pub(super) fn parse_client_id(url: &Url) -> Result<ClientId, DeepLinkParseError> {
+    ClientId::new(&required_query(url, "cid")?)
+        .map_err(|e| DeepLinkParseError::InvalidQueryParameter("cid", Box::new(e)))
+}
+
+pub(super) fn parse_client_pk(url: &Url) -> Result<PublicKey, DeepLinkParseError> {
+    PublicKey::try_from_z32(&required_query(url, "cpk")?)
+        .map_err(|e| DeepLinkParseError::InvalidQueryParameter("cpk", Box::new(e)))
+}
+
+pub(super) fn required_query(url: &Url, key: &'static str) -> Result<String, DeepLinkParseError> {
+    optional_query(url, key).ok_or(DeepLinkParseError::MissingQueryParameter(key))
+}
+
+pub(super) fn optional_query(url: &Url, key: &str) -> Option<String> {
+    url.query_pairs()
+        .find(|(param_key, _)| param_key == key)
+        .map(|(_, value)| value.to_string())
+}
+
+pub(super) fn append_signin_params(
+    url: &mut Url,
+    capabilities: &Capabilities,
+    relay: &Url,
+    secret: &[u8; 32],
+) {
+    url.query_pairs_mut()
+        .append_pair("caps", &capabilities.to_string())
+        .append_pair("relay", relay.as_str())
+        .append_pair("secret", &URL_SAFE_NO_PAD.encode(secret));
+}
+
+pub(super) fn append_signup_params(
+    url: &mut Url,
+    capabilities: &Capabilities,
+    relay: &Url,
+    secret: &[u8; 32],
+    homeserver: &PublicKey,
+    signup_token: Option<&str>,
+) {
+    append_signin_params(url, capabilities, relay, secret);
+    let mut query = url.query_pairs_mut();
+    query.append_pair("hs", &homeserver.z32());
+    if let Some(signup_token) = signup_token {
+        query.append_pair("st", signup_token);
+    }
+}
+
+pub(super) fn append_grant_params(url: &mut Url, client_id: &ClientId, client_pk: &PublicKey) {
+    url.query_pairs_mut()
+        .append_pair("cid", &client_id.to_string())
+        .append_pair("cpk", &client_pk.z32());
+}
+
+pub(super) fn append_secret_param(url: &mut Url, secret: &[u8; 32]) {
+    url.query_pairs_mut()
+        .append_pair("secret", &URL_SAFE_NO_PAD.encode(secret));
+}

--- a/pubky-sdk/src/actors/auth/deep_links/query_params.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/query_params.rs
@@ -89,5 +89,3 @@ pub(super) fn append_grant_params(url: &mut Url, client_id: &ClientId, client_pk
         .append_pair("cid", &client_id.to_string())
         .append_pair("cpk", &client_pk.z32());
 }
-
-

--- a/pubky-sdk/src/actors/auth/deep_links/query_params.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/query_params.rs
@@ -90,7 +90,4 @@ pub(super) fn append_grant_params(url: &mut Url, client_id: &ClientId, client_pk
         .append_pair("cpk", &client_pk.z32());
 }
 
-pub(super) fn append_secret_param(url: &mut Url, secret: &[u8; 32]) {
-    url.query_pairs_mut()
-        .append_pair("secret", &URL_SAFE_NO_PAD.encode(secret));
-}
+

--- a/pubky-sdk/src/actors/auth/deep_links/schemes.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/schemes.rs
@@ -1,8 +1,3 @@
-#![allow(
-    dead_code,
-    reason = "Scheme type is introduced before the deep link parser refactor uses it"
-)]
-
 use std::{fmt::Display, str::FromStr};
 
 use super::DeepLinkParseError;

--- a/pubky-sdk/src/actors/auth/deep_links/schemes.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/schemes.rs
@@ -12,15 +12,18 @@ const PUBKY_AUTH_SCHEME: &str = "pubkyauth";
 const PUBKY_RING_SCHEME: &str = "pubkyring";
 const EXPECTED_DEEP_LINK_SCHEMES: &str = "pubkyauth or pubkyring";
 
+/// Supported Pubky deep-link URI schemes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) enum DeepLinkScheme {
+pub enum DeepLinkScheme {
+    /// Current Pubky auth deep-link scheme.
     PubkyAuth,
+    /// Deprecated Pubky Ring deep-link scheme.
     PubkyRing,
 }
 
 impl DeepLinkScheme {
     /// Return the canonical URI scheme string.
-    pub(super) const fn as_str(self) -> &'static str {
+    pub const fn as_str(self) -> &'static str {
         match self {
             Self::PubkyAuth => PUBKY_AUTH_SCHEME,
             Self::PubkyRing => PUBKY_RING_SCHEME,

--- a/pubky-sdk/src/actors/auth/deep_links/schemes.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/schemes.rs
@@ -23,6 +23,7 @@ pub enum DeepLinkScheme {
 
 impl DeepLinkScheme {
     /// Return the canonical URI scheme string.
+    #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
             Self::PubkyAuth => PUBKY_AUTH_SCHEME,

--- a/pubky-sdk/src/actors/auth/deep_links/schemes.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/schemes.rs
@@ -1,0 +1,85 @@
+#![allow(
+    dead_code,
+    reason = "Scheme type is introduced before the deep link parser refactor uses it"
+)]
+
+use std::{fmt::Display, str::FromStr};
+
+use super::DeepLinkParseError;
+
+const PUBKY_AUTH_SCHEME: &str = "pubkyauth";
+/// Deprecated schema
+const PUBKY_RING_SCHEME: &str = "pubkyring";
+const EXPECTED_DEEP_LINK_SCHEMES: &str = "pubkyauth or pubkyring";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum DeepLinkScheme {
+    PubkyAuth,
+    PubkyRing,
+}
+
+impl DeepLinkScheme {
+    /// Return the canonical URI scheme string.
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::PubkyAuth => PUBKY_AUTH_SCHEME,
+            Self::PubkyRing => PUBKY_RING_SCHEME,
+        }
+    }
+}
+
+impl Display for DeepLinkScheme {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for DeepLinkScheme {
+    type Err = DeepLinkParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            PUBKY_AUTH_SCHEME => Ok(Self::PubkyAuth),
+            PUBKY_RING_SCHEME => Ok(Self::PubkyRing),
+            _ => Err(DeepLinkParseError::InvalidSchema(
+                EXPECTED_DEEP_LINK_SCHEMES,
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_pubky_auth_scheme() {
+        let scheme: DeepLinkScheme = "pubkyauth".parse().unwrap();
+
+        assert_eq!(scheme, DeepLinkScheme::PubkyAuth);
+    }
+
+    #[test]
+    fn parses_pubky_ring_scheme() {
+        let scheme: DeepLinkScheme = "pubkyring".parse().unwrap();
+
+        assert_eq!(scheme, DeepLinkScheme::PubkyRing);
+    }
+
+    #[test]
+    fn rejects_unknown_scheme() {
+        let error = "https".parse::<DeepLinkScheme>().unwrap_err();
+
+        assert!(matches!(error, DeepLinkParseError::InvalidSchema(_)));
+    }
+
+    #[test]
+    fn formats_pubky_auth_scheme() {
+        assert_eq!(DeepLinkScheme::PubkyAuth.to_string(), "pubkyauth");
+    }
+
+    #[test]
+    fn formats_pubky_ring_scheme() {
+        assert_eq!(DeepLinkScheme::PubkyRing.to_string(), "pubkyring");
+    }
+}

--- a/pubky-sdk/src/actors/auth/deep_links/seed_export.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/seed_export.rs
@@ -1,8 +1,9 @@
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use url::Url;
 
 use super::{
     DeepLinkParseError,
-    query_params::{append_secret_param, parse_secret},
+    query_params::parse_secret,
     typed_deep_link::{DeepLinkIntent, DeepLinkParams, TypedDeepLink},
 };
 
@@ -32,7 +33,8 @@ impl DeepLinkParams for SeedExportParams {
     }
 
     fn append_query_pairs(&self, url: &mut Url) {
-        append_secret_param(url, &self.secret);
+        url.query_pairs_mut()
+            .append_pair("secret", &URL_SAFE_NO_PAD.encode(&self.secret));
     }
 }
 

--- a/pubky-sdk/src/actors/auth/deep_links/seed_export.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/seed_export.rs
@@ -1,104 +1,118 @@
-use std::{fmt::Display, str::FromStr};
-
 use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use url::Url;
 
-use crate::actors::auth::deep_links::{DEEP_LINK_SCHEMES, error::DeepLinkParseError};
+use super::{
+    DeepLinkParseError,
+    typed_deep_link::{DeepLinkIntent, DeepLinkParams, TypedDeepLink, parse_secret},
+};
 
-/// A deep link for exporting a user secret to a signer like Pubky Ring.
-/// Supported formats:
-/// - <pubkyauth://secret_export?secret=base64_encoded_secret>
+/// Intent marker for seed-export deep links.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SecretExportIntent;
+
+impl DeepLinkIntent for SecretExportIntent {
+    const NAME: &'static str = "secret_export";
+}
+
+/// A typed seed-export deep link.
+pub type SeedExportDeepLink = TypedDeepLink<SecretExportIntent, SeedExportParams>;
+
+/// Typed parameters for a seed-export deep link.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SeedExportDeepLink {
-    secret: [u8; 32],
+pub struct SeedExportParams {
+    /// The keypair secret to export.
+    pub secret: [u8; 32],
 }
 
-impl SeedExportDeepLink {
-    /// Create a new seed export deep link.
-    ///
-    /// # Arguments
-    /// * `secret` - The keypair secret to export.
-    #[must_use]
-    pub fn new(secret: [u8; 32]) -> Self {
-        Self { secret }
+impl DeepLinkParams for SeedExportParams {
+    fn parse(url: &Url) -> Result<Self, DeepLinkParseError> {
+        Ok(Self {
+            secret: parse_secret(url)?,
+        })
     }
 
-    /// Get the secret for the seed export flow.
-    #[must_use]
-    pub fn secret(&self) -> &[u8; 32] {
-        &self.secret
-    }
-}
-
-impl Display for SeedExportDeepLink {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "pubkyauth://secret_export?secret={}",
-            URL_SAFE_NO_PAD.encode(self.secret)
-        )
-    }
-}
-
-impl FromStr for SeedExportDeepLink {
-    type Err = DeepLinkParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let url = Url::parse(s)?;
-        if !DEEP_LINK_SCHEMES.contains(&url.scheme()) {
-            return Err(DeepLinkParseError::InvalidSchema("pubkyauth or pubkyring"));
-        }
-        let intent = url.host_str().unwrap_or("").to_string();
-        if intent != "secret_export" {
-            return Err(DeepLinkParseError::InvalidIntent("secret_export"));
-        }
-
-        let raw_secret = url
-            .query_pairs()
-            .find(|(key, _)| key == "secret")
-            .ok_or(DeepLinkParseError::MissingQueryParameter("secret"))?
-            .1
-            .to_string();
-        let secret = URL_SAFE_NO_PAD
-            .decode(raw_secret.as_str())
-            .map_err(|e| DeepLinkParseError::InvalidQueryParameter("secret", Box::new(e)))?;
-        let secret: [u8; 32] = secret.try_into().map_err(|e: Vec<u8>| {
-            let msg = format!("Expected 32 bytes, got {}", e.len());
-            DeepLinkParseError::InvalidQueryParameter(
-                "secret",
-                Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, msg)),
-            )
-        })?;
-
-        Ok(SeedExportDeepLink { secret })
-    }
-}
-
-impl From<SeedExportDeepLink> for Url {
-    fn from(val: SeedExportDeepLink) -> Self {
-        Url::parse(&val.to_string()).expect("Should be able to parse the deep link")
+    fn append_query_pairs(&self, url: &mut Url) {
+        url.query_pairs_mut()
+            .append_pair("secret", &URL_SAFE_NO_PAD.encode(self.secret));
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Keypair;
+    use crate::actors::auth::deep_links::DeepLinkScheme;
+
+    const SECRET: &str = "kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8";
+    const SECRET_BYTES: [u8; 32] = [
+        146, 169, 220, 120, 67, 32, 172, 212, 12, 255, 24, 180, 234, 132, 23, 140, 13, 220, 36,
+        117, 255, 69, 9, 176, 212, 22, 58, 36, 77, 91, 177, 239,
+    ];
 
     #[test]
-    fn test_signin_deep_link_parse() {
-        let keypair = Keypair::random();
-        let secret = keypair.secret();
-        let deep_link = SeedExportDeepLink::new(secret);
-        let deep_link_str = deep_link.to_string();
-        assert_eq!(
-            deep_link_str,
-            format!(
-                "pubkyauth://secret_export?secret={}",
-                URL_SAFE_NO_PAD.encode(secret)
-            )
+    fn parses_seed_export_deep_link() {
+        let deep_link: SeedExportDeepLink =
+            format!("pubkyring://secret_export?secret={SECRET}")
+                .parse()
+                .unwrap();
+
+        assert_eq!(deep_link.scheme(), DeepLinkScheme::PubkyRing);
+        assert_eq!(deep_link.intent(), "secret_export");
+        assert_eq!(deep_link.params().secret, SECRET_BYTES);
+    }
+
+    #[test]
+    fn converts_seed_export_deep_link_to_url() {
+        let deep_link: SeedExportDeepLink =
+            format!("pubkyring://secret_export?secret={SECRET}")
+                .parse()
+                .unwrap();
+        let url = deep_link.to_url();
+
+        assert_eq!(url.scheme(), "pubkyring");
+        assert_eq!(url.host_str(), Some("secret_export"));
+        assert_eq!(SeedExportDeepLink::parse_url(&url).unwrap(), deep_link);
+    }
+
+    #[test]
+    fn creates_seed_export_deep_link_from_params() {
+        let deep_link = SeedExportDeepLink::new(
+            DeepLinkScheme::PubkyAuth,
+            SeedExportParams {
+                secret: SECRET_BYTES,
+            },
         );
-        let deep_link_parsed = SeedExportDeepLink::from_str(&deep_link_str).unwrap();
-        assert_eq!(deep_link_parsed, deep_link);
+        let url = deep_link.to_url();
+        let parsed_again = SeedExportDeepLink::parse_url(&url).unwrap();
+
+        assert_eq!(deep_link.scheme(), DeepLinkScheme::PubkyAuth);
+        assert_eq!(deep_link.intent(), "secret_export");
+        assert_eq!(deep_link.params().secret, SECRET_BYTES);
+        assert_eq!(parsed_again, deep_link);
+    }
+
+    #[test]
+    fn display_formats_as_url() {
+        let deep_link: SeedExportDeepLink =
+            format!("pubkyauth://secret_export?secret={SECRET}")
+                .parse()
+                .unwrap();
+
+        assert_eq!(deep_link.to_string(), deep_link.to_url().to_string());
+    }
+
+    #[test]
+    fn converts_owned_typed_deep_link_into_url() {
+        let deep_link: SeedExportDeepLink =
+            format!("pubkyauth://secret_export?secret={SECRET}")
+                .parse()
+                .unwrap();
+        let url: Url = deep_link.into();
+
+        assert_eq!(url.scheme(), "pubkyauth");
+        assert_eq!(url.host_str(), Some("secret_export"));
+        url.query_pairs()
+            .find(|(key, _)| key == "secret")
+            .map(|(_, value)| assert_eq!(value, SECRET))
+            .expect("Expected 'secret' query parameter");
     }
 }

--- a/pubky-sdk/src/actors/auth/deep_links/seed_export.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/seed_export.rs
@@ -34,7 +34,7 @@ impl DeepLinkParams for SeedExportParams {
 
     fn append_query_pairs(&self, url: &mut Url) {
         url.query_pairs_mut()
-            .append_pair("secret", &URL_SAFE_NO_PAD.encode(&self.secret));
+            .append_pair("secret", &URL_SAFE_NO_PAD.encode(self.secret));
     }
 }
 

--- a/pubky-sdk/src/actors/auth/deep_links/seed_export.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/seed_export.rs
@@ -1,9 +1,9 @@
-use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use url::Url;
 
 use super::{
     DeepLinkParseError,
-    typed_deep_link::{DeepLinkIntent, DeepLinkParams, TypedDeepLink, parse_secret},
+    query_params::{append_secret_param, parse_secret},
+    typed_deep_link::{DeepLinkIntent, DeepLinkParams, TypedDeepLink},
 };
 
 /// Intent marker for seed-export deep links.
@@ -32,8 +32,7 @@ impl DeepLinkParams for SeedExportParams {
     }
 
     fn append_query_pairs(&self, url: &mut Url) {
-        url.query_pairs_mut()
-            .append_pair("secret", &URL_SAFE_NO_PAD.encode(self.secret));
+        append_secret_param(url, &self.secret);
     }
 }
 
@@ -50,10 +49,9 @@ mod tests {
 
     #[test]
     fn parses_seed_export_deep_link() {
-        let deep_link: SeedExportDeepLink =
-            format!("pubkyring://secret_export?secret={SECRET}")
-                .parse()
-                .unwrap();
+        let deep_link: SeedExportDeepLink = format!("pubkyring://secret_export?secret={SECRET}")
+            .parse()
+            .unwrap();
 
         assert_eq!(deep_link.scheme(), DeepLinkScheme::PubkyRing);
         assert_eq!(deep_link.intent(), "secret_export");
@@ -62,10 +60,9 @@ mod tests {
 
     #[test]
     fn converts_seed_export_deep_link_to_url() {
-        let deep_link: SeedExportDeepLink =
-            format!("pubkyring://secret_export?secret={SECRET}")
-                .parse()
-                .unwrap();
+        let deep_link: SeedExportDeepLink = format!("pubkyring://secret_export?secret={SECRET}")
+            .parse()
+            .unwrap();
         let url = deep_link.to_url();
 
         assert_eq!(url.scheme(), "pubkyring");
@@ -92,20 +89,18 @@ mod tests {
 
     #[test]
     fn display_formats_as_url() {
-        let deep_link: SeedExportDeepLink =
-            format!("pubkyauth://secret_export?secret={SECRET}")
-                .parse()
-                .unwrap();
+        let deep_link: SeedExportDeepLink = format!("pubkyauth://secret_export?secret={SECRET}")
+            .parse()
+            .unwrap();
 
         assert_eq!(deep_link.to_string(), deep_link.to_url().to_string());
     }
 
     #[test]
     fn converts_owned_typed_deep_link_into_url() {
-        let deep_link: SeedExportDeepLink =
-            format!("pubkyauth://secret_export?secret={SECRET}")
-                .parse()
-                .unwrap();
+        let deep_link: SeedExportDeepLink = format!("pubkyauth://secret_export?secret={SECRET}")
+            .parse()
+            .unwrap();
         let url: Url = deep_link.into();
 
         assert_eq!(url.scheme(), "pubkyauth");

--- a/pubky-sdk/src/actors/auth/deep_links/signin.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/signin.rs
@@ -67,6 +67,15 @@ mod tests {
     }
 
     #[test]
+    fn parses_signin_deep_link_with_extra_query_params() {
+        let deep_link: SigninDeepLink = "pubkyauth://signin?caps=/pub/pubky.app/:rw&relay=https://httprelay.pubky.app/inbox/&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&cid=franky.pubky.app&cpk=not-a-public-key"
+            .parse()
+            .unwrap();
+
+        assert_eq!(deep_link.intent(), "signin");
+    }
+
+    #[test]
     fn creates_signin_deep_link_from_params() {
         let capabilities = Capabilities::builder()
             .read_write("/")

--- a/pubky-sdk/src/actors/auth/deep_links/signin.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/signin.rs
@@ -1,154 +1,110 @@
-use std::{fmt::Display, str::FromStr};
-
-use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use pubky_common::capabilities::Capabilities;
 use url::Url;
 
-use crate::actors::auth::deep_links::{DEEP_LINK_SCHEMES, error::DeepLinkParseError};
+use super::{
+    DeepLinkParseError,
+    query_params::{append_signin_params, parse_capabilities, parse_relay, parse_secret},
+    typed_deep_link::{DeepLinkIntent, DeepLinkParams, TypedDeepLink},
+};
 
-/// A deep link for signing into a Pubky homeserver via the legacy
-/// [`AuthToken`](pubky_common::auth::AuthToken) flow (cookie-based session).
-///
-/// Format: `pubkyauth://signin?caps=…&relay=…&secret=…`.
-///
-/// For the grant flow, use [`SigninGrantDeepLink`](super::SigninGrantDeepLink)
-/// instead.
+/// Intent marker for legacy signin deep links.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SigninIntent;
+
+impl DeepLinkIntent for SigninIntent {
+    const NAME: &'static str = "signin";
+}
+
+/// Typed parameters for legacy signin deep links.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SigninDeepLink {
-    capabilities: Capabilities,
-    relay: Url,
-    secret: [u8; 32],
+pub struct SigninParams {
+    /// Capabilities requested by the app.
+    pub capabilities: Capabilities,
+    /// Base HTTP relay URL.
+    pub relay: Url,
+    /// Secret used to derive the encrypted relay channel.
+    pub secret: [u8; 32],
 }
 
-impl SigninDeepLink {
-    /// Create a new signin deep link.
-    #[must_use]
-    pub fn new(capabilities: Capabilities, relay: Url, secret: [u8; 32]) -> Self {
-        Self {
-            capabilities,
-            relay,
-            secret,
-        }
-    }
-
-    /// Get the capabilities for the signin flow.
-    pub fn capabilities(&self) -> &Capabilities {
-        &self.capabilities
-    }
-
-    /// Get the relay for the signin flow.
-    #[must_use]
-    pub fn relay(&self) -> &Url {
-        &self.relay
-    }
-
-    /// Get the secret for the signin flow.
-    #[must_use]
-    pub fn secret(&self) -> &[u8; 32] {
-        &self.secret
-    }
-}
-
-impl Display for SigninDeepLink {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "pubkyauth://signin?caps={}&relay={}&secret={}",
-            self.capabilities,
-            self.relay,
-            URL_SAFE_NO_PAD.encode(self.secret)
-        )
-    }
-}
-
-impl FromStr for SigninDeepLink {
-    type Err = DeepLinkParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let url = Url::parse(s)?;
-        if !DEEP_LINK_SCHEMES.contains(&url.scheme()) {
-            return Err(DeepLinkParseError::InvalidSchema("pubkyauth or pubkyring"));
-        }
-        let intent = url.host_str().unwrap_or("").to_string();
-        if intent != "signin" {
-            return Err(DeepLinkParseError::InvalidIntent("signin"));
-        }
-
-        let raw_caps = url
-            .query_pairs()
-            .find(|(key, _)| key == "caps")
-            .ok_or(DeepLinkParseError::MissingQueryParameter("caps"))?
-            .1
-            .to_string();
-        let capabilities: Capabilities = raw_caps
-            .as_str()
-            .try_into()
-            .map_err(|e| DeepLinkParseError::InvalidQueryParameter("caps", Box::new(e)))?;
-
-        let raw_relay = url
-            .query_pairs()
-            .find(|(key, _)| key == "relay")
-            .ok_or(DeepLinkParseError::MissingQueryParameter("relay"))?
-            .1
-            .to_string();
-        let relay = Url::parse(&raw_relay)
-            .map_err(|e| DeepLinkParseError::InvalidQueryParameter("relay", Box::new(e)))?;
-
-        let raw_secret = url
-            .query_pairs()
-            .find(|(key, _)| key == "secret")
-            .ok_or(DeepLinkParseError::MissingQueryParameter("secret"))?
-            .1
-            .to_string();
-        let secret = URL_SAFE_NO_PAD
-            .decode(raw_secret.as_str())
-            .map_err(|e| DeepLinkParseError::InvalidQueryParameter("secret", Box::new(e)))?;
-        let secret: [u8; 32] = secret.try_into().map_err(|e: Vec<u8>| {
-            let msg = format!("Expected 32 bytes, got {}", e.len());
-            DeepLinkParseError::InvalidQueryParameter(
-                "secret",
-                Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, msg)),
-            )
-        })?;
-
-        Ok(SigninDeepLink {
-            capabilities,
-            relay,
-            secret,
+impl DeepLinkParams for SigninParams {
+    fn parse(url: &Url) -> Result<Self, DeepLinkParseError> {
+        Ok(Self {
+            capabilities: parse_capabilities(url)?,
+            relay: parse_relay(url)?,
+            secret: parse_secret(url)?,
         })
     }
-}
 
-impl From<SigninDeepLink> for Url {
-    fn from(val: SigninDeepLink) -> Self {
-        Url::parse(&val.to_string()).expect("Should be able to parse the deep link")
+    fn append_query_pairs(&self, url: &mut Url) {
+        append_signin_params(url, &self.capabilities, &self.relay, &self.secret);
     }
 }
+
+/// A deep link for signing into a Pubky homeserver via the legacy cookie flow.
+pub type SigninDeepLink = TypedDeepLink<SigninIntent, SigninParams>;
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::actors::auth::deep_links::DeepLinkScheme;
 
     #[test]
-    fn test_signin_deep_link_parse() {
+    fn parses_signin_deep_link() {
+        let deep_link: SigninDeepLink = "pubkyauth://signin?caps=/pub/pubky.app/:rw&relay=https://httprelay.pubky.app/inbox/&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8"
+            .parse()
+            .unwrap();
+
+        assert_eq!(deep_link.scheme(), DeepLinkScheme::PubkyAuth);
+        assert_eq!(deep_link.intent(), "signin");
+        assert_eq!(
+            deep_link.params().capabilities.to_string(),
+            "/pub/pubky.app/:rw"
+        );
+        assert_eq!(
+            deep_link.params().relay.as_str(),
+            "https://httprelay.pubky.app/inbox/"
+        );
+    }
+
+    #[test]
+    fn creates_signin_deep_link_from_params() {
         let capabilities = Capabilities::builder()
             .read_write("/")
             .read("/test")
             .finish();
         let relay = Url::parse("https://httprelay.pubky.app/inbox/").unwrap();
         let secret = [123; 32];
-        let deep_link = SigninDeepLink::new(capabilities.clone(), relay.clone(), secret);
-        let deep_link_str = deep_link.to_string();
-        assert_eq!(
-            deep_link_str,
-            format!(
-                "pubkyauth://signin?caps={}&relay={}&secret={}",
+        let deep_link = SigninDeepLink::new(
+            DeepLinkScheme::PubkyAuth,
+            SigninParams {
                 capabilities,
                 relay,
-                URL_SAFE_NO_PAD.encode(secret)
-            )
+                secret,
+            },
         );
-        let deep_link_parsed = SigninDeepLink::from_str(&deep_link_str).unwrap();
-        assert_eq!(deep_link_parsed, deep_link);
+        let parsed_again = SigninDeepLink::parse_url(&deep_link.to_url()).unwrap();
+
+        assert_eq!(parsed_again, deep_link);
+    }
+
+    #[test]
+    fn rejects_missing_secret() {
+        let error = "pubkyauth://signin?caps=/:rw&relay=https://httprelay.pubky.app/inbox/"
+            .parse::<SigninDeepLink>()
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            DeepLinkParseError::MissingQueryParameter("secret")
+        ));
+    }
+
+    #[test]
+    fn rejects_wrong_intent() {
+        let error = "pubkyauth://signup?caps=/:rw&relay=https://httprelay.pubky.app/inbox/&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8"
+            .parse::<SigninDeepLink>()
+            .unwrap_err();
+
+        assert!(matches!(error, DeepLinkParseError::InvalidIntent("signin")));
     }
 }

--- a/pubky-sdk/src/actors/auth/deep_links/signin_grant.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/signin_grant.rs
@@ -1,222 +1,107 @@
-use std::{fmt::Display, str::FromStr};
-
-use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use pubky_common::{auth::jws::ClientId, capabilities::Capabilities, crypto::PublicKey};
 use url::Url;
 
-use crate::actors::auth::deep_links::{DEEP_LINK_SCHEMES, error::DeepLinkParseError};
+use super::{
+    DeepLinkParseError,
+    query_params::{
+        append_grant_params, append_signin_params, parse_capabilities, parse_client_id,
+        parse_client_pk, parse_relay, parse_secret,
+    },
+    typed_deep_link::{DeepLinkIntent, DeepLinkParams, TypedDeepLink},
+};
 
-/// A deep link for signing in to a Pubky homeserver via the **grant**
-/// (Proof-of-Possession) flow.
-///
-/// Format:
-/// `pubkyauth://signin?caps=…&relay=…&secret=…&cid=…&cpk=…`
-///
-/// `cid` is the application identifier and `cpk` is the client public key
-/// bound by the grant's `cnf` claim. Both are required — for the legacy
-/// cookie flow without grant binding, use [`SigninDeepLink`](super::SigninDeepLink).
+/// Intent marker for grant-mode signin deep links.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SigninGrantIntent;
+
+impl DeepLinkIntent for SigninGrantIntent {
+    const NAME: &'static str = "signin_grant";
+}
+
+/// Typed parameters for grant-mode signin deep links.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SigninGrantDeepLink {
-    capabilities: Capabilities,
-    relay: Url,
-    secret: [u8; 32],
-    client_id: ClientId,
-    client_pk: PublicKey,
-}
-
-impl SigninGrantDeepLink {
-    /// Create a new grant-mode signin deep link.
-    #[must_use]
-    pub fn new(
-        capabilities: Capabilities,
-        relay: Url,
-        secret: [u8; 32],
-        client_id: ClientId,
-        client_pk: PublicKey,
-    ) -> Self {
-        Self {
-            capabilities,
-            relay,
-            secret,
-            client_id,
-            client_pk,
-        }
-    }
-
-    /// Get the capabilities for the signin flow.
-    pub fn capabilities(&self) -> &Capabilities {
-        &self.capabilities
-    }
-
-    /// Get the relay for the signin flow.
-    #[must_use]
-    pub fn relay(&self) -> &Url {
-        &self.relay
-    }
-
-    /// Get the secret for the signin flow.
-    #[must_use]
-    pub fn secret(&self) -> &[u8; 32] {
-        &self.secret
-    }
-
+pub struct SigninGrantParams {
+    /// Capabilities requested by the app.
+    pub capabilities: Capabilities,
+    /// Base HTTP relay URL.
+    pub relay: Url,
+    /// Secret used to derive the encrypted relay channel.
+    pub secret: [u8; 32],
     /// Application identifier carried by this deep link.
-    #[must_use]
-    pub fn client_id(&self) -> &ClientId {
-        &self.client_id
-    }
-
-    /// Client public key (`cnf` for the grant) carried by this deep link.
-    #[must_use]
-    pub fn client_pk(&self) -> &PublicKey {
-        &self.client_pk
-    }
+    pub client_id: ClientId,
+    /// Client public key bound by the grant's `cnf` claim.
+    pub client_pk: PublicKey,
 }
 
-impl Display for SigninGrantDeepLink {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "pubkyauth://signin?caps={}&relay={}&secret={}&cid={}&cpk={}",
-            self.capabilities,
-            self.relay,
-            URL_SAFE_NO_PAD.encode(self.secret),
-            self.client_id,
-            self.client_pk.z32()
-        )
-    }
-}
-
-impl FromStr for SigninGrantDeepLink {
-    type Err = DeepLinkParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let url = Url::parse(s)?;
-        if !DEEP_LINK_SCHEMES.contains(&url.scheme()) {
-            return Err(DeepLinkParseError::InvalidSchema("pubkyauth or pubkyring"));
-        }
-        let intent = url.host_str().unwrap_or("").to_string();
-        if intent != "signin" {
-            return Err(DeepLinkParseError::InvalidIntent("signin"));
-        }
-
-        let raw_caps = url
-            .query_pairs()
-            .find(|(key, _)| key == "caps")
-            .ok_or(DeepLinkParseError::MissingQueryParameter("caps"))?
-            .1
-            .to_string();
-        let capabilities: Capabilities = raw_caps
-            .as_str()
-            .try_into()
-            .map_err(|e| DeepLinkParseError::InvalidQueryParameter("caps", Box::new(e)))?;
-
-        let raw_relay = url
-            .query_pairs()
-            .find(|(key, _)| key == "relay")
-            .ok_or(DeepLinkParseError::MissingQueryParameter("relay"))?
-            .1
-            .to_string();
-        let relay = Url::parse(&raw_relay)
-            .map_err(|e| DeepLinkParseError::InvalidQueryParameter("relay", Box::new(e)))?;
-
-        let raw_secret = url
-            .query_pairs()
-            .find(|(key, _)| key == "secret")
-            .ok_or(DeepLinkParseError::MissingQueryParameter("secret"))?
-            .1
-            .to_string();
-        let secret = URL_SAFE_NO_PAD
-            .decode(raw_secret.as_str())
-            .map_err(|e| DeepLinkParseError::InvalidQueryParameter("secret", Box::new(e)))?;
-        let secret: [u8; 32] = secret.try_into().map_err(|e: Vec<u8>| {
-            let msg = format!("Expected 32 bytes, got {}", e.len());
-            DeepLinkParseError::InvalidQueryParameter(
-                "secret",
-                Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, msg)),
-            )
-        })?;
-
-        let raw_cid = url
-            .query_pairs()
-            .find(|(key, _)| key == "cid")
-            .ok_or(DeepLinkParseError::MissingQueryParameter("cid"))?
-            .1
-            .to_string();
-        let client_id = ClientId::new(&raw_cid)
-            .map_err(|e| DeepLinkParseError::InvalidQueryParameter("cid", Box::new(e)))?;
-
-        let raw_cpk = url
-            .query_pairs()
-            .find(|(key, _)| key == "cpk")
-            .ok_or(DeepLinkParseError::MissingQueryParameter("cpk"))?
-            .1
-            .to_string();
-        let client_pk = PublicKey::try_from_z32(&raw_cpk)
-            .map_err(|e| DeepLinkParseError::InvalidQueryParameter("cpk", Box::new(e)))?;
-
-        Ok(SigninGrantDeepLink {
-            capabilities,
-            relay,
-            secret,
-            client_id,
-            client_pk,
+impl DeepLinkParams for SigninGrantParams {
+    fn parse(url: &Url) -> Result<Self, DeepLinkParseError> {
+        Ok(Self {
+            capabilities: parse_capabilities(url)?,
+            relay: parse_relay(url)?,
+            secret: parse_secret(url)?,
+            client_id: parse_client_id(url)?,
+            client_pk: parse_client_pk(url)?,
         })
     }
-}
 
-impl From<SigninGrantDeepLink> for Url {
-    fn from(val: SigninGrantDeepLink) -> Self {
-        Url::parse(&val.to_string()).expect("Should be able to parse the deep link")
+    fn append_query_pairs(&self, url: &mut Url) {
+        append_signin_params(url, &self.capabilities, &self.relay, &self.secret);
+        append_grant_params(url, &self.client_id, &self.client_pk);
     }
 }
+
+/// A deep link for signing in via the grant flow.
+pub type SigninGrantDeepLink = TypedDeepLink<SigninGrantIntent, SigninGrantParams>;
 
 #[cfg(test)]
 mod tests {
     use pubky_common::crypto::Keypair;
 
     use super::*;
+    use crate::actors::auth::deep_links::DeepLinkScheme;
 
     #[test]
-    fn test_signin_grant_deep_link_parse() {
-        let capabilities = Capabilities::builder()
-            .read_write("/pub/franky.app/")
-            .read("/pub/foo.bar/file")
-            .finish();
-        let relay = Url::parse("https://httprelay.pubky.app/inbox/").unwrap();
-        let secret = [42; 32];
-        let client_id = ClientId::new("franky.pubky.app").unwrap();
-        let client_kp = Keypair::random();
-        let client_pk = client_kp.public_key();
+    fn parses_signin_grant_deep_link() {
+        let client_pk = Keypair::random().public_key();
+        let deep_link: SigninGrantDeepLink = format!(
+            "pubkyauth://signin_grant?caps=/pub/pubky.app/:rw&relay=https://httprelay.pubky.app/inbox/&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&cid=franky.pubky.app&cpk={}",
+            client_pk.z32()
+        )
+        .parse()
+        .unwrap();
 
-        let deep_link = SigninGrantDeepLink::new(
-            capabilities.clone(),
-            relay.clone(),
-            secret,
-            client_id.clone(),
-            client_pk.clone(),
-        );
-        let deep_link_str = deep_link.to_string();
-        assert_eq!(
-            deep_link_str,
-            format!(
-                "pubkyauth://signin?caps={}&relay={}&secret={}&cid={}&cpk={}",
-                capabilities,
-                relay,
-                URL_SAFE_NO_PAD.encode(secret),
-                client_id,
-                client_pk.z32()
-            )
-        );
-        let deep_link_parsed = SigninGrantDeepLink::from_str(&deep_link_str).unwrap();
-        assert_eq!(deep_link_parsed, deep_link);
+        assert_eq!(deep_link.scheme(), DeepLinkScheme::PubkyAuth);
+        assert_eq!(deep_link.intent(), "signin_grant");
+        assert_eq!(deep_link.params().client_id.to_string(), "franky.pubky.app");
+        assert_eq!(deep_link.params().client_pk.z32(), client_pk.z32());
     }
 
     #[test]
-    fn test_signin_grant_deep_link_rejects_missing_cpk() {
-        // A signin URL with cid but no cpk must not parse as a grant deep link.
-        let url = "pubkyauth://signin?caps=/:rw&relay=https://httprelay.pubky.app/inbox/&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&cid=franky.pubky.app";
-        let err = SigninGrantDeepLink::from_str(url).unwrap_err();
+    fn creates_signin_grant_deep_link_from_params() {
+        let capabilities = Capabilities::builder().read_write("/").finish();
+        let relay = Url::parse("https://httprelay.pubky.app/inbox/").unwrap();
+        let client_id = ClientId::new("franky.pubky.app").unwrap();
+        let client_pk = Keypair::random().public_key();
+        let deep_link = SigninGrantDeepLink::new(
+            DeepLinkScheme::PubkyAuth,
+            SigninGrantParams {
+                capabilities,
+                relay,
+                secret: [42; 32],
+                client_id,
+                client_pk,
+            },
+        );
+        let parsed_again = SigninGrantDeepLink::parse_url(&deep_link.to_url()).unwrap();
+
+        assert_eq!(parsed_again, deep_link);
+    }
+
+    #[test]
+    fn rejects_missing_cpk() {
+        let url = "pubkyauth://signin_grant?caps=/:rw&relay=https://httprelay.pubky.app/inbox/&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&cid=franky.pubky.app";
+        let err = url.parse::<SigninGrantDeepLink>().unwrap_err();
+
         assert!(matches!(
             err,
             DeepLinkParseError::MissingQueryParameter("cpk")
@@ -224,14 +109,14 @@ mod tests {
     }
 
     #[test]
-    fn test_signin_grant_deep_link_rejects_missing_cid() {
-        // A signin URL with cpk but no cid must not parse as a grant deep link.
-        let kp = Keypair::random();
+    fn rejects_missing_cid() {
+        let pk = Keypair::random().public_key();
         let url = format!(
-            "pubkyauth://signin?caps=/:rw&relay=https://httprelay.pubky.app/inbox/&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&cpk={}",
-            kp.public_key().z32()
+            "pubkyauth://signin_grant?caps=/:rw&relay=https://httprelay.pubky.app/inbox/&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&cpk={}",
+            pk.z32()
         );
-        let err = SigninGrantDeepLink::from_str(&url).unwrap_err();
+        let err = url.parse::<SigninGrantDeepLink>().unwrap_err();
+
         assert!(matches!(
             err,
             DeepLinkParseError::MissingQueryParameter("cid")

--- a/pubky-sdk/src/actors/auth/deep_links/signup.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/signup.rs
@@ -94,6 +94,17 @@ mod tests {
     }
 
     #[test]
+    fn parses_signup_deep_link_with_extra_query_params() {
+        let deep_link: SignupDeepLink = format!(
+            "pubkyauth://signup?caps=/pub/pubky.app/:rw&relay=https://httprelay.pubky.app/inbox/&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&hs={HOMESERVER}&cid=franky.pubky.app&cpk=not-a-public-key"
+        )
+        .parse()
+        .unwrap();
+
+        assert_eq!(deep_link.intent(), "signup");
+    }
+
+    #[test]
     fn creates_signup_deep_link_from_params() {
         let capabilities = Capabilities::builder().read_write("/").finish();
         let relay = Url::parse("https://httprelay.pubky.app/inbox/").unwrap();

--- a/pubky-sdk/src/actors/auth/deep_links/signup.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/signup.rs
@@ -1,239 +1,127 @@
-use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
-use pubky_common::capabilities::Capabilities;
-use std::{fmt::Display, str::FromStr};
+use pubky_common::{capabilities::Capabilities, crypto::PublicKey};
 use url::Url;
 
-use crate::PublicKey;
-use crate::actors::auth::deep_links::{DEEP_LINK_SCHEMES, error::DeepLinkParseError};
+use super::{
+    DeepLinkParseError,
+    query_params::{
+        append_signup_params, optional_query, parse_capabilities, parse_homeserver, parse_relay,
+        parse_secret,
+    },
+    typed_deep_link::{DeepLinkIntent, DeepLinkParams, TypedDeepLink},
+};
 
-/// A deep link for signing up to a Pubky homeserver via the legacy
-/// [`AuthToken`](pubky_common::auth::AuthToken) flow (cookie-based session).
-///
-/// Format: `pubkyauth://signup?caps=…&relay=…&secret=…&hs=…&st=…`.
-///
-/// For the grant flow, use [`SignupGrantDeepLink`](super::SignupGrantDeepLink)
-/// instead.
+/// Intent marker for legacy signup deep links.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SignupIntent;
+
+impl DeepLinkIntent for SignupIntent {
+    const NAME: &'static str = "signup";
+}
+
+/// Typed parameters for legacy signup deep links.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SignupDeepLink {
-    capabilities: Capabilities,
-    relay: Url,
-    secret: [u8; 32],
-    homeserver: PublicKey,
-    signup_token: Option<String>,
+pub struct SignupParams {
+    /// Capabilities requested by the app.
+    pub capabilities: Capabilities,
+    /// Base HTTP relay URL.
+    pub relay: Url,
+    /// Secret used to derive the encrypted relay channel.
+    pub secret: [u8; 32],
+    /// Homeserver public key.
+    pub homeserver: PublicKey,
+    /// Optional signup token.
+    pub signup_token: Option<String>,
 }
 
-impl SignupDeepLink {
-    /// Create a new signup deep link.
-    #[must_use]
-    pub fn new(
-        capabilities: Capabilities,
-        relay: Url,
-        secret: [u8; 32],
-        homeserver: PublicKey,
-        signup_token: Option<String>,
-    ) -> Self {
-        Self {
-            capabilities,
-            relay,
-            secret,
-            homeserver,
-            signup_token,
-        }
-    }
-
-    /// Get the capabilities for the signup flow.
-    pub fn capabilities(&self) -> &Capabilities {
-        &self.capabilities
-    }
-
-    /// Get the relay for the signup flow.
-    #[must_use]
-    pub fn relay(&self) -> &Url {
-        &self.relay
-    }
-
-    /// Get the secret for the signup flow.
-    #[must_use]
-    pub fn secret(&self) -> &[u8; 32] {
-        &self.secret
-    }
-
-    /// Get the homeserver for the signup flow.
-    #[must_use]
-    pub fn homeserver(&self) -> &PublicKey {
-        &self.homeserver
-    }
-
-    /// Get the signup token for the signup flow.
-    #[must_use]
-    pub fn signup_token(&self) -> Option<String> {
-        self.signup_token.clone()
-    }
-}
-
-impl Display for SignupDeepLink {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let url = format!(
-            "pubkyauth://signup?caps={}&relay={}&secret={}&hs={}",
-            self.capabilities,
-            self.relay,
-            URL_SAFE_NO_PAD.encode(self.secret),
-            self.homeserver.z32()
-        );
-        write!(f, "{url}")?;
-        if let Some(signup_token) = self.signup_token.as_ref() {
-            write!(f, "&st={signup_token}")?;
-        }
-        Ok(())
-    }
-}
-
-impl FromStr for SignupDeepLink {
-    type Err = DeepLinkParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let url = Url::parse(s)?;
-        if !DEEP_LINK_SCHEMES.contains(&url.scheme()) {
-            return Err(DeepLinkParseError::InvalidSchema("pubkyauth or pubkyring"));
-        }
-        let intent = url.host_str().unwrap_or("").to_string();
-        if intent != "signup" {
-            return Err(DeepLinkParseError::InvalidIntent("signup"));
-        }
-        let raw_caps = url
-            .query_pairs()
-            .find(|(key, _)| key == "caps")
-            .ok_or(DeepLinkParseError::MissingQueryParameter("caps"))?
-            .1
-            .to_string();
-        let capabilities: Capabilities = raw_caps
-            .as_str()
-            .try_into()
-            .map_err(|e| DeepLinkParseError::InvalidQueryParameter("caps", Box::new(e)))?;
-
-        let raw_relay = url
-            .query_pairs()
-            .find(|(key, _)| key == "relay")
-            .ok_or(DeepLinkParseError::MissingQueryParameter("relay"))?
-            .1
-            .to_string();
-        let relay = Url::parse(&raw_relay)
-            .map_err(|e| DeepLinkParseError::InvalidQueryParameter("relay", Box::new(e)))?;
-
-        let raw_secret = url
-            .query_pairs()
-            .find(|(key, _)| key == "secret")
-            .ok_or(DeepLinkParseError::MissingQueryParameter("secret"))?
-            .1
-            .to_string();
-        let secret = URL_SAFE_NO_PAD
-            .decode(raw_secret.as_str())
-            .map_err(|e| DeepLinkParseError::InvalidQueryParameter("secret", Box::new(e)))?;
-        let secret: [u8; 32] = secret.try_into().map_err(|e: Vec<u8>| {
-            let msg = format!("Expected 32 bytes, got {}", e.len());
-            DeepLinkParseError::InvalidQueryParameter(
-                "secret",
-                Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, msg)),
-            )
-        })?;
-
-        let raw_homeserver = url
-            .query_pairs()
-            .find(|(key, _)| key == "hs")
-            .ok_or(DeepLinkParseError::MissingQueryParameter("hs"))?
-            .1
-            .to_string();
-        let homeserver = PublicKey::try_from_z32(raw_homeserver.as_str())
-            .map_err(|e| DeepLinkParseError::InvalidQueryParameter("hs", Box::new(e)))?;
-
-        let signup_token = url
-            .query_pairs()
-            .find(|(key, _)| key == "st")
-            .map(|(_, value)| value.to_string());
-
-        Ok(SignupDeepLink {
-            capabilities,
-            relay,
-            secret,
-            homeserver,
-            signup_token,
+impl DeepLinkParams for SignupParams {
+    fn parse(url: &Url) -> Result<Self, DeepLinkParseError> {
+        Ok(Self {
+            capabilities: parse_capabilities(url)?,
+            relay: parse_relay(url)?,
+            secret: parse_secret(url)?,
+            homeserver: parse_homeserver(url)?,
+            signup_token: optional_query(url, "st"),
         })
     }
-}
 
-impl From<SignupDeepLink> for Url {
-    fn from(val: SignupDeepLink) -> Self {
-        Url::parse(&val.to_string()).expect("Should be able to parse the deep link")
+    fn append_query_pairs(&self, url: &mut Url) {
+        append_signup_params(
+            url,
+            &self.capabilities,
+            &self.relay,
+            &self.secret,
+            &self.homeserver,
+            self.signup_token.as_deref(),
+        );
     }
 }
+
+/// A deep link for signing up to a Pubky homeserver via the legacy cookie flow.
+pub type SignupDeepLink = TypedDeepLink<SignupIntent, SignupParams>;
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use super::*;
+    use crate::actors::auth::deep_links::DeepLinkScheme;
+
+    const HOMESERVER: &str = "5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo";
 
     #[test]
-    fn test_signup_deep_link_parse_no_signup_token() {
-        let capabilities = Capabilities::builder()
-            .read_write("/")
-            .read("/test")
-            .finish();
-        let relay = Url::parse("https://httprelay.pubky.app/inbox/").unwrap();
-        let secret = [123; 32];
-        let homeserver =
-            PublicKey::from_str("5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo").unwrap();
-        let deep_link = SignupDeepLink::new(
-            capabilities.clone(),
-            relay.clone(),
-            secret,
-            homeserver.clone(),
-            None,
-        );
-        let deep_link_str = deep_link.to_string();
-        assert_eq!(
-            deep_link_str,
-            format!(
-                "pubkyauth://signup?caps={}&relay={}&secret={}&hs={}",
-                capabilities,
-                relay,
-                URL_SAFE_NO_PAD.encode(secret),
-                homeserver.z32()
-            )
-        );
-        let deep_link_parsed = SignupDeepLink::from_str(&deep_link_str).unwrap();
-        assert_eq!(deep_link_parsed, deep_link);
+    fn parses_signup_deep_link_without_signup_token() {
+        let deep_link: SignupDeepLink = format!(
+            "pubkyauth://signup?caps=/pub/pubky.app/:rw&relay=https://httprelay.pubky.app/inbox/&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&hs={HOMESERVER}"
+        )
+        .parse()
+        .unwrap();
+
+        assert_eq!(deep_link.scheme(), DeepLinkScheme::PubkyAuth);
+        assert_eq!(deep_link.intent(), "signup");
+        assert_eq!(deep_link.params().homeserver.z32(), HOMESERVER);
+        assert_eq!(deep_link.params().signup_token, None);
     }
 
     #[test]
-    fn test_signup_deep_link_parse_with_signup_token() {
-        let capabilities = Capabilities::builder()
-            .read_write("/")
-            .read("/test")
-            .finish();
+    fn parses_signup_deep_link_with_signup_token() {
+        let deep_link: SignupDeepLink = format!(
+            "pubkyauth://signup?caps=/pub/pubky.app/:rw&relay=https://httprelay.pubky.app/inbox/&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&hs={HOMESERVER}&st=1234567890"
+        )
+        .parse()
+        .unwrap();
+
+        assert_eq!(deep_link.params().signup_token, Some("1234567890".into()));
+    }
+
+    #[test]
+    fn creates_signup_deep_link_from_params() {
+        let capabilities = Capabilities::builder().read_write("/").finish();
         let relay = Url::parse("https://httprelay.pubky.app/inbox/").unwrap();
-        let secret = [123; 32];
-        let homeserver =
-            PublicKey::from_str("5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo").unwrap();
-        let signup_token = "1234567890";
+        let homeserver = PublicKey::from_str(HOMESERVER).unwrap();
         let deep_link = SignupDeepLink::new(
-            capabilities.clone(),
-            relay.clone(),
-            secret,
-            homeserver.clone(),
-            Some(signup_token.to_string()),
-        );
-        let deep_link_str = deep_link.to_string();
-        assert_eq!(
-            deep_link_str,
-            format!(
-                "pubkyauth://signup?caps={}&relay={}&secret={}&hs={}&st={}",
+            DeepLinkScheme::PubkyAuth,
+            SignupParams {
                 capabilities,
                 relay,
-                URL_SAFE_NO_PAD.encode(secret),
-                homeserver.z32(),
-                signup_token
-            )
+                secret: [123; 32],
+                homeserver,
+                signup_token: Some("1234567890".into()),
+            },
         );
-        let deep_link_parsed = SignupDeepLink::from_str(&deep_link_str).unwrap();
-        assert_eq!(deep_link_parsed, deep_link);
+        let parsed_again = SignupDeepLink::parse_url(&deep_link.to_url()).unwrap();
+
+        assert_eq!(parsed_again, deep_link);
+    }
+
+    #[test]
+    fn rejects_missing_homeserver() {
+        let error = "pubkyauth://signup?caps=/:rw&relay=https://httprelay.pubky.app/inbox/&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8"
+            .parse::<SignupDeepLink>()
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            DeepLinkParseError::MissingQueryParameter("hs")
+        ));
     }
 }

--- a/pubky-sdk/src/actors/auth/deep_links/signup_grant.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/signup_grant.rs
@@ -1,300 +1,147 @@
-use std::{fmt::Display, str::FromStr};
-
-use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
 use pubky_common::{auth::jws::ClientId, capabilities::Capabilities, crypto::PublicKey};
 use url::Url;
 
-use crate::actors::auth::deep_links::{DEEP_LINK_SCHEMES, error::DeepLinkParseError};
+use super::{
+    DeepLinkParseError,
+    query_params::{
+        append_grant_params, append_signup_params, optional_query, parse_capabilities,
+        parse_client_id, parse_client_pk, parse_homeserver, parse_relay, parse_secret,
+    },
+    typed_deep_link::{DeepLinkIntent, DeepLinkParams, TypedDeepLink},
+};
 
-/// A deep link for signing up to a Pubky homeserver via the **grant**
-/// (Proof-of-Possession) flow.
-///
-/// Format:
-/// `pubkyauth://signup?caps=…&relay=…&secret=…&hs=…&st=…&cid=…&cpk=…`
-///
-/// `cid` is the application identifier and `cpk` is the client public key
-/// bound by the grant's `cnf` claim. Both are required — for the legacy
-/// cookie flow without grant binding, use [`SignupDeepLink`](super::SignupDeepLink).
+/// Intent marker for grant-mode signup deep links.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SignupGrantIntent;
+
+impl DeepLinkIntent for SignupGrantIntent {
+    const NAME: &'static str = "signup_grant";
+}
+
+/// Typed parameters for grant-mode signup deep links.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SignupGrantDeepLink {
-    capabilities: Capabilities,
-    relay: Url,
-    secret: [u8; 32],
-    homeserver: PublicKey,
-    signup_token: Option<String>,
-    client_id: ClientId,
-    client_pk: PublicKey,
-}
-
-impl SignupGrantDeepLink {
-    /// Create a new grant-mode signup deep link.
-    #[must_use]
-    #[allow(
-        clippy::too_many_arguments,
-        reason = "All fields are part of the wire format and equally required to construct a deep link"
-    )]
-    pub fn new(
-        capabilities: Capabilities,
-        relay: Url,
-        secret: [u8; 32],
-        homeserver: PublicKey,
-        signup_token: Option<String>,
-        client_id: ClientId,
-        client_pk: PublicKey,
-    ) -> Self {
-        Self {
-            capabilities,
-            relay,
-            secret,
-            homeserver,
-            signup_token,
-            client_id,
-            client_pk,
-        }
-    }
-
-    /// Get the capabilities for the signup flow.
-    pub fn capabilities(&self) -> &Capabilities {
-        &self.capabilities
-    }
-
-    /// Get the relay for the signup flow.
-    #[must_use]
-    pub fn relay(&self) -> &Url {
-        &self.relay
-    }
-
-    /// Get the secret for the signup flow.
-    #[must_use]
-    pub fn secret(&self) -> &[u8; 32] {
-        &self.secret
-    }
-
-    /// Get the homeserver for the signup flow.
-    #[must_use]
-    pub fn homeserver(&self) -> &PublicKey {
-        &self.homeserver
-    }
-
-    /// Get the signup token for the signup flow.
-    #[must_use]
-    pub fn signup_token(&self) -> Option<String> {
-        self.signup_token.clone()
-    }
-
+pub struct SignupGrantParams {
+    /// Capabilities requested by the app.
+    pub capabilities: Capabilities,
+    /// Base HTTP relay URL.
+    pub relay: Url,
+    /// Secret used to derive the encrypted relay channel.
+    pub secret: [u8; 32],
+    /// Homeserver public key.
+    pub homeserver: PublicKey,
+    /// Optional signup token.
+    pub signup_token: Option<String>,
     /// Application identifier carried by this deep link.
-    #[must_use]
-    pub fn client_id(&self) -> &ClientId {
-        &self.client_id
-    }
-
-    /// Client public key (`cnf` for the grant) carried by this deep link.
-    #[must_use]
-    pub fn client_pk(&self) -> &PublicKey {
-        &self.client_pk
-    }
+    pub client_id: ClientId,
+    /// Client public key bound by the grant's `cnf` claim.
+    pub client_pk: PublicKey,
 }
 
-impl Display for SignupGrantDeepLink {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "pubkyauth://signup?caps={}&relay={}&secret={}&hs={}",
-            self.capabilities,
-            self.relay,
-            URL_SAFE_NO_PAD.encode(self.secret),
-            self.homeserver.z32()
-        )?;
-        if let Some(signup_token) = self.signup_token.as_ref() {
-            write!(f, "&st={signup_token}")?;
-        }
-        write!(f, "&cid={}&cpk={}", self.client_id, self.client_pk.z32())
-    }
-}
-
-impl FromStr for SignupGrantDeepLink {
-    type Err = DeepLinkParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let url = Url::parse(s)?;
-        if !DEEP_LINK_SCHEMES.contains(&url.scheme()) {
-            return Err(DeepLinkParseError::InvalidSchema("pubkyauth or pubkyring"));
-        }
-        let intent = url.host_str().unwrap_or("").to_string();
-        if intent != "signup" {
-            return Err(DeepLinkParseError::InvalidIntent("signup"));
-        }
-
-        let raw_caps = url
-            .query_pairs()
-            .find(|(key, _)| key == "caps")
-            .ok_or(DeepLinkParseError::MissingQueryParameter("caps"))?
-            .1
-            .to_string();
-        let capabilities: Capabilities = raw_caps
-            .as_str()
-            .try_into()
-            .map_err(|e| DeepLinkParseError::InvalidQueryParameter("caps", Box::new(e)))?;
-
-        let raw_relay = url
-            .query_pairs()
-            .find(|(key, _)| key == "relay")
-            .ok_or(DeepLinkParseError::MissingQueryParameter("relay"))?
-            .1
-            .to_string();
-        let relay = Url::parse(&raw_relay)
-            .map_err(|e| DeepLinkParseError::InvalidQueryParameter("relay", Box::new(e)))?;
-
-        let raw_secret = url
-            .query_pairs()
-            .find(|(key, _)| key == "secret")
-            .ok_or(DeepLinkParseError::MissingQueryParameter("secret"))?
-            .1
-            .to_string();
-        let secret = URL_SAFE_NO_PAD
-            .decode(raw_secret.as_str())
-            .map_err(|e| DeepLinkParseError::InvalidQueryParameter("secret", Box::new(e)))?;
-        let secret: [u8; 32] = secret.try_into().map_err(|e: Vec<u8>| {
-            let msg = format!("Expected 32 bytes, got {}", e.len());
-            DeepLinkParseError::InvalidQueryParameter(
-                "secret",
-                Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, msg)),
-            )
-        })?;
-
-        let raw_homeserver = url
-            .query_pairs()
-            .find(|(key, _)| key == "hs")
-            .ok_or(DeepLinkParseError::MissingQueryParameter("hs"))?
-            .1
-            .to_string();
-        let homeserver = PublicKey::try_from_z32(raw_homeserver.as_str())
-            .map_err(|e| DeepLinkParseError::InvalidQueryParameter("hs", Box::new(e)))?;
-
-        let signup_token = url
-            .query_pairs()
-            .find(|(key, _)| key == "st")
-            .map(|(_, value)| value.to_string());
-
-        let raw_cid = url
-            .query_pairs()
-            .find(|(key, _)| key == "cid")
-            .ok_or(DeepLinkParseError::MissingQueryParameter("cid"))?
-            .1
-            .to_string();
-        let client_id = ClientId::new(&raw_cid)
-            .map_err(|e| DeepLinkParseError::InvalidQueryParameter("cid", Box::new(e)))?;
-
-        let raw_cpk = url
-            .query_pairs()
-            .find(|(key, _)| key == "cpk")
-            .ok_or(DeepLinkParseError::MissingQueryParameter("cpk"))?
-            .1
-            .to_string();
-        let client_pk = PublicKey::try_from_z32(&raw_cpk)
-            .map_err(|e| DeepLinkParseError::InvalidQueryParameter("cpk", Box::new(e)))?;
-
-        Ok(SignupGrantDeepLink {
-            capabilities,
-            relay,
-            secret,
-            homeserver,
-            signup_token,
-            client_id,
-            client_pk,
+impl DeepLinkParams for SignupGrantParams {
+    fn parse(url: &Url) -> Result<Self, DeepLinkParseError> {
+        Ok(Self {
+            capabilities: parse_capabilities(url)?,
+            relay: parse_relay(url)?,
+            secret: parse_secret(url)?,
+            homeserver: parse_homeserver(url)?,
+            signup_token: optional_query(url, "st"),
+            client_id: parse_client_id(url)?,
+            client_pk: parse_client_pk(url)?,
         })
     }
-}
 
-impl From<SignupGrantDeepLink> for Url {
-    fn from(val: SignupGrantDeepLink) -> Self {
-        Url::parse(&val.to_string()).expect("Should be able to parse the deep link")
+    fn append_query_pairs(&self, url: &mut Url) {
+        append_signup_params(
+            url,
+            &self.capabilities,
+            &self.relay,
+            &self.secret,
+            &self.homeserver,
+            self.signup_token.as_deref(),
+        );
+        append_grant_params(url, &self.client_id, &self.client_pk);
     }
 }
+
+/// A deep link for signing up via the grant flow.
+pub type SignupGrantDeepLink = TypedDeepLink<SignupGrantIntent, SignupGrantParams>;
 
 #[cfg(test)]
 mod tests {
+    use std::str::FromStr;
+
     use pubky_common::crypto::Keypair;
 
     use super::*;
+    use crate::actors::auth::deep_links::DeepLinkScheme;
+
+    const HOMESERVER: &str = "5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo";
 
     #[test]
-    fn test_signup_grant_deep_link_parse_no_signup_token() {
-        let capabilities = Capabilities::builder()
-            .read_write("/pub/franky.app/")
-            .finish();
-        let relay = Url::parse("https://httprelay.pubky.app/inbox/").unwrap();
-        let secret = [42; 32];
-        let homeserver =
-            PublicKey::from_str("5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo").unwrap();
-        let client_id = ClientId::new("franky.pubky.app").unwrap();
-        let client_kp = Keypair::random();
-        let client_pk = client_kp.public_key();
+    fn parses_signup_grant_deep_link_without_signup_token() {
+        let client_pk = Keypair::random().public_key();
+        let deep_link: SignupGrantDeepLink = format!(
+            "pubkyauth://signup_grant?caps=/pub/pubky.app/:rw&relay=https://httprelay.pubky.app/inbox/&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&hs={HOMESERVER}&cid=franky.pubky.app&cpk={}",
+            client_pk.z32()
+        )
+        .parse()
+        .unwrap();
 
-        let deep_link = SignupGrantDeepLink::new(
-            capabilities.clone(),
-            relay.clone(),
-            secret,
-            homeserver.clone(),
-            None,
-            client_id.clone(),
-            client_pk.clone(),
-        );
-        let deep_link_str = deep_link.to_string();
-        assert_eq!(
-            deep_link_str,
-            format!(
-                "pubkyauth://signup?caps={}&relay={}&secret={}&hs={}&cid={}&cpk={}",
-                capabilities,
-                relay,
-                URL_SAFE_NO_PAD.encode(secret),
-                homeserver.z32(),
-                client_id,
-                client_pk.z32()
-            )
-        );
-        let deep_link_parsed = SignupGrantDeepLink::from_str(&deep_link_str).unwrap();
-        assert_eq!(deep_link_parsed, deep_link);
+        assert_eq!(deep_link.scheme(), DeepLinkScheme::PubkyAuth);
+        assert_eq!(deep_link.intent(), "signup_grant");
+        assert_eq!(deep_link.params().signup_token, None);
+        assert_eq!(deep_link.params().client_pk.z32(), client_pk.z32());
     }
 
     #[test]
-    fn test_signup_grant_deep_link_parse_with_signup_token() {
-        let capabilities = Capabilities::builder()
-            .read_write("/pub/franky.app/")
-            .finish();
-        let relay = Url::parse("https://httprelay.pubky.app/inbox/").unwrap();
-        let secret = [42; 32];
-        let homeserver =
-            PublicKey::from_str("5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo").unwrap();
-        let signup_token = "1234567890";
-        let client_id = ClientId::new("franky.pubky.app").unwrap();
-        let client_kp = Keypair::random();
-        let client_pk = client_kp.public_key();
+    fn parses_signup_grant_deep_link_with_signup_token() {
+        let client_pk = Keypair::random().public_key();
+        let deep_link: SignupGrantDeepLink = format!(
+            "pubkyauth://signup_grant?caps=/pub/pubky.app/:rw&relay=https://httprelay.pubky.app/inbox/&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&hs={HOMESERVER}&st=123&cid=franky.pubky.app&cpk={}",
+            client_pk.z32()
+        )
+        .parse()
+        .unwrap();
 
+        assert_eq!(deep_link.params().signup_token, Some("123".into()));
+    }
+
+    #[test]
+    fn creates_signup_grant_deep_link_from_params() {
+        let capabilities = Capabilities::builder().read_write("/").finish();
+        let relay = Url::parse("https://httprelay.pubky.app/inbox/").unwrap();
+        let homeserver = PublicKey::from_str(HOMESERVER).unwrap();
+        let client_id = ClientId::new("franky.pubky.app").unwrap();
+        let client_pk = Keypair::random().public_key();
         let deep_link = SignupGrantDeepLink::new(
-            capabilities.clone(),
-            relay.clone(),
-            secret,
-            homeserver.clone(),
-            Some(signup_token.to_string()),
-            client_id.clone(),
-            client_pk.clone(),
-        );
-        let deep_link_str = deep_link.to_string();
-        assert_eq!(
-            deep_link_str,
-            format!(
-                "pubkyauth://signup?caps={}&relay={}&secret={}&hs={}&st={}&cid={}&cpk={}",
+            DeepLinkScheme::PubkyAuth,
+            SignupGrantParams {
                 capabilities,
                 relay,
-                URL_SAFE_NO_PAD.encode(secret),
-                homeserver.z32(),
-                signup_token,
+                secret: [42; 32],
+                homeserver,
+                signup_token: Some("123".into()),
                 client_id,
-                client_pk.z32()
-            )
+                client_pk,
+            },
         );
-        let deep_link_parsed = SignupGrantDeepLink::from_str(&deep_link_str).unwrap();
-        assert_eq!(deep_link_parsed, deep_link);
+        let parsed_again = SignupGrantDeepLink::parse_url(&deep_link.to_url()).unwrap();
+
+        assert_eq!(parsed_again, deep_link);
+    }
+
+    #[test]
+    fn rejects_missing_cid() {
+        let pk = Keypair::random().public_key();
+        let url = format!(
+            "pubkyauth://signup_grant?caps=/:rw&relay=https://httprelay.pubky.app/inbox/&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&hs={HOMESERVER}&cpk={}",
+            pk.z32()
+        );
+        let err = url.parse::<SignupGrantDeepLink>().unwrap_err();
+
+        assert!(matches!(
+            err,
+            DeepLinkParseError::MissingQueryParameter("cid")
+        ));
     }
 }

--- a/pubky-sdk/src/actors/auth/deep_links/typed_deep_link.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/typed_deep_link.rs
@@ -15,18 +15,24 @@ use url::Url;
 
 use super::{DeepLinkParseError, schemes::DeepLinkScheme};
 
-pub(super) trait DeepLinkIntent {
+/// Intent marker for typed Pubky deep links.
+pub trait DeepLinkIntent {
+    /// URI host value used as the deep-link intent.
     const NAME: &'static str;
 }
 
-pub(super) trait DeepLinkParams: Sized {
+/// Typed parameter set for a Pubky deep-link intent.
+pub trait DeepLinkParams: Sized {
+    /// Parse this parameter set from a URL.
     fn parse(url: &Url) -> Result<Self, DeepLinkParseError>;
 
+    /// Append this parameter set as URL query pairs.
     fn append_query_pairs(&self, url: &mut Url);
 }
 
+/// A typed Pubky deep link with a statically selected intent and parameter set.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct TypedDeepLink<I, P> {
+pub struct TypedDeepLink<I, P> {
     scheme: DeepLinkScheme,
     params: P,
     _intent: PhantomData<I>,
@@ -34,7 +40,7 @@ pub(super) struct TypedDeepLink<I, P> {
 
 impl<I, P> TypedDeepLink<I, P> {
     /// Create a typed deep link from a scheme and typed params.
-    pub(super) fn new(scheme: DeepLinkScheme, params: P) -> Self {
+    pub fn new(scheme: DeepLinkScheme, params: P) -> Self {
         Self {
             scheme,
             params,
@@ -49,7 +55,7 @@ where
     P: DeepLinkParams,
 {
     /// Parse a typed deep link from a URL.
-    pub(super) fn parse_url(url: &Url) -> Result<Self, DeepLinkParseError> {
+    pub fn parse_url(url: &Url) -> Result<Self, DeepLinkParseError> {
         let scheme = url.scheme().parse()?;
         if url.host_str().unwrap_or("") != I::NAME {
             return Err(DeepLinkParseError::InvalidIntent(I::NAME));
@@ -63,22 +69,22 @@ where
     }
 
     /// Return the validated deep-link scheme.
-    pub(super) fn scheme(&self) -> DeepLinkScheme {
+    pub fn scheme(&self) -> DeepLinkScheme {
         self.scheme
     }
 
     /// Return the statically selected deep-link intent.
-    pub(super) fn intent(&self) -> &'static str {
+    pub fn intent(&self) -> &'static str {
         I::NAME
     }
 
     /// Return the typed parameter set for this deep link.
-    pub(super) fn params(&self) -> &P {
+    pub fn params(&self) -> &P {
         &self.params
     }
 
     /// Convert this typed deep link into a URL.
-    pub(super) fn to_url(&self) -> Url {
+    pub fn to_url(&self) -> Url {
         let mut url = Url::parse(&format!("{}://{}", self.scheme.as_str(), I::NAME))
             .expect("invariant: deep-link scheme and intent form a valid URL");
         self.params.append_query_pairs(&mut url);
@@ -132,18 +138,10 @@ impl DeepLinkIntent for SignupIntent {
     const NAME: &'static str = "signup";
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) struct SecretExportIntent;
-
-impl DeepLinkIntent for SecretExportIntent {
-    const NAME: &'static str = "secret_export";
-}
-
 pub(super) type TypedSigninDeepLink = TypedDeepLink<SigninIntent, SigninParams>;
 pub(super) type TypedSignupDeepLink = TypedDeepLink<SignupIntent, SignupParams>;
 pub(super) type TypedSigninGrantDeepLink = TypedDeepLink<SigninIntent, SigninGrantParams>;
 pub(super) type TypedSignupGrantDeepLink = TypedDeepLink<SignupIntent, SignupGrantParams>;
-pub(super) type TypedSeedExportDeepLink = TypedDeepLink<SecretExportIntent, SeedExportParams>;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(super) struct SigninParams {
@@ -261,24 +259,6 @@ impl DeepLinkParams for SignupGrantParams {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct SeedExportParams {
-    pub(super) secret: [u8; 32],
-}
-
-impl DeepLinkParams for SeedExportParams {
-    fn parse(url: &Url) -> Result<Self, DeepLinkParseError> {
-        Ok(Self {
-            secret: parse_secret(url)?,
-        })
-    }
-
-    fn append_query_pairs(&self, url: &mut Url) {
-        url.query_pairs_mut()
-            .append_pair("secret", &URL_SAFE_NO_PAD.encode(self.secret));
-    }
-}
-
 fn append_signin_params(
     url: &mut Url,
     capabilities: &Capabilities,
@@ -325,7 +305,7 @@ fn parse_relay(url: &Url) -> Result<Url, DeepLinkParseError> {
         .map_err(|e| DeepLinkParseError::InvalidQueryParameter("relay", Box::new(e)))
 }
 
-fn parse_secret(url: &Url) -> Result<[u8; 32], DeepLinkParseError> {
+pub(super) fn parse_secret(url: &Url) -> Result<[u8; 32], DeepLinkParseError> {
     let raw_secret = required_query(url, "secret")?;
     let secret = URL_SAFE_NO_PAD
         .decode(raw_secret.as_str())
@@ -439,18 +419,6 @@ mod tests {
     }
 
     #[test]
-    fn parses_seed_export_deep_link() {
-        let deep_link: TypedSeedExportDeepLink =
-            format!("pubkyring://secret_export?secret={SECRET}")
-                .parse()
-                .unwrap();
-
-        assert_eq!(deep_link.scheme(), DeepLinkScheme::PubkyRing);
-        assert_eq!(deep_link.intent(), "secret_export");
-        assert_eq!(deep_link.params().secret, SECRET_BYTES);
-    }
-
-    #[test]
     fn parses_from_url() {
         let url = Url::parse(&format!(
             "pubkyauth://signin?caps=/:rw&relay=https://relay.test/inbox&secret={SECRET}"
@@ -487,62 +455,6 @@ mod tests {
         let parsed_again = TypedSignupGrantDeepLink::parse_url(&url).unwrap();
 
         assert_eq!(parsed_again, deep_link);
-    }
-
-    #[test]
-    fn converts_seed_export_deep_link_to_url() {
-        let deep_link: TypedSeedExportDeepLink =
-            format!("pubkyring://secret_export?secret={SECRET}")
-                .parse()
-                .unwrap();
-        let url = deep_link.to_url();
-
-        assert_eq!(url.scheme(), "pubkyring");
-        assert_eq!(url.host_str(), Some("secret_export"));
-        assert_eq!(TypedSeedExportDeepLink::parse_url(&url).unwrap(), deep_link);
-    }
-
-    #[test]
-    fn creates_seed_export_deep_link_from_params() {
-        let deep_link = TypedSeedExportDeepLink::new(
-            DeepLinkScheme::PubkyAuth,
-            SeedExportParams {
-                secret: SECRET_BYTES,
-            },
-        );
-        let url = deep_link.to_url();
-        let parsed_again = TypedSeedExportDeepLink::parse_url(&url).unwrap();
-
-        assert_eq!(deep_link.scheme(), DeepLinkScheme::PubkyAuth);
-        assert_eq!(deep_link.intent(), "secret_export");
-        assert_eq!(deep_link.params().secret, SECRET_BYTES);
-        assert_eq!(parsed_again, deep_link);
-    }
-
-    #[test]
-    fn display_formats_as_url() {
-        let deep_link: TypedSeedExportDeepLink =
-            format!("pubkyauth://secret_export?secret={SECRET}")
-                .parse()
-                .unwrap();
-
-        assert_eq!(deep_link.to_string(), deep_link.to_url().to_string());
-    }
-
-    #[test]
-    fn converts_owned_typed_deep_link_into_url() {
-        let deep_link: TypedSeedExportDeepLink =
-            format!("pubkyauth://secret_export?secret={SECRET}")
-                .parse()
-                .unwrap();
-        let url: Url = deep_link.into();
-
-        assert_eq!(url.scheme(), "pubkyauth");
-        assert_eq!(url.host_str(), Some("secret_export"));
-        url.query_pairs()
-            .find(|(key, _)| key == "secret")
-            .map(|(_, value)| assert_eq!(value, SECRET))
-            .expect("Expected 'secret' query parameter");
     }
 
     #[test]

--- a/pubky-sdk/src/actors/auth/deep_links/typed_deep_link.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/typed_deep_link.rs
@@ -1,16 +1,9 @@
-#![allow(
-    dead_code,
-    reason = "Typed deep link parser is experimental until the deep link refactor chooses a direction"
-)]
-
 use std::{
     fmt::{self, Display},
     marker::PhantomData,
     str::FromStr,
 };
 
-use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
-use pubky_common::{auth::jws::ClientId, capabilities::Capabilities, crypto::PublicKey};
 use url::Url;
 
 use super::{DeepLinkParseError, schemes::DeepLinkScheme};
@@ -24,6 +17,10 @@ pub trait DeepLinkIntent {
 /// Typed parameter set for a Pubky deep-link intent.
 pub trait DeepLinkParams: Sized {
     /// Parse this parameter set from a URL.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DeepLinkParseError`] when required parameters are missing or malformed.
     fn parse(url: &Url) -> Result<Self, DeepLinkParseError>;
 
     /// Append this parameter set as URL query pairs.
@@ -55,6 +52,10 @@ where
     P: DeepLinkParams,
 {
     /// Parse a typed deep link from a URL.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DeepLinkParseError`] when the URL scheme, intent, or parameters are invalid.
     pub fn parse_url(url: &Url) -> Result<Self, DeepLinkParseError> {
         let scheme = url.scheme().parse()?;
         if url.host_str().unwrap_or("") != I::NAME {
@@ -84,6 +85,10 @@ where
     }
 
     /// Convert this typed deep link into a URL.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the validated deep-link scheme and static intent cannot form a valid URL.
     pub fn to_url(&self) -> Url {
         let mut url = Url::parse(&format!("{}://{}", self.scheme.as_str(), I::NAME))
             .expect("invariant: deep-link scheme and intent form a valid URL");
@@ -124,371 +129,117 @@ where
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) struct SigninIntent;
-
-impl DeepLinkIntent for SigninIntent {
-    const NAME: &'static str = "signin";
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(super) struct SignupIntent;
-
-impl DeepLinkIntent for SignupIntent {
-    const NAME: &'static str = "signup";
-}
-
-pub(super) type TypedSigninDeepLink = TypedDeepLink<SigninIntent, SigninParams>;
-pub(super) type TypedSignupDeepLink = TypedDeepLink<SignupIntent, SignupParams>;
-pub(super) type TypedSigninGrantDeepLink = TypedDeepLink<SigninIntent, SigninGrantParams>;
-pub(super) type TypedSignupGrantDeepLink = TypedDeepLink<SignupIntent, SignupGrantParams>;
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct SigninParams {
-    pub(super) capabilities: Capabilities,
-    pub(super) relay: Url,
-    pub(super) secret: [u8; 32],
-}
-
-impl DeepLinkParams for SigninParams {
-    fn parse(url: &Url) -> Result<Self, DeepLinkParseError> {
-        Ok(Self {
-            capabilities: parse_capabilities(url)?,
-            relay: parse_relay(url)?,
-            secret: parse_secret(url)?,
-        })
-    }
-
-    fn append_query_pairs(&self, url: &mut Url) {
-        append_signin_params(url, &self.capabilities, &self.relay, &self.secret);
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct SignupParams {
-    pub(super) capabilities: Capabilities,
-    pub(super) relay: Url,
-    pub(super) secret: [u8; 32],
-    pub(super) homeserver: PublicKey,
-    pub(super) signup_token: Option<String>,
-}
-
-impl DeepLinkParams for SignupParams {
-    fn parse(url: &Url) -> Result<Self, DeepLinkParseError> {
-        Ok(Self {
-            capabilities: parse_capabilities(url)?,
-            relay: parse_relay(url)?,
-            secret: parse_secret(url)?,
-            homeserver: parse_homeserver(url)?,
-            signup_token: optional_query(url, "st"),
-        })
-    }
-
-    fn append_query_pairs(&self, url: &mut Url) {
-        append_signup_params(
-            url,
-            &self.capabilities,
-            &self.relay,
-            &self.secret,
-            &self.homeserver,
-            self.signup_token.as_deref(),
-        );
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct SigninGrantParams {
-    pub(super) capabilities: Capabilities,
-    pub(super) relay: Url,
-    pub(super) secret: [u8; 32],
-    pub(super) client_id: ClientId,
-    pub(super) client_pk: PublicKey,
-}
-
-impl DeepLinkParams for SigninGrantParams {
-    fn parse(url: &Url) -> Result<Self, DeepLinkParseError> {
-        Ok(Self {
-            capabilities: parse_capabilities(url)?,
-            relay: parse_relay(url)?,
-            secret: parse_secret(url)?,
-            client_id: parse_client_id(url)?,
-            client_pk: parse_client_pk(url)?,
-        })
-    }
-
-    fn append_query_pairs(&self, url: &mut Url) {
-        append_signin_params(url, &self.capabilities, &self.relay, &self.secret);
-        append_grant_params(url, &self.client_id, &self.client_pk);
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct SignupGrantParams {
-    pub(super) capabilities: Capabilities,
-    pub(super) relay: Url,
-    pub(super) secret: [u8; 32],
-    pub(super) homeserver: PublicKey,
-    pub(super) signup_token: Option<String>,
-    pub(super) client_id: ClientId,
-    pub(super) client_pk: PublicKey,
-}
-
-impl DeepLinkParams for SignupGrantParams {
-    fn parse(url: &Url) -> Result<Self, DeepLinkParseError> {
-        Ok(Self {
-            capabilities: parse_capabilities(url)?,
-            relay: parse_relay(url)?,
-            secret: parse_secret(url)?,
-            homeserver: parse_homeserver(url)?,
-            signup_token: optional_query(url, "st"),
-            client_id: parse_client_id(url)?,
-            client_pk: parse_client_pk(url)?,
-        })
-    }
-
-    fn append_query_pairs(&self, url: &mut Url) {
-        append_signup_params(
-            url,
-            &self.capabilities,
-            &self.relay,
-            &self.secret,
-            &self.homeserver,
-            self.signup_token.as_deref(),
-        );
-        append_grant_params(url, &self.client_id, &self.client_pk);
-    }
-}
-
-fn append_signin_params(
-    url: &mut Url,
-    capabilities: &Capabilities,
-    relay: &Url,
-    secret: &[u8; 32],
-) {
-    url.query_pairs_mut()
-        .append_pair("caps", &capabilities.to_string())
-        .append_pair("relay", relay.as_str())
-        .append_pair("secret", &URL_SAFE_NO_PAD.encode(secret));
-}
-
-fn append_signup_params(
-    url: &mut Url,
-    capabilities: &Capabilities,
-    relay: &Url,
-    secret: &[u8; 32],
-    homeserver: &PublicKey,
-    signup_token: Option<&str>,
-) {
-    append_signin_params(url, capabilities, relay, secret);
-    let mut query = url.query_pairs_mut();
-    query.append_pair("hs", &homeserver.z32());
-    if let Some(signup_token) = signup_token {
-        query.append_pair("st", signup_token);
-    }
-}
-
-fn append_grant_params(url: &mut Url, client_id: &ClientId, client_pk: &PublicKey) {
-    url.query_pairs_mut()
-        .append_pair("cid", &client_id.to_string())
-        .append_pair("cpk", &client_pk.z32());
-}
-
-fn parse_capabilities(url: &Url) -> Result<Capabilities, DeepLinkParseError> {
-    required_query(url, "caps")?
-        .as_str()
-        .try_into()
-        .map_err(|e| DeepLinkParseError::InvalidQueryParameter("caps", Box::new(e)))
-}
-
-fn parse_relay(url: &Url) -> Result<Url, DeepLinkParseError> {
-    Url::parse(&required_query(url, "relay")?)
-        .map_err(|e| DeepLinkParseError::InvalidQueryParameter("relay", Box::new(e)))
-}
-
-pub(super) fn parse_secret(url: &Url) -> Result<[u8; 32], DeepLinkParseError> {
-    let raw_secret = required_query(url, "secret")?;
-    let secret = URL_SAFE_NO_PAD
-        .decode(raw_secret.as_str())
-        .map_err(|e| DeepLinkParseError::InvalidQueryParameter("secret", Box::new(e)))?;
-
-    secret.try_into().map_err(|e: Vec<u8>| {
-        let msg = format!("Expected 32 bytes, got {}", e.len());
-        DeepLinkParseError::InvalidQueryParameter(
-            "secret",
-            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, msg)),
-        )
-    })
-}
-
-fn parse_homeserver(url: &Url) -> Result<PublicKey, DeepLinkParseError> {
-    PublicKey::try_from_z32(&required_query(url, "hs")?)
-        .map_err(|e| DeepLinkParseError::InvalidQueryParameter("hs", Box::new(e)))
-}
-
-fn parse_client_id(url: &Url) -> Result<ClientId, DeepLinkParseError> {
-    ClientId::new(&required_query(url, "cid")?)
-        .map_err(|e| DeepLinkParseError::InvalidQueryParameter("cid", Box::new(e)))
-}
-
-fn parse_client_pk(url: &Url) -> Result<PublicKey, DeepLinkParseError> {
-    PublicKey::try_from_z32(&required_query(url, "cpk")?)
-        .map_err(|e| DeepLinkParseError::InvalidQueryParameter("cpk", Box::new(e)))
-}
-
-fn required_query(url: &Url, key: &'static str) -> Result<String, DeepLinkParseError> {
-    optional_query(url, key).ok_or(DeepLinkParseError::MissingQueryParameter(key))
-}
-
-fn optional_query(url: &Url, key: &str) -> Option<String> {
-    url.query_pairs()
-        .find(|(param_key, _)| param_key == key)
-        .map(|(_, value)| value.to_string())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use pubky_common::crypto::Keypair;
 
-    const SECRET: &str = "kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8";
-    const SECRET_BYTES: [u8; 32] = [
-        146, 169, 220, 120, 67, 32, 172, 212, 12, 255, 24, 180, 234, 132, 23, 140, 13, 220, 36,
-        117, 255, 69, 9, 176, 212, 22, 58, 36, 77, 91, 177, 239,
-    ];
-    const CLIENT_ID: &str = "franky.pubky.app";
-    const PUBLIC_KEY: &str = "5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo";
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct TestIntent;
+
+    impl DeepLinkIntent for TestIntent {
+        const NAME: &'static str = "test";
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    struct TestParams {
+        value: String,
+    }
+
+    impl DeepLinkParams for TestParams {
+        fn parse(url: &Url) -> Result<Self, DeepLinkParseError> {
+            let value = url
+                .query_pairs()
+                .find(|(key, _)| key == "value")
+                .ok_or(DeepLinkParseError::MissingQueryParameter("value"))?
+                .1
+                .to_string();
+
+            Ok(Self { value })
+        }
+
+        fn append_query_pairs(&self, url: &mut Url) {
+            url.query_pairs_mut().append_pair("value", &self.value);
+        }
+    }
+
+    type TestDeepLink = TypedDeepLink<TestIntent, TestParams>;
 
     #[test]
-    fn parses_signin_deep_link() {
-        let deep_link: TypedSigninDeepLink = format!(
-            "pubkyauth://signin?caps=/pub/pubky.app/:rw&relay=https://relay.test/inbox&secret={SECRET}"
-        )
-        .parse()
-        .unwrap();
+    fn creates_typed_deep_link_from_params() {
+        let deep_link = TestDeepLink::new(
+            DeepLinkScheme::PubkyAuth,
+            TestParams {
+                value: "hello".into(),
+            },
+        );
 
         assert_eq!(deep_link.scheme(), DeepLinkScheme::PubkyAuth);
-        assert_eq!(deep_link.intent(), "signin");
-        assert_eq!(
-            deep_link.params().capabilities.to_string(),
-            "/pub/pubky.app/:rw"
+        assert_eq!(deep_link.intent(), "test");
+        assert_eq!(deep_link.params().value, "hello");
+    }
+
+    #[test]
+    fn parses_typed_deep_link_from_url() {
+        let url = Url::parse("pubkyauth://test?value=hello").unwrap();
+        let deep_link = TestDeepLink::parse_url(&url).unwrap();
+
+        assert_eq!(deep_link.params().value, "hello");
+    }
+
+    #[test]
+    fn parses_typed_deep_link_from_str() {
+        let deep_link: TestDeepLink = "pubkyring://test?value=hello".parse().unwrap();
+
+        assert_eq!(deep_link.scheme(), DeepLinkScheme::PubkyRing);
+        assert_eq!(deep_link.params().value, "hello");
+    }
+
+    #[test]
+    fn converts_typed_deep_link_to_url() {
+        let deep_link = TestDeepLink::new(
+            DeepLinkScheme::PubkyAuth,
+            TestParams {
+                value: "hello world".into(),
+            },
         );
-        assert_eq!(deep_link.params().relay.as_str(), "https://relay.test/inbox");
-        assert_eq!(deep_link.params().secret, SECRET_BYTES);
-    }
-
-    #[test]
-    fn parses_signup_deep_link() {
-        let deep_link: TypedSignupDeepLink = format!(
-            "pubkyauth://signup?caps=/pub/pubky.app/:rw&relay=https://relay.test/inbox&secret={SECRET}&hs={PUBLIC_KEY}&st=123"
-        )
-        .parse()
-        .unwrap();
-
-        assert_eq!(deep_link.params().homeserver.z32(), PUBLIC_KEY);
-        assert_eq!(deep_link.params().signup_token, Some("123".to_string()));
-    }
-
-    #[test]
-    fn parses_signin_grant_deep_link() {
-        let client_pk = Keypair::random().public_key();
-        let deep_link: TypedSigninGrantDeepLink = format!(
-            "pubkyauth://signin?caps=/pub/pubky.app/:rw&relay=https://relay.test/inbox&secret={SECRET}&cid={CLIENT_ID}&cpk={}",
-            client_pk.z32()
-        )
-        .parse()
-        .unwrap();
-
-        assert_eq!(deep_link.params().client_id.to_string(), CLIENT_ID);
-        assert_eq!(deep_link.params().client_pk.z32(), client_pk.z32());
-    }
-
-    #[test]
-    fn parses_signup_grant_deep_link() {
-        let client_pk = Keypair::random().public_key();
-        let deep_link: TypedSignupGrantDeepLink = format!(
-            "pubkyauth://signup?caps=/pub/pubky.app/:rw&relay=https://relay.test/inbox&secret={SECRET}&hs={PUBLIC_KEY}&st=123&cid={CLIENT_ID}&cpk={}",
-            client_pk.z32()
-        )
-        .parse()
-        .unwrap();
-
-        assert_eq!(deep_link.params().homeserver.z32(), PUBLIC_KEY);
-        assert_eq!(deep_link.params().signup_token, Some("123".to_string()));
-        assert_eq!(deep_link.params().client_id.to_string(), CLIENT_ID);
-        assert_eq!(deep_link.params().client_pk.z32(), client_pk.z32());
-    }
-
-    #[test]
-    fn parses_from_url() {
-        let url = Url::parse(&format!(
-            "pubkyauth://signin?caps=/:rw&relay=https://relay.test/inbox&secret={SECRET}"
-        ))
-        .unwrap();
-        let deep_link = TypedSigninDeepLink::parse_url(&url).unwrap();
-
-        assert_eq!(deep_link.params().secret, SECRET_BYTES);
-    }
-
-    #[test]
-    fn converts_signin_deep_link_to_url() {
-        let deep_link: TypedSigninDeepLink = format!(
-            "pubkyauth://signin?caps=/pub/pubky.app/:rw&relay=https://relay.test/inbox&secret={SECRET}"
-        )
-        .parse()
-        .unwrap();
         let url = deep_link.to_url();
-        let parsed_again = TypedSigninDeepLink::parse_url(&url).unwrap();
 
-        assert_eq!(parsed_again, deep_link);
+        assert_eq!(url.scheme(), "pubkyauth");
+        assert_eq!(url.host_str(), Some("test"));
+        assert_eq!(TestDeepLink::parse_url(&url).unwrap(), deep_link);
     }
 
     #[test]
-    fn converts_signup_grant_deep_link_to_url() {
-        let client_pk = Keypair::random().public_key();
-        let deep_link: TypedSignupGrantDeepLink = format!(
-            "pubkyauth://signup?caps=/pub/pubky.app/:rw&relay=https://relay.test/inbox&secret={SECRET}&hs={PUBLIC_KEY}&st=123&cid={CLIENT_ID}&cpk={}",
-            client_pk.z32()
-        )
-        .parse()
-        .unwrap();
-        let url = deep_link.to_url();
-        let parsed_again = TypedSignupGrantDeepLink::parse_url(&url).unwrap();
+    fn displays_as_url() {
+        let deep_link: TestDeepLink = "pubkyauth://test?value=hello".parse().unwrap();
 
-        assert_eq!(parsed_again, deep_link);
+        assert_eq!(deep_link.to_string(), deep_link.to_url().to_string());
+    }
+
+    #[test]
+    fn converts_owned_typed_deep_link_into_url() {
+        let deep_link: TestDeepLink = "pubkyauth://test?value=hello".parse().unwrap();
+        let url: Url = deep_link.into();
+
+        assert_eq!(url.as_str(), "pubkyauth://test?value=hello");
     }
 
     #[test]
     fn rejects_wrong_intent() {
-        let error = format!(
-            "pubkyauth://signup?caps=/:rw&relay=https://relay.test/inbox&secret={SECRET}"
-        )
-        .parse::<TypedSigninDeepLink>()
-        .unwrap_err();
+        let error = "pubkyauth://other?value=hello"
+            .parse::<TestDeepLink>()
+            .unwrap_err();
 
-        assert!(matches!(error, DeepLinkParseError::InvalidIntent("signin")));
+        assert!(matches!(error, DeepLinkParseError::InvalidIntent("test")));
     }
 
     #[test]
     fn rejects_missing_required_param() {
-        let error = format!("pubkyauth://signin?relay=https://relay.test/inbox&secret={SECRET}")
-            .parse::<TypedSigninDeepLink>()
-            .unwrap_err();
+        let error = "pubkyauth://test".parse::<TestDeepLink>().unwrap_err();
 
         assert!(matches!(
             error,
-            DeepLinkParseError::MissingQueryParameter("caps")
-        ));
-    }
-
-    #[test]
-    fn rejects_invalid_typed_param() {
-        let error = "pubkyauth://signin?caps=/:rw&relay=not-a-url&secret=abc"
-            .parse::<TypedSigninDeepLink>()
-            .unwrap_err();
-
-        assert!(matches!(
-            error,
-            DeepLinkParseError::InvalidQueryParameter("relay", _)
+            DeepLinkParseError::MissingQueryParameter("value")
         ));
     }
 }

--- a/pubky-sdk/src/actors/auth/deep_links/typed_deep_link.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/typed_deep_link.rs
@@ -1,0 +1,582 @@
+#![allow(
+    dead_code,
+    reason = "Typed deep link parser is experimental until the deep link refactor chooses a direction"
+)]
+
+use std::{
+    fmt::{self, Display},
+    marker::PhantomData,
+    str::FromStr,
+};
+
+use base64::{Engine, engine::general_purpose::URL_SAFE_NO_PAD};
+use pubky_common::{auth::jws::ClientId, capabilities::Capabilities, crypto::PublicKey};
+use url::Url;
+
+use super::{DeepLinkParseError, schemes::DeepLinkScheme};
+
+pub(super) trait DeepLinkIntent {
+    const NAME: &'static str;
+}
+
+pub(super) trait DeepLinkParams: Sized {
+    fn parse(url: &Url) -> Result<Self, DeepLinkParseError>;
+
+    fn append_query_pairs(&self, url: &mut Url);
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct TypedDeepLink<I, P> {
+    scheme: DeepLinkScheme,
+    params: P,
+    _intent: PhantomData<I>,
+}
+
+impl<I, P> TypedDeepLink<I, P> {
+    /// Create a typed deep link from a scheme and typed params.
+    pub(super) fn new(scheme: DeepLinkScheme, params: P) -> Self {
+        Self {
+            scheme,
+            params,
+            _intent: PhantomData,
+        }
+    }
+}
+
+impl<I, P> TypedDeepLink<I, P>
+where
+    I: DeepLinkIntent,
+    P: DeepLinkParams,
+{
+    /// Parse a typed deep link from a URL.
+    pub(super) fn parse_url(url: &Url) -> Result<Self, DeepLinkParseError> {
+        let scheme = url.scheme().parse()?;
+        if url.host_str().unwrap_or("") != I::NAME {
+            return Err(DeepLinkParseError::InvalidIntent(I::NAME));
+        }
+
+        Ok(Self {
+            scheme,
+            params: P::parse(url)?,
+            _intent: PhantomData,
+        })
+    }
+
+    /// Return the validated deep-link scheme.
+    pub(super) fn scheme(&self) -> DeepLinkScheme {
+        self.scheme
+    }
+
+    /// Return the statically selected deep-link intent.
+    pub(super) fn intent(&self) -> &'static str {
+        I::NAME
+    }
+
+    /// Return the typed parameter set for this deep link.
+    pub(super) fn params(&self) -> &P {
+        &self.params
+    }
+
+    /// Convert this typed deep link into a URL.
+    pub(super) fn to_url(&self) -> Url {
+        let mut url = Url::parse(&format!("{}://{}", self.scheme.as_str(), I::NAME))
+            .expect("invariant: deep-link scheme and intent form a valid URL");
+        self.params.append_query_pairs(&mut url);
+        url
+    }
+}
+
+impl<I, P> FromStr for TypedDeepLink<I, P>
+where
+    I: DeepLinkIntent,
+    P: DeepLinkParams,
+{
+    type Err = DeepLinkParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Self::parse_url(&Url::parse(value)?)
+    }
+}
+
+impl<I, P> Display for TypedDeepLink<I, P>
+where
+    I: DeepLinkIntent,
+    P: DeepLinkParams,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.to_url())
+    }
+}
+
+impl<I, P> From<TypedDeepLink<I, P>> for Url
+where
+    I: DeepLinkIntent,
+    P: DeepLinkParams,
+{
+    fn from(value: TypedDeepLink<I, P>) -> Self {
+        value.to_url()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct SigninIntent;
+
+impl DeepLinkIntent for SigninIntent {
+    const NAME: &'static str = "signin";
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct SignupIntent;
+
+impl DeepLinkIntent for SignupIntent {
+    const NAME: &'static str = "signup";
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct SecretExportIntent;
+
+impl DeepLinkIntent for SecretExportIntent {
+    const NAME: &'static str = "secret_export";
+}
+
+pub(super) type TypedSigninDeepLink = TypedDeepLink<SigninIntent, SigninParams>;
+pub(super) type TypedSignupDeepLink = TypedDeepLink<SignupIntent, SignupParams>;
+pub(super) type TypedSigninGrantDeepLink = TypedDeepLink<SigninIntent, SigninGrantParams>;
+pub(super) type TypedSignupGrantDeepLink = TypedDeepLink<SignupIntent, SignupGrantParams>;
+pub(super) type TypedSeedExportDeepLink = TypedDeepLink<SecretExportIntent, SeedExportParams>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SigninParams {
+    pub(super) capabilities: Capabilities,
+    pub(super) relay: Url,
+    pub(super) secret: [u8; 32],
+}
+
+impl DeepLinkParams for SigninParams {
+    fn parse(url: &Url) -> Result<Self, DeepLinkParseError> {
+        Ok(Self {
+            capabilities: parse_capabilities(url)?,
+            relay: parse_relay(url)?,
+            secret: parse_secret(url)?,
+        })
+    }
+
+    fn append_query_pairs(&self, url: &mut Url) {
+        append_signin_params(url, &self.capabilities, &self.relay, &self.secret);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SignupParams {
+    pub(super) capabilities: Capabilities,
+    pub(super) relay: Url,
+    pub(super) secret: [u8; 32],
+    pub(super) homeserver: PublicKey,
+    pub(super) signup_token: Option<String>,
+}
+
+impl DeepLinkParams for SignupParams {
+    fn parse(url: &Url) -> Result<Self, DeepLinkParseError> {
+        Ok(Self {
+            capabilities: parse_capabilities(url)?,
+            relay: parse_relay(url)?,
+            secret: parse_secret(url)?,
+            homeserver: parse_homeserver(url)?,
+            signup_token: optional_query(url, "st"),
+        })
+    }
+
+    fn append_query_pairs(&self, url: &mut Url) {
+        append_signup_params(
+            url,
+            &self.capabilities,
+            &self.relay,
+            &self.secret,
+            &self.homeserver,
+            self.signup_token.as_deref(),
+        );
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SigninGrantParams {
+    pub(super) capabilities: Capabilities,
+    pub(super) relay: Url,
+    pub(super) secret: [u8; 32],
+    pub(super) client_id: ClientId,
+    pub(super) client_pk: PublicKey,
+}
+
+impl DeepLinkParams for SigninGrantParams {
+    fn parse(url: &Url) -> Result<Self, DeepLinkParseError> {
+        Ok(Self {
+            capabilities: parse_capabilities(url)?,
+            relay: parse_relay(url)?,
+            secret: parse_secret(url)?,
+            client_id: parse_client_id(url)?,
+            client_pk: parse_client_pk(url)?,
+        })
+    }
+
+    fn append_query_pairs(&self, url: &mut Url) {
+        append_signin_params(url, &self.capabilities, &self.relay, &self.secret);
+        append_grant_params(url, &self.client_id, &self.client_pk);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SignupGrantParams {
+    pub(super) capabilities: Capabilities,
+    pub(super) relay: Url,
+    pub(super) secret: [u8; 32],
+    pub(super) homeserver: PublicKey,
+    pub(super) signup_token: Option<String>,
+    pub(super) client_id: ClientId,
+    pub(super) client_pk: PublicKey,
+}
+
+impl DeepLinkParams for SignupGrantParams {
+    fn parse(url: &Url) -> Result<Self, DeepLinkParseError> {
+        Ok(Self {
+            capabilities: parse_capabilities(url)?,
+            relay: parse_relay(url)?,
+            secret: parse_secret(url)?,
+            homeserver: parse_homeserver(url)?,
+            signup_token: optional_query(url, "st"),
+            client_id: parse_client_id(url)?,
+            client_pk: parse_client_pk(url)?,
+        })
+    }
+
+    fn append_query_pairs(&self, url: &mut Url) {
+        append_signup_params(
+            url,
+            &self.capabilities,
+            &self.relay,
+            &self.secret,
+            &self.homeserver,
+            self.signup_token.as_deref(),
+        );
+        append_grant_params(url, &self.client_id, &self.client_pk);
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct SeedExportParams {
+    pub(super) secret: [u8; 32],
+}
+
+impl DeepLinkParams for SeedExportParams {
+    fn parse(url: &Url) -> Result<Self, DeepLinkParseError> {
+        Ok(Self {
+            secret: parse_secret(url)?,
+        })
+    }
+
+    fn append_query_pairs(&self, url: &mut Url) {
+        url.query_pairs_mut()
+            .append_pair("secret", &URL_SAFE_NO_PAD.encode(self.secret));
+    }
+}
+
+fn append_signin_params(
+    url: &mut Url,
+    capabilities: &Capabilities,
+    relay: &Url,
+    secret: &[u8; 32],
+) {
+    url.query_pairs_mut()
+        .append_pair("caps", &capabilities.to_string())
+        .append_pair("relay", relay.as_str())
+        .append_pair("secret", &URL_SAFE_NO_PAD.encode(secret));
+}
+
+fn append_signup_params(
+    url: &mut Url,
+    capabilities: &Capabilities,
+    relay: &Url,
+    secret: &[u8; 32],
+    homeserver: &PublicKey,
+    signup_token: Option<&str>,
+) {
+    append_signin_params(url, capabilities, relay, secret);
+    let mut query = url.query_pairs_mut();
+    query.append_pair("hs", &homeserver.z32());
+    if let Some(signup_token) = signup_token {
+        query.append_pair("st", signup_token);
+    }
+}
+
+fn append_grant_params(url: &mut Url, client_id: &ClientId, client_pk: &PublicKey) {
+    url.query_pairs_mut()
+        .append_pair("cid", &client_id.to_string())
+        .append_pair("cpk", &client_pk.z32());
+}
+
+fn parse_capabilities(url: &Url) -> Result<Capabilities, DeepLinkParseError> {
+    required_query(url, "caps")?
+        .as_str()
+        .try_into()
+        .map_err(|e| DeepLinkParseError::InvalidQueryParameter("caps", Box::new(e)))
+}
+
+fn parse_relay(url: &Url) -> Result<Url, DeepLinkParseError> {
+    Url::parse(&required_query(url, "relay")?)
+        .map_err(|e| DeepLinkParseError::InvalidQueryParameter("relay", Box::new(e)))
+}
+
+fn parse_secret(url: &Url) -> Result<[u8; 32], DeepLinkParseError> {
+    let raw_secret = required_query(url, "secret")?;
+    let secret = URL_SAFE_NO_PAD
+        .decode(raw_secret.as_str())
+        .map_err(|e| DeepLinkParseError::InvalidQueryParameter("secret", Box::new(e)))?;
+
+    secret.try_into().map_err(|e: Vec<u8>| {
+        let msg = format!("Expected 32 bytes, got {}", e.len());
+        DeepLinkParseError::InvalidQueryParameter(
+            "secret",
+            Box::new(std::io::Error::new(std::io::ErrorKind::InvalidData, msg)),
+        )
+    })
+}
+
+fn parse_homeserver(url: &Url) -> Result<PublicKey, DeepLinkParseError> {
+    PublicKey::try_from_z32(&required_query(url, "hs")?)
+        .map_err(|e| DeepLinkParseError::InvalidQueryParameter("hs", Box::new(e)))
+}
+
+fn parse_client_id(url: &Url) -> Result<ClientId, DeepLinkParseError> {
+    ClientId::new(&required_query(url, "cid")?)
+        .map_err(|e| DeepLinkParseError::InvalidQueryParameter("cid", Box::new(e)))
+}
+
+fn parse_client_pk(url: &Url) -> Result<PublicKey, DeepLinkParseError> {
+    PublicKey::try_from_z32(&required_query(url, "cpk")?)
+        .map_err(|e| DeepLinkParseError::InvalidQueryParameter("cpk", Box::new(e)))
+}
+
+fn required_query(url: &Url, key: &'static str) -> Result<String, DeepLinkParseError> {
+    optional_query(url, key).ok_or(DeepLinkParseError::MissingQueryParameter(key))
+}
+
+fn optional_query(url: &Url, key: &str) -> Option<String> {
+    url.query_pairs()
+        .find(|(param_key, _)| param_key == key)
+        .map(|(_, value)| value.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pubky_common::crypto::Keypair;
+
+    const SECRET: &str = "kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8";
+    const SECRET_BYTES: [u8; 32] = [
+        146, 169, 220, 120, 67, 32, 172, 212, 12, 255, 24, 180, 234, 132, 23, 140, 13, 220, 36,
+        117, 255, 69, 9, 176, 212, 22, 58, 36, 77, 91, 177, 239,
+    ];
+    const CLIENT_ID: &str = "franky.pubky.app";
+    const PUBLIC_KEY: &str = "5jsjx1o6fzu6aeeo697r3i5rx15zq41kikcye8wtwdqm4nb4tryo";
+
+    #[test]
+    fn parses_signin_deep_link() {
+        let deep_link: TypedSigninDeepLink = format!(
+            "pubkyauth://signin?caps=/pub/pubky.app/:rw&relay=https://relay.test/inbox&secret={SECRET}"
+        )
+        .parse()
+        .unwrap();
+
+        assert_eq!(deep_link.scheme(), DeepLinkScheme::PubkyAuth);
+        assert_eq!(deep_link.intent(), "signin");
+        assert_eq!(
+            deep_link.params().capabilities.to_string(),
+            "/pub/pubky.app/:rw"
+        );
+        assert_eq!(deep_link.params().relay.as_str(), "https://relay.test/inbox");
+        assert_eq!(deep_link.params().secret, SECRET_BYTES);
+    }
+
+    #[test]
+    fn parses_signup_deep_link() {
+        let deep_link: TypedSignupDeepLink = format!(
+            "pubkyauth://signup?caps=/pub/pubky.app/:rw&relay=https://relay.test/inbox&secret={SECRET}&hs={PUBLIC_KEY}&st=123"
+        )
+        .parse()
+        .unwrap();
+
+        assert_eq!(deep_link.params().homeserver.z32(), PUBLIC_KEY);
+        assert_eq!(deep_link.params().signup_token, Some("123".to_string()));
+    }
+
+    #[test]
+    fn parses_signin_grant_deep_link() {
+        let client_pk = Keypair::random().public_key();
+        let deep_link: TypedSigninGrantDeepLink = format!(
+            "pubkyauth://signin?caps=/pub/pubky.app/:rw&relay=https://relay.test/inbox&secret={SECRET}&cid={CLIENT_ID}&cpk={}",
+            client_pk.z32()
+        )
+        .parse()
+        .unwrap();
+
+        assert_eq!(deep_link.params().client_id.to_string(), CLIENT_ID);
+        assert_eq!(deep_link.params().client_pk.z32(), client_pk.z32());
+    }
+
+    #[test]
+    fn parses_signup_grant_deep_link() {
+        let client_pk = Keypair::random().public_key();
+        let deep_link: TypedSignupGrantDeepLink = format!(
+            "pubkyauth://signup?caps=/pub/pubky.app/:rw&relay=https://relay.test/inbox&secret={SECRET}&hs={PUBLIC_KEY}&st=123&cid={CLIENT_ID}&cpk={}",
+            client_pk.z32()
+        )
+        .parse()
+        .unwrap();
+
+        assert_eq!(deep_link.params().homeserver.z32(), PUBLIC_KEY);
+        assert_eq!(deep_link.params().signup_token, Some("123".to_string()));
+        assert_eq!(deep_link.params().client_id.to_string(), CLIENT_ID);
+        assert_eq!(deep_link.params().client_pk.z32(), client_pk.z32());
+    }
+
+    #[test]
+    fn parses_seed_export_deep_link() {
+        let deep_link: TypedSeedExportDeepLink =
+            format!("pubkyring://secret_export?secret={SECRET}")
+                .parse()
+                .unwrap();
+
+        assert_eq!(deep_link.scheme(), DeepLinkScheme::PubkyRing);
+        assert_eq!(deep_link.intent(), "secret_export");
+        assert_eq!(deep_link.params().secret, SECRET_BYTES);
+    }
+
+    #[test]
+    fn parses_from_url() {
+        let url = Url::parse(&format!(
+            "pubkyauth://signin?caps=/:rw&relay=https://relay.test/inbox&secret={SECRET}"
+        ))
+        .unwrap();
+        let deep_link = TypedSigninDeepLink::parse_url(&url).unwrap();
+
+        assert_eq!(deep_link.params().secret, SECRET_BYTES);
+    }
+
+    #[test]
+    fn converts_signin_deep_link_to_url() {
+        let deep_link: TypedSigninDeepLink = format!(
+            "pubkyauth://signin?caps=/pub/pubky.app/:rw&relay=https://relay.test/inbox&secret={SECRET}"
+        )
+        .parse()
+        .unwrap();
+        let url = deep_link.to_url();
+        let parsed_again = TypedSigninDeepLink::parse_url(&url).unwrap();
+
+        assert_eq!(parsed_again, deep_link);
+    }
+
+    #[test]
+    fn converts_signup_grant_deep_link_to_url() {
+        let client_pk = Keypair::random().public_key();
+        let deep_link: TypedSignupGrantDeepLink = format!(
+            "pubkyauth://signup?caps=/pub/pubky.app/:rw&relay=https://relay.test/inbox&secret={SECRET}&hs={PUBLIC_KEY}&st=123&cid={CLIENT_ID}&cpk={}",
+            client_pk.z32()
+        )
+        .parse()
+        .unwrap();
+        let url = deep_link.to_url();
+        let parsed_again = TypedSignupGrantDeepLink::parse_url(&url).unwrap();
+
+        assert_eq!(parsed_again, deep_link);
+    }
+
+    #[test]
+    fn converts_seed_export_deep_link_to_url() {
+        let deep_link: TypedSeedExportDeepLink =
+            format!("pubkyring://secret_export?secret={SECRET}")
+                .parse()
+                .unwrap();
+        let url = deep_link.to_url();
+
+        assert_eq!(url.scheme(), "pubkyring");
+        assert_eq!(url.host_str(), Some("secret_export"));
+        assert_eq!(TypedSeedExportDeepLink::parse_url(&url).unwrap(), deep_link);
+    }
+
+    #[test]
+    fn creates_seed_export_deep_link_from_params() {
+        let deep_link = TypedSeedExportDeepLink::new(
+            DeepLinkScheme::PubkyAuth,
+            SeedExportParams {
+                secret: SECRET_BYTES,
+            },
+        );
+        let url = deep_link.to_url();
+        let parsed_again = TypedSeedExportDeepLink::parse_url(&url).unwrap();
+
+        assert_eq!(deep_link.scheme(), DeepLinkScheme::PubkyAuth);
+        assert_eq!(deep_link.intent(), "secret_export");
+        assert_eq!(deep_link.params().secret, SECRET_BYTES);
+        assert_eq!(parsed_again, deep_link);
+    }
+
+    #[test]
+    fn display_formats_as_url() {
+        let deep_link: TypedSeedExportDeepLink =
+            format!("pubkyauth://secret_export?secret={SECRET}")
+                .parse()
+                .unwrap();
+
+        assert_eq!(deep_link.to_string(), deep_link.to_url().to_string());
+    }
+
+    #[test]
+    fn converts_owned_typed_deep_link_into_url() {
+        let deep_link: TypedSeedExportDeepLink =
+            format!("pubkyauth://secret_export?secret={SECRET}")
+                .parse()
+                .unwrap();
+        let url: Url = deep_link.into();
+
+        assert_eq!(url.scheme(), "pubkyauth");
+        assert_eq!(url.host_str(), Some("secret_export"));
+        url.query_pairs()
+            .find(|(key, _)| key == "secret")
+            .map(|(_, value)| assert_eq!(value, SECRET))
+            .expect("Expected 'secret' query parameter");
+    }
+
+    #[test]
+    fn rejects_wrong_intent() {
+        let error = format!(
+            "pubkyauth://signup?caps=/:rw&relay=https://relay.test/inbox&secret={SECRET}"
+        )
+        .parse::<TypedSigninDeepLink>()
+        .unwrap_err();
+
+        assert!(matches!(error, DeepLinkParseError::InvalidIntent("signin")));
+    }
+
+    #[test]
+    fn rejects_missing_required_param() {
+        let error = format!("pubkyauth://signin?relay=https://relay.test/inbox&secret={SECRET}")
+            .parse::<TypedSigninDeepLink>()
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            DeepLinkParseError::MissingQueryParameter("caps")
+        ));
+    }
+
+    #[test]
+    fn rejects_invalid_typed_param() {
+        let error = "pubkyauth://signin?caps=/:rw&relay=not-a-url&secret=abc"
+            .parse::<TypedSigninDeepLink>()
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            DeepLinkParseError::InvalidQueryParameter("relay", _)
+        ));
+    }
+}

--- a/pubky-sdk/src/actors/auth/grant/builder.rs
+++ b/pubky-sdk/src/actors/auth/grant/builder.rs
@@ -140,7 +140,7 @@ impl GrantAuthFlowBuilder {
         Ok(PubkyGrantAuthFlow::new(
             relay_listener,
             client,
-            auth_url,
+            auth_url.into(),
             client_keypair,
         ))
     }

--- a/pubky-sdk/src/actors/auth/grant/builder.rs
+++ b/pubky-sdk/src/actors/auth/grant/builder.rs
@@ -6,7 +6,10 @@ use pubky_common::{
 };
 
 use crate::actors::DEFAULT_HTTP_RELAY_INBOX;
-use crate::actors::auth::deep_links::{DeepLink, SigninGrantDeepLink, SignupGrantDeepLink};
+use crate::actors::auth::deep_links::{
+    DeepLink, DeepLinkScheme, SigninGrantDeepLink, SigninGrantParams, SignupGrantDeepLink,
+    SignupGrantParams,
+};
 use crate::actors::auth::grant::flow::PubkyGrantAuthFlow;
 use crate::actors::auth::kind::AuthFlowKind;
 use crate::actors::auth::relay::auth_relay_listener::AuthRelayListener;
@@ -100,11 +103,14 @@ impl GrantAuthFlowBuilder {
 
         let auth_url = match auth_kind {
             AuthFlowKind::SignIn => DeepLink::SigninGrant(SigninGrantDeepLink::new(
-                caps,
-                base_relay.clone(),
-                client_secret,
-                client_id,
-                client_pk,
+                DeepLinkScheme::PubkyAuth,
+                SigninGrantParams {
+                    capabilities: caps,
+                    relay: base_relay.clone(),
+                    secret: client_secret,
+                    client_id,
+                    client_pk,
+                },
             )),
             AuthFlowKind::SignUp {
                 homeserver_public_key,
@@ -112,13 +118,16 @@ impl GrantAuthFlowBuilder {
             } => {
                 let hs_pk = *homeserver_public_key;
                 DeepLink::SignupGrant(SignupGrantDeepLink::new(
-                    caps,
-                    base_relay.clone(),
-                    client_secret,
-                    hs_pk.clone(),
-                    signup_token.clone(),
-                    client_id,
-                    client_pk,
+                    DeepLinkScheme::PubkyAuth,
+                    SignupGrantParams {
+                        capabilities: caps,
+                        relay: base_relay.clone(),
+                        secret: client_secret,
+                        homeserver: hs_pk,
+                        signup_token: signup_token.clone(),
+                        client_id,
+                        client_pk,
+                    },
                 ))
             }
         };

--- a/pubky-sdk/src/actors/auth/grant/flow.rs
+++ b/pubky-sdk/src/actors/auth/grant/flow.rs
@@ -333,8 +333,16 @@ impl PubkyGrantAuthFlow {
 
 fn grant_deep_link_parts(deep_link: &DeepLink) -> Result<(&Url, &[u8; 32], &PublicKey)> {
     match deep_link {
-        DeepLink::SigninGrant(link) => Ok((link.relay(), link.secret(), link.client_pk())),
-        DeepLink::SignupGrant(link) => Ok((link.relay(), link.secret(), link.client_pk())),
+        DeepLink::SigninGrant(link) => Ok((
+            &link.params().relay,
+            &link.params().secret,
+            &link.params().client_pk,
+        )),
+        DeepLink::SignupGrant(link) => Ok((
+            &link.params().relay,
+            &link.params().secret,
+            &link.params().client_pk,
+        )),
         _ => Err(AuthError::Validation(
             "saved grant auth flow state must contain a grant signin or signup deep link".into(),
         )
@@ -345,7 +353,9 @@ fn grant_deep_link_parts(deep_link: &DeepLink) -> Result<(&Url, &[u8; 32], &Publ
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::actors::auth::deep_links::{SigninDeepLink, SigninGrantDeepLink};
+    use crate::actors::auth::deep_links::{
+        DeepLinkScheme, SigninDeepLink, SigninGrantDeepLink, SigninGrantParams, SigninParams,
+    };
 
     #[tokio::test]
     async fn save_restore_round_trips_authorization_url() {
@@ -375,9 +385,12 @@ mod tests {
     #[test]
     fn restore_rejects_cookie_auth_url() {
         let auth_url = SigninDeepLink::new(
-            Capabilities::default(),
-            Url::parse("http://localhost/inbox").unwrap(),
-            [7; 32],
+            DeepLinkScheme::PubkyAuth,
+            SigninParams {
+                capabilities: Capabilities::default(),
+                relay: Url::parse("http://localhost/inbox").unwrap(),
+                secret: [7; 32],
+            },
         )
         .to_string();
         let state = GrantAuthFlowState {
@@ -397,11 +410,14 @@ mod tests {
         let expected_client = Keypair::random();
         let actual_client = Keypair::random();
         let auth_url = SigninGrantDeepLink::new(
-            Capabilities::default(),
-            Url::parse("http://localhost/inbox").unwrap(),
-            [7; 32],
-            ClientId::new("mismatch.test").unwrap(),
-            expected_client.public_key(),
+            DeepLinkScheme::PubkyAuth,
+            SigninGrantParams {
+                capabilities: Capabilities::default(),
+                relay: Url::parse("http://localhost/inbox").unwrap(),
+                secret: [7; 32],
+                client_id: ClientId::new("mismatch.test").unwrap(),
+                client_pk: expected_client.public_key(),
+            },
         )
         .to_string();
         let state = GrantAuthFlowState {

--- a/pubky-sdk/src/actors/auth/grant/flow.rs
+++ b/pubky-sdk/src/actors/auth/grant/flow.rs
@@ -110,7 +110,7 @@ impl fmt::Debug for GrantAuthFlowState {
 pub struct PubkyGrantAuthFlow {
     relay_listener: AuthRelayListener,
     client: PubkyHttpClient,
-    auth_url: DeepLink,
+    auth_url: Url,
     client_keypair: Keypair,
 }
 
@@ -129,7 +129,7 @@ impl PubkyGrantAuthFlow {
     pub(crate) fn new(
         relay_listener: AuthRelayListener,
         client: PubkyHttpClient,
-        auth_url: DeepLink,
+        auth_url: Url,
         client_keypair: Keypair,
     ) -> Self {
         Self {
@@ -169,7 +169,7 @@ impl PubkyGrantAuthFlow {
     /// The `pubkyauth://` deep link you display (QR/URL) to the signer.
     #[must_use]
     pub fn authorization_url(&self) -> Url {
-        self.auth_url.clone().into()
+        self.auth_url.clone()
     }
 
     /// Save the sensitive state required to restore this pending grant flow.
@@ -219,7 +219,12 @@ impl PubkyGrantAuthFlow {
             .client(client.clone())
             .start()?;
 
-        Ok(Self::new(relay_listener, client, auth_url, client_keypair))
+        Ok(Self::new(
+            relay_listener,
+            client,
+            auth_url.into(),
+            client_keypair,
+        ))
     }
 
     /// Block until the signer approves and return a ready-to-use

--- a/pubky-sdk/src/actors/signer/auth.rs
+++ b/pubky-sdk/src/actors/signer/auth.rs
@@ -55,56 +55,62 @@ impl PubkySigner {
 
         let (relay, client_secret, encrypted_payload) = match &deep_link {
             DeepLink::Signin(d) => {
+                let params = d.params();
                 cross_log!(
                     info,
                     "Approving legacy signin via relay {} (caps={:?})",
-                    d.relay(),
-                    d.capabilities()
+                    params.relay,
+                    params.capabilities
                 );
-                let payload = self.build_encrypted_token(d.capabilities().clone(), d.secret());
-                (d.relay().clone(), *d.secret(), payload)
+                let payload =
+                    self.build_encrypted_token(params.capabilities.clone(), &params.secret);
+                (params.relay.clone(), params.secret, payload)
             }
             DeepLink::Signup(d) => {
+                let params = d.params();
                 cross_log!(
                     info,
                     "Approving legacy signup via relay {} (caps={:?})",
-                    d.relay(),
-                    d.capabilities()
+                    params.relay,
+                    params.capabilities
                 );
-                let payload = self.build_encrypted_token(d.capabilities().clone(), d.secret());
-                (d.relay().clone(), *d.secret(), payload)
+                let payload =
+                    self.build_encrypted_token(params.capabilities.clone(), &params.secret);
+                (params.relay.clone(), params.secret, payload)
             }
             DeepLink::SigninGrant(d) => {
+                let params = d.params();
                 cross_log!(
                     info,
                     "Approving grant signin via relay {} (client_id={}, caps={:?})",
-                    d.relay(),
-                    d.client_id(),
-                    d.capabilities()
+                    params.relay,
+                    params.client_id,
+                    params.capabilities
                 );
                 let payload = self.build_encrypted_grant(
-                    d.capabilities(),
-                    d.client_id().clone(),
-                    d.client_pk().clone(),
-                    d.secret(),
+                    &params.capabilities,
+                    params.client_id.clone(),
+                    params.client_pk.clone(),
+                    &params.secret,
                 );
-                (d.relay().clone(), *d.secret(), payload)
+                (params.relay.clone(), params.secret, payload)
             }
             DeepLink::SignupGrant(d) => {
+                let params = d.params();
                 cross_log!(
                     info,
                     "Approving grant signup via relay {} (client_id={}, caps={:?})",
-                    d.relay(),
-                    d.client_id(),
-                    d.capabilities()
+                    params.relay,
+                    params.client_id,
+                    params.capabilities
                 );
                 let payload = self.build_encrypted_grant(
-                    d.capabilities(),
-                    d.client_id().clone(),
-                    d.client_pk().clone(),
-                    d.secret(),
+                    &params.capabilities,
+                    params.client_id.clone(),
+                    params.client_pk.clone(),
+                    &params.secret,
                 );
-                (d.relay().clone(), *d.secret(), payload)
+                (params.relay.clone(), params.secret, payload)
             }
             DeepLink::SeedExport(_) => {
                 return Err(AuthError::Validation(

--- a/pubky-sdk/src/pubky.rs
+++ b/pubky-sdk/src/pubky.rs
@@ -346,16 +346,19 @@ fn parse_auth_deep_link(url: &str) -> Result<(Capabilities, url::Url, [u8; 32], 
 
     match &deep_link {
         DeepLink::Signin(s) => Ok((
-            s.capabilities().clone(),
-            s.relay().clone(),
-            *s.secret(),
+            s.params().capabilities.clone(),
+            s.params().relay.clone(),
+            s.params().secret,
             AuthFlowKind::signin(),
         )),
         DeepLink::Signup(s) => Ok((
-            s.capabilities().clone(),
-            s.relay().clone(),
-            *s.secret(),
-            AuthFlowKind::signup(s.homeserver().clone(), s.signup_token()),
+            s.params().capabilities.clone(),
+            s.params().relay.clone(),
+            s.params().secret,
+            AuthFlowKind::signup(
+                s.params().homeserver.clone(),
+                s.params().signup_token.clone(),
+            ),
         )),
         DeepLink::SigninGrant(_) | DeepLink::SignupGrant(_) => Err(AuthError::Validation(
             "grant auth flows cannot be resumed from the authorization URL alone; the PoP client private key is required and is not encoded in the deep link."


### PR DESCRIPTION
Refactors the deep link SDK module. The previous module 
- Had a lot of duplicated code.
- Didn't align with any clean code/architecture principles.

This PR fixes this with an abstract but strongly typed `TypedDeepLink`. It standardizes a deep link the following way:

- `DeepLinkScheme` The URL scheme. Can be `pubkyauth` or the deprecated `pubkyring`.
- `DeepLinkIntent` A simple one word string, for example `signup` or `secret_export`.
- `DeepLinkParams` A flexible list of GET parameter key values.

To visualized it: `{DeepLinkScheme}://{DeepLinkIntent}?{DeepLinkParams}`. 
The seed export would be: `pubkyauth://secret_export?secret=123456`.


It also gives the grant signup/signin a dedicated deeplink intent for better parsing.