### PR TITLE
ci: Improve auto-generated release change log and enforce conventional commit PR titles 

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,0 +1,33 @@
+# Enforces conventional commit format on PR titles (e.g. "feat:", "fix(scope)!:").
+# This ensures clean commit messages on main (via squash merge) which are then
+# parsed by requarks/changelog-action to generate categorised release notes.
+name: PR Title
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited]
+
+jobs:
+  pr-title:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            refactor
+            test
+            ci
+            build
+            chore
+            deps
+          requireScope: false
+          subjectPattern: ^.+$
+          subjectPatternError: "PR title must have a subject after the type prefix"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,16 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Generate changelog
+        id: changelog
+        uses: requarks/changelog-action@v1
+        with:
+          token: ${{ github.token }}
+          tag: ${{ github.ref_name }}
+          excludeTypes: ""
+          useGitmojis: false
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
@@ -85,7 +95,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          generate_release_notes: true
+          body: ${{ steps.changelog.outputs.changes }}
           files: artifacts/*
 
   publish-crates:


### PR DESCRIPTION
- Use requarks/changelog-action to generate categorised changelog for release notes from conventional commit messages. 
- Ensure PR titles follow correct conventional commit pattern.