### PR TITLE
feat(sdk): restore grant session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1594,6 +1594,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 name = "e2e"
 version = "0.9.0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "eventsource-stream",
  "futures",

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 [dependencies]
 pubky-testnet = { path = "../pubky-testnet" , version = "0.9.0" }
 pubky-common = { path = "../pubky-common" , version = "0.9.0" }
+base64 = "0.22"
 tokio = { workspace = true, features = ["full", "test-util"] }
 tracing-subscriber.workspace = true
 pkarr = { workspace = true }

--- a/e2e/src/tests/auth/cookie.rs
+++ b/e2e/src/tests/auth/cookie.rs
@@ -342,9 +342,7 @@ async fn session_secret_export_import_restores_session() {
     drop(session);
 
     // Rehydrate from the exported secret (validates the session)
-    let restored = PubkySession::import_secret(&secret_token, Some(pubky.client().clone()))
-        .await
-        .unwrap();
+    let restored = pubky.restore_session(&secret_token).await.unwrap();
 
     assert_eq!(restored.info().public_key(), &signer.public_key());
 

--- a/e2e/src/tests/auth/grant.rs
+++ b/e2e/src/tests/auth/grant.rs
@@ -98,6 +98,41 @@ async fn auth_flow() {
 
 #[tokio::test]
 #[pubky_testnet::test]
+async fn grant_secret_restore_mints_fresh_bearer() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+
+    let signer = pubky.signer(Keypair::random());
+    signer.signup(&server.public_key(), None).await.unwrap();
+    let session = signer
+        .signin(ClientId::new("restore-bearer.test").unwrap())
+        .await
+        .unwrap();
+
+    let original_bearer = session.as_grant().unwrap().current_bearer().await;
+    let secret_token = session.as_grant().unwrap().export_secret().await;
+
+    let restored = pubky.restore_session(&secret_token).await.unwrap();
+    let restored_bearer = restored.as_grant().unwrap().current_bearer().await;
+
+    assert_ne!(
+        original_bearer, restored_bearer,
+        "restoring a grant secret must mint a fresh bearer"
+    );
+    assert!(
+        session.revalidate().await.unwrap().is_none(),
+        "minting the restored bearer replaces the old grant session"
+    );
+    restored
+        .storage()
+        .put("/pub/restore-bearer.test/hello", b"world".to_vec())
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+#[pubky_testnet::test]
 async fn auth_flow_survives_long_poll_timeout() {
     let testnet = build_full_testnet().await;
     let server = testnet.homeserver_app();

--- a/e2e/src/tests/auth/grant.rs
+++ b/e2e/src/tests/auth/grant.rs
@@ -1,5 +1,13 @@
 use super::*;
-
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use pubky_testnet::pubky_common::{
+    auth::{
+        grant::GrantClaims,
+        jws::{GrantId, GRANT_JWS_TYP},
+    },
+    crypto::PublicKey,
+};
+use std::time::{SystemTime, UNIX_EPOCH};
 // =====================================================================
 // Grant + Proof-of-Possession auth flow tests
 // =====================================================================
@@ -129,6 +137,91 @@ async fn grant_secret_restore_mints_fresh_bearer() {
         .put("/pub/restore-bearer.test/hello", b"world".to_vec())
         .await
         .unwrap();
+}
+
+#[tokio::test]
+#[pubky_testnet::test]
+async fn grant_secret_restore_rejects_revoked_grant() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+
+    let signer = pubky.signer(Keypair::random());
+    signer.signup(&server.public_key(), None).await.unwrap();
+    let session = signer
+        .signin(ClientId::new("revoked-restore.test").unwrap())
+        .await
+        .unwrap();
+
+    let secret_token = session.as_grant().unwrap().export_secret().await;
+    let grant_id = session.as_grant().unwrap().grant_id().await;
+    session
+        .as_grant()
+        .unwrap()
+        .revoke_grant(&grant_id)
+        .await
+        .unwrap();
+
+    let err = pubky.restore_session(&secret_token).await.unwrap_err();
+
+    assert!(
+        matches!(err, Error::Request(RequestError::Server { status, .. }) if status == StatusCode::UNAUTHORIZED),
+        "restoring a revoked grant must fail with 401, got {err:?}"
+    );
+}
+
+#[tokio::test]
+#[pubky_testnet::test]
+async fn grant_secret_restore_rejects_expired_grant() {
+    const STORED_GRANT_CREDENTIAL_PREFIX: &str = "pubky-grant-credential-v1";
+
+    fn grant_secret_token(
+        grant_jws: String,
+        client_keypair: &Keypair,
+        homeserver_pk: &PublicKey,
+    ) -> String {
+        let client_secret = URL_SAFE_NO_PAD.encode(client_keypair.secret());
+        format!(
+            "{STORED_GRANT_CREDENTIAL_PREFIX}:{}:{client_secret}:{grant_jws}",
+            homeserver_pk.z32()
+        )
+    }
+
+    fn current_unix() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|duration| duration.as_secs())
+            .unwrap_or(0)
+    }
+
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+
+    let user_keypair = Keypair::random();
+    let signer = pubky.signer(user_keypair.clone());
+    signer.signup(&server.public_key(), None).await.unwrap();
+
+    let client_keypair = Keypair::random();
+    let now = current_unix();
+    let claims = GrantClaims {
+        iss: user_keypair.public_key(),
+        client_id: ClientId::new("expired-restore.test").unwrap(),
+        caps: vec![Capability::root()],
+        cnf: client_keypair.public_key(),
+        jti: GrantId::generate(),
+        iat: now.saturating_sub(120),
+        exp: now.saturating_sub(1),
+    };
+    let grant_jws = claims.sign(&user_keypair, GRANT_JWS_TYP);
+    let secret_token = grant_secret_token(grant_jws, &client_keypair, &server.public_key());
+
+    let err = pubky.restore_session(&secret_token).await.unwrap_err();
+
+    assert!(
+        matches!(err, Error::Authentication(_)) && err.to_string().contains("has expired"),
+        "restoring an expired grant must fail before minting a bearer, got {err:?}"
+    );
 }
 
 #[tokio::test]

