### PR TITLE
chore!: v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,7 +1592,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "bytes",
  "eventsource-stream",
@@ -4046,7 +4046,7 @@ checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "pubky"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64 0.22.1",
  "cookie",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-common"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "argon2",
  "base32",
@@ -4094,7 +4094,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-core-examples"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4113,7 +4113,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-homeserver"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "async-dropper",
@@ -4175,7 +4175,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-testnet"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-wasm"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64 0.22.1",
  "console_log",

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -2,12 +2,12 @@
 name = "e2e"
 edition.workspace = true
 rust-version.workspace = true
-version = "0.8.0"
+version = "0.9.0"
 publish = false
 
 [dependencies]
-pubky-testnet = { path = "../pubky-testnet" , version = "0.8.0" }
-pubky-common = { path = "../pubky-common" , version = "0.8.0" }
+pubky-testnet = { path = "../pubky-testnet" , version = "0.9.0" }
+pubky-common = { path = "../pubky-common" , version = "0.9.0" }
 tokio = { workspace = true, features = ["full", "test-util"] }
 tracing-subscriber.workspace = true
 pkarr = { workspace = true }

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky-core-examples"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 rust-version.workspace = true
 publish = false
@@ -52,9 +52,9 @@ futures-util = "0.3.31"
 anyhow.workspace = true
 base64 = "0.22.1"
 clap = { version = "4.6.0", features = ["derive"] }
-pubky = { path = "../../pubky-sdk" , version = "0.8.0" }
-pubky-testnet = { path = "../../pubky-testnet" , version = "0.8.0" }
-pubky-common = { path = "../../pubky-common" , version = "0.8.0" }
+pubky = { path = "../../pubky-sdk" , version = "0.9.0" }
+pubky-testnet = { path = "../../pubky-testnet" , version = "0.9.0" }
+pubky-common = { path = "../../pubky-common" , version = "0.9.0" }
 reqwest.workspace = true
 rpassword = "7.4.0"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/pubky-common/Cargo.toml
+++ b/pubky-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubky-common"
 description = "Types and struct in common between Pubky client and homeserver"
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/pubky-homeserver/Cargo.toml
+++ b/pubky-homeserver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubky-homeserver"
 description = "Pubky core's homeserver."
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -33,7 +33,7 @@ futures-util = "0.3.31"
 hex = "0.4.3"
 httpdate = "1.0.3"
 pkarr = { workspace = true, features = ["default", "dht", "tls"] }
-pubky-common = { path = "../pubky-common" , version = "0.8.0" }
+pubky-common = { path = "../pubky-common" , version = "0.9.0" }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1"
 tokio = { workspace = true, features = ["full"] }

--- a/pubky-sdk/Cargo.toml
+++ b/pubky-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubky"
 description = "Pubky SDK"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version.workspace = true
 authors = [
@@ -29,7 +29,7 @@ default = []
 json = ["dep:serde", "reqwest/json"]
 
 [dependencies]
-pubky-common = { path = "../pubky-common" , version = "0.8.0" }
+pubky-common = { path = "../pubky-common" , version = "0.9.0" }
 thiserror.workspace = true
 eventsource-stream = "0.2.3"
 url.workspace = true
@@ -59,7 +59,7 @@ wasm-bindgen-futures = "0.4.50"
 futures-lite = { version = "2.6.0", default-features = false }
 
 [dev-dependencies]
-pubky-testnet = { path = "../pubky-testnet" , version = "0.8.0" } # used in docstring tests
+pubky-testnet = { path = "../pubky-testnet" , version = "0.9.0" } # used in docstring tests
 httpmock = "0.7"
 http-relay = { workspace = true, features = ["server", "link-compat"] }
 

--- a/pubky-sdk/bindings/js/Cargo.toml
+++ b/pubky-sdk/bindings/js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky-wasm"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 rust-version.workspace = true
 description = "Pubky-Core Client WASM bindings"
@@ -41,8 +41,8 @@ serde-wasm-bindgen = "0.6"
 tsify = "0.5.5"
 pubky = { path = "../../../pubky-sdk", default-features = false, features = [
     "json",
-] , version = "0.8.0" }
-pubky-common = { path = "../../../pubky-common" , version = "0.8.0" }
+] , version = "0.9.0" }
+pubky-common = { path = "../../../pubky-common" , version = "0.9.0" }
 pkarr = { workspace = true, default-features = false }
 web-sys = { version = "0.3.77", default-features = false, features = [
     "Request",

--- a/pubky-sdk/bindings/js/pkg/package-lock.json
+++ b/pubky-sdk/bindings/js/pkg/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@synonymdev/pubky",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@synonymdev/pubky",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "fetch-cookie": "^3.0.1"

--- a/pubky-sdk/bindings/js/pkg/package.json
+++ b/pubky-sdk/bindings/js/pkg/package.json
@@ -2,7 +2,7 @@
   "name": "@synonymdev/pubky",
   "type": "module",
   "description": "Pubky client",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/pubky-testnet/Cargo.toml
+++ b/pubky-testnet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubky-testnet"
 description = "A local test network for Pubky Core development."
-version = "0.8.0"
+version = "0.9.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -20,11 +20,11 @@ tokio = { workspace = true, features = ["full"] }
 tracing-subscriber.workspace = true
 url.workspace = true
 
-pubky = { path = "../pubky-sdk", features = ["json"] , version = "0.8.0" }
-pubky-common = { path = "../pubky-common" , version = "0.8.0" }
+pubky = { path = "../pubky-sdk", features = ["json"] , version = "0.9.0" }
+pubky-common = { path = "../pubky-common" , version = "0.9.0" }
 pubky-homeserver = { path = "../pubky-homeserver", default-features = false, features = [
     "testing",
-] , version = "0.8.0" }
+] , version = "0.9.0" }
 pubky_test_utils = { path = "../test_utils/pubky_test", version = "0.1.0" }
 # External http-relay: server + link-compat, no persist/cli (in-memory storage for tests)
 http-relay = { workspace = true, features = ["server", "link-compat"] }


### PR DESCRIPTION
BREAKING CHANGE: The embedded-postgres feature was renamed to docker-postgres and now requires Docker on the host. Deprecated aliases are provided for the old feature flag and API names. 

This break was introduced in f9e75f0 but the `!` marker missed from the commit.