--- a/pubky-sdk/src/actors/auth/grant/credential.rs
+++ b/pubky-sdk/src/actors/auth/grant/credential.rs
@@ -6,9 +6,11 @@
 //! and a fresh `PoP` proof.
 
 use std::any::Any;
+use std::fmt;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use pubky_common::{
     auth::{
         grant::GrantClaims,
@@ -22,6 +24,7 @@ use pubky_common::{
 use reqwest::{Method, RequestBuilder};
 use tokio::sync::Mutex;
 
+use super::grant_exchange::credential_from_grant_exchange;
 use crate::actors::session::core::PubkySession;
 use crate::actors::session::credential::{SessionCredential, credential_session_missing};
 use crate::{
@@ -29,12 +32,15 @@ use crate::{
     actors::session::SessionInfo,
     actors::storage::resource::resolve_pubky,
     cross_log,
-    errors::{RequestError, Result},
+    errors::{AuthError, RequestError, Result},
     util::check_http_status,
 };
 
 /// Refresh the bearer proactively when it has less than this many seconds left.
 pub(crate) const REFRESH_SLACK_SECS: u64 = 300;
+
+const STORED_GRANT_CREDENTIAL_PREFIX: &str = "pubky-grant-credential-v1";
+const STORED_GRANT_CREDENTIAL_PREFIX_FAMILY: &str = "pubky-grant-credential-";
 
 /// Current Unix timestamp in seconds, cross-target.
 pub(crate) fn now_unix() -> u64 {
@@ -82,6 +88,90 @@ pub struct GrantCredential {
     pub(crate) info: SessionInfo,
 }
 
+/// Durable refresh material for restoring a grant-backed session.
+///
+/// This is the part of [`GrantCredential`] that is worth persisting. It omits
+/// the short-lived bearer token and cached session metadata; restoring always
+/// exchanges the stored grant for a fresh bearer.
+///
+/// Treat values of this type as bearer-equivalent secrets until the underlying
+/// grant expires or is revoked.
+#[derive(Clone, PartialEq, Eq)]
+struct StoredGrantCredential {
+    /// User-signed grant JWS.
+    grant_jws: String,
+    /// Secret bytes for the `PoP` client keypair bound by the grant `cnf`.
+    client_key_secret: [u8; 32],
+    /// Homeserver public key used as the `PoP` audience.
+    homeserver_pk: PublicKey,
+}
+
+impl fmt::Debug for StoredGrantCredential {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("StoredGrantCredential")
+            .field("grant_jws", &"<redacted>")
+            .field("client_key_secret", &"<redacted>")
+            .field("homeserver_pk", &self.homeserver_pk)
+            .finish()
+    }
+}
+
+impl StoredGrantCredential {
+    /// Encode this credential as a compact token suitable for secure storage.
+    #[must_use]
+    fn encode(&self) -> String {
+        let secret = URL_SAFE_NO_PAD.encode(self.client_key_secret);
+        format!(
+            "{STORED_GRANT_CREDENTIAL_PREFIX}:{}:{secret}:{}",
+            self.homeserver_pk.z32(),
+            self.grant_jws
+        )
+    }
+
+    /// Decode a compact token produced by [`Self::encode`].
+    ///
+    /// # Errors
+    /// Returns validation errors when the token is malformed or contains an
+    /// unsupported version, invalid homeserver key, or invalid client secret.
+    fn decode(token: &str) -> Result<Self> {
+        // Manual decoding without serde to keep serde_json out of the required dependencies of the sdk to
+        // not unnecessarily bloat the lib.
+        let (prefix, rest) = token.split_once(':').ok_or_else(invalid_stored_grant)?;
+        if prefix != STORED_GRANT_CREDENTIAL_PREFIX {
+            return Err(RequestError::Validation {
+                message: "unsupported grant credential token version".into(),
+            }
+            .into());
+        }
+
+        let (homeserver, rest) = rest.split_once(':').ok_or_else(invalid_stored_grant)?;
+        let (secret, grant_jws) = rest.split_once(':').ok_or_else(invalid_stored_grant)?;
+        if grant_jws.is_empty() {
+            return Err(invalid_stored_grant().into());
+        }
+
+        let homeserver_pk =
+            PublicKey::try_from_z32(homeserver).map_err(|_err| RequestError::Validation {
+                message: "invalid stored grant credential homeserver public key".into(),
+            })?;
+        let secret = URL_SAFE_NO_PAD
+            .decode(secret)
+            .map_err(|_err| RequestError::Validation {
+                message: "invalid stored grant credential client secret".into(),
+            })?;
+        let client_key_secret =
+            <[u8; 32]>::try_from(secret.as_slice()).map_err(|_err| RequestError::Validation {
+                message: "stored grant credential client secret must be 32 bytes".into(),
+            })?;
+
+        Ok(Self {
+            grant_jws: grant_jws.to_string(),
+            client_key_secret,
+            homeserver_pk,
+        })
+    }
+}
+
 impl GrantCredential {
     /// Build a grant credential from a `GrantSessionResponse` returned by
     /// `POST /auth/grant/session` or `POST /auth/grant/signup`.
@@ -111,6 +201,48 @@ impl GrantCredential {
     /// Snapshot of the current bearer token (released immediately).
     pub(crate) async fn current_bearer(&self) -> String {
         self.state.lock().await.bearer.clone()
+    }
+
+    /// Export the durable refresh material needed to restore this credential.
+    ///
+    /// The returned token intentionally does not include the current bearer.
+    /// Restoring uses the grant + `PoP` key to mint a fresh bearer instead.
+    /// Treat it as a bearer-equivalent secret until the grant expires or is
+    /// revoked.
+    pub async fn export_secret(&self) -> String {
+        let state = self.state.lock().await;
+        StoredGrantCredential {
+            grant_jws: state.grant_jws.clone(),
+            client_key_secret: state.client_keypair.secret(),
+            homeserver_pk: state.homeserver_pk.clone(),
+        }
+        .encode()
+    }
+
+    pub(crate) fn is_secret_token(token: &str) -> bool {
+        token.starts_with(STORED_GRANT_CREDENTIAL_PREFIX_FAMILY)
+    }
+
+    /// Restore a grant credential from an exported secret token.
+    ///
+    /// This validates the token locally, then exchanges its grant and `PoP`
+    /// key with the homeserver for a fresh short-lived bearer.
+    ///
+    /// # Errors
+    /// - Returns validation errors for malformed tokens, expired grants, or
+    ///   mismatched `PoP` keys.
+    /// - Propagates HTTP/server errors from `POST /auth/grant/session`.
+    pub async fn import_secret(token: &str, client: &PubkyHttpClient) -> Result<Self> {
+        let saved = StoredGrantCredential::decode(token)?;
+        let (grant_jws, grant_claims, client_keypair, homeserver_pk) = restore_material(saved)?;
+        credential_from_grant_exchange(
+            client,
+            grant_jws,
+            grant_claims,
+            client_keypair,
+            homeserver_pk,
+        )
+        .await
     }
 
     /// Refresh the credential by exchanging the stored grant for a new bearer.
@@ -248,11 +380,61 @@ impl PubkySession {
     pub fn from_grant_credential(client: PubkyHttpClient, credential: GrantCredential) -> Self {
         Self::from_credential(client, Arc::new(credential))
     }
+
+    /// Restore a grant-backed [`PubkySession`] from an exported secret token.
+    ///
+    /// This mints a fresh bearer from the token's grant and `PoP` key instead
+    /// of replaying an old short-lived bearer. The token should come from
+    /// [`GrantSessionView::export_secret`](crate::GrantSessionView::export_secret)
+    /// or [`GrantCredential::export_secret`].
+    ///
+    /// # Errors
+    /// - See [`GrantCredential::import_secret`].
+    pub async fn import_grant_secret(token: &str, client: Option<PubkyHttpClient>) -> Result<Self> {
+        let client = match client {
+            Some(client) => client,
+            None => PubkyHttpClient::new()?,
+        };
+        let credential = GrantCredential::import_secret(token, &client).await?;
+        Ok(Self::from_grant_credential(client, credential))
+    }
 }
 
 /// Build a minimal [`SessionInfo`] from a [`GrantSessionInfo`].
 fn to_session_info(session: &GrantSessionInfo) -> SessionInfo {
     SessionInfo::new(session.pubky.clone(), session.capabilities.clone())
+}
+
+fn restore_material(
+    saved: StoredGrantCredential,
+) -> Result<(String, GrantClaims, Keypair, PublicKey)> {
+    let grant_claims = GrantClaims::decode(&saved.grant_jws).map_err(|err| {
+        AuthError::Validation(format!("invalid stored grant credential grant JWS: {err}"))
+    })?;
+    if grant_claims.exp <= now_unix() {
+        return Err(AuthError::Validation("stored grant credential has expired".into()).into());
+    }
+
+    let client_keypair = Keypair::from_secret(&saved.client_key_secret);
+    if client_keypair.public_key() != grant_claims.cnf {
+        return Err(AuthError::Validation(
+            "stored grant credential client key does not match the grant cnf".into(),
+        )
+        .into());
+    }
+
+    Ok((
+        saved.grant_jws,
+        grant_claims,
+        client_keypair,
+        saved.homeserver_pk,
+    ))
+}
+
+fn invalid_stored_grant() -> AuthError {
+    AuthError::Validation(format!(
+        "invalid stored grant credential: expected `{STORED_GRANT_CREDENTIAL_PREFIX}:<homeserver>:<client_secret>:<grant_jws>`"
+    ))
 }
 
 /// Sign a Proof-of-Possession proof JWS for a given grant.
@@ -272,4 +454,74 @@ pub(crate) fn sign_pop_for_grant(
         iat: now_unix(),
     };
     pubky_common::auth::jws::sign_jws(client_keypair, POP_JWS_TYP, &claims)
+}
+
+#[cfg(test)]
+mod tests {
+    use pubky_common::{
+        auth::jws::{ClientId, GRANT_JWS_TYP, GrantId},
+        capabilities::Capability,
+    };
+
+    use super::*;
+
+    #[test]
+    fn stored_grant_credential_encode_decode_round_trips() {
+        let (stored, _claims) = stored_credential(now_unix() + 3600);
+
+        let encoded = stored.encode();
+        let decoded = StoredGrantCredential::decode(&encoded).unwrap();
+
+        assert_eq!(decoded, stored);
+    }
+
+    #[test]
+    fn restore_material_rejects_mismatched_client_key() {
+        let (mut stored, _claims) = stored_credential(now_unix() + 3600);
+        stored.client_key_secret = Keypair::random().secret();
+
+        let error = restore_material(stored).unwrap_err().to_string();
+
+        assert!(error.contains("client key does not match"));
+    }
+
+    #[test]
+    fn restore_material_rejects_expired_grant() {
+        let (stored, _claims) = stored_credential(now_unix().saturating_sub(1));
+
+        let error = restore_material(stored).unwrap_err().to_string();
+
+        assert!(error.contains("has expired"));
+    }
+
+    #[test]
+    fn stored_grant_credential_decode_rejects_wrong_prefix() {
+        let error = StoredGrantCredential::decode("wrong:v:secret:grant")
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("unsupported grant credential token version"));
+    }
+
+    fn stored_credential(exp: u64) -> (StoredGrantCredential, GrantClaims) {
+        let user_keypair = Keypair::random();
+        let client_keypair = Keypair::random();
+        let homeserver_keypair = Keypair::random();
+        let claims = GrantClaims {
+            iss: user_keypair.public_key(),
+            client_id: ClientId::new("stored-grant.test").unwrap(),
+            caps: vec![Capability::root()],
+            cnf: client_keypair.public_key(),
+            jti: GrantId::generate(),
+            iat: now_unix(),
+            exp,
+        };
+        let grant_jws = claims.sign(&user_keypair, GRANT_JWS_TYP);
+        let stored = StoredGrantCredential {
+            grant_jws,
+            client_key_secret: client_keypair.secret(),
+            homeserver_pk: homeserver_keypair.public_key(),
+        };
+        (stored, claims)
+    }
 }

--- a/pubky-sdk/src/actors/auth/grant/view.rs
+++ b/pubky-sdk/src/actors/auth/grant/view.rs
@@ -11,7 +11,7 @@ use pubky_common::auth::{
 };
 use reqwest::Method;
 
-use super::credential::GrantCredential;
+use super::GrantCredential;
 use crate::actors::session::core::PubkySession;
 use crate::actors::storage::resource::resolve_pubky;
 use crate::errors::{RequestError, Result};
@@ -54,6 +54,14 @@ impl<'a> GrantSessionView<'a> {
     /// accessor.
     pub async fn session_info(&self) -> GrantSessionInfo {
         self.credential.state.lock().await.session.clone()
+    }
+
+    /// Export the durable refresh material needed to restore this session.
+    ///
+    /// The returned token contains the grant JWS and `PoP` client secret. Treat
+    /// it as a bearer-equivalent secret until the grant expires or is revoked.
+    pub async fn export_secret(&self) -> String {
+        self.credential.export_secret().await
     }
 
     /// List all active grants for this user.

--- a/pubky-sdk/src/pubky.rs
+++ b/pubky-sdk/src/pubky.rs
@@ -322,7 +322,7 @@ impl Pubky {
     /// - Propagates transport/server errors while validating or restoring the session.
     pub async fn restore_session(&self, token: &str) -> Result<PubkySession> {
         if GrantCredential::is_secret_token(token) {
-            return PubkySession::import_grant_secret(token, Some(self.client.clone())).await
+            return PubkySession::import_grant_secret(token, Some(self.client.clone())).await;
         }
 
         PubkySession::import_secret(token, Some(self.client.clone())).await

--- a/pubky-sdk/src/pubky.rs
+++ b/pubky-sdk/src/pubky.rs
@@ -57,13 +57,13 @@ use crate::PublicKey;
 #[allow(deprecated, reason = "Internal use of deprecated public API")]
 use crate::PubkyCookieAuthFlow;
 use crate::{
-    Capabilities, ClientId, EventCursor, EventStreamBuilder, Pkdns, PubkyGrantAuthFlow,
-    PubkyHttpClient, PubkySigner, PublicStorage, Result, actors::AuthFlowKind,
-    deep_links::DeepLink, errors::AuthError,
+    Capabilities, ClientId, EventCursor, EventStreamBuilder, GrantCredential, Pkdns,
+    PubkyGrantAuthFlow, PubkyHttpClient, PubkySession, PubkySigner, PublicStorage, Result,
+    actors::AuthFlowKind, deep_links::DeepLink, errors::AuthError,
 };
 
 #[cfg(not(target_arch = "wasm32"))]
-use crate::{PubkySession, errors::RequestError};
+use crate::errors::RequestError;
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::Path;
 
@@ -302,6 +302,30 @@ impl Pubky {
     #[cfg(not(target_arch = "wasm32"))]
     pub async fn session_from_file<P: AsRef<Path>>(&self, path: P) -> Result<PubkySession> {
         PubkySession::from_secret_file(path.as_ref(), Some(self.client.clone())).await
+    }
+
+    /// Restore a session from an exported session secret token.
+    ///
+    /// Accepts both legacy cookie session tokens from
+    /// [`CookieSessionView::export_secret`](crate::CookieSessionView::export_secret)
+    /// and grant session tokens from
+    /// [`GrantSessionView::export_secret`](crate::GrantSessionView::export_secret).
+    /// Grant restore mints a fresh short-lived bearer; cookie restore revalidates
+    /// the stored cookie secret.
+    ///
+    /// # Errors
+    /// - Returns [`crate::errors::RequestError::Validation`] when the token is malformed.
+    /// - Returns [`crate::errors::AuthError::RequestExpired`] when a stored cookie
+    ///   session is no longer valid.
+    /// - Returns [`crate::errors::Error::Authentication`] when a stored grant is
+    ///   expired or its stored `PoP` key does not match the grant.
+    /// - Propagates transport/server errors while validating or restoring the session.
+    pub async fn restore_session(&self, token: &str) -> Result<PubkySession> {
+        if GrantCredential::is_secret_token(token) {
+            return PubkySession::import_grant_secret(token, Some(self.client.clone())).await
+        }
+
+        PubkySession::import_secret(token, Some(self.client.clone())).await
     }
 
     /// Recover a keypair from an encrypted `.pkarr` secret file and return a [`PubkySigner`].


### PR DESCRIPTION
Adds the ability to save a grant session by exporting a string token and restore a grant session by importing it again.

```rust
let secret_token = session.as_grant().unwrap().export_secret().await;
let restored = pubky.restore_session(&secret_token).await.unwrap();
```

`pubky.restore_session` is a general facade method that takes either a grant token or a cookie token to restore a session.