### PR TITLE
refactor(sdk): Extract grant management from session to GrantManager

### DIFF
--- a/e2e/src/tests/auth/grant.rs
+++ b/e2e/src/tests/auth/grant.rs
@@ -154,13 +154,7 @@ async fn grant_secret_restore_rejects_revoked_grant() {
         .unwrap();
 
     let secret_token = session.as_grant().unwrap().export_secret().await;
-    let grant_id = session.as_grant().unwrap().grant_id().await;
-    session
-        .as_grant()
-        .unwrap()
-        .revoke_grant(&grant_id)
-        .await
-        .unwrap();
+    session.signout().await.unwrap();
 
     let err = pubky.restore_session(&secret_token).await.unwrap_err();
 
@@ -343,7 +337,7 @@ async fn signout_revokes_current_grant_only() {
         .unwrap();
 
     // Both sessions should appear in the root session's grant list.
-    let grants_before = session_a.as_grant().unwrap().list_grants().await.unwrap();
+    let grants_before = GrantManager::new(&session_a).list().await.unwrap();
     assert!(
         grants_before.len() >= 2,
         "expected at least 2 grants, got {}",
@@ -361,10 +355,10 @@ async fn signout_revokes_current_grant_only() {
         .unwrap();
 
     // The revoked grant no longer shows up in the active list.
-    let grants_after = session_a.as_grant().unwrap().list_grants().await.unwrap();
+    let grants_after = GrantManager::new(&session_a).list().await.unwrap();
     assert!(
         grants_after.len() < grants_before.len(),
-        "signout should drop the revoked grant from list_grants()"
+        "signout should drop the revoked grant from GrantManager::list()"
     );
 }
 
@@ -485,7 +479,7 @@ async fn disabled_user() {
 
 #[tokio::test]
 #[pubky_testnet::test]
-async fn non_root_session_can_list_revoke_grants() {
+async fn non_root_session_cannot_list_revoke_grants() {
     let testnet = build_full_testnet().await;
     let server = testnet.homeserver_app();
     let pubky = testnet.sdk().unwrap();
@@ -533,24 +527,17 @@ async fn non_root_session_can_list_revoke_grants() {
         .unwrap_err();
 
     // Non-root sessions cannot enumerate grants — homeserver returns 403.
-    let err = scoped_session
-        .as_grant()
-        .unwrap()
-        .list_grants()
-        .await
-        .unwrap_err();
+    let err = GrantManager::new(&scoped_session).list().await.unwrap_err();
     assert!(
         matches!(err, Error::Request(RequestError::Server { status, .. }) if status == StatusCode::FORBIDDEN),
-        "non-root list_grants must be forbidden, got {err:?}"
+        "non-root GrantManager::list must be forbidden, got {err:?}"
     );
 
     let root_grant_id = root_session.as_grant().unwrap().grant_id().await;
 
     // Scoped session cannot revoke root grant — homeserver returns 403.
-    scoped_session
-        .as_grant()
-        .unwrap()
-        .revoke_grant(&root_grant_id)
+    GrantManager::new(&scoped_session)
+        .revoke(&root_grant_id)
         .await
         .unwrap_err();
 }
@@ -591,12 +578,7 @@ async fn root_session_can_list_and_revoke_scoped_grant() {
     let scoped_session = auth.await_approval().await.unwrap();
 
     // Root can list grants — both sessions appear.
-    let grants = root_session
-        .as_grant()
-        .unwrap()
-        .list_grants()
-        .await
-        .unwrap();
+    let grants = GrantManager::new(&root_session).list().await.unwrap();
     assert!(
         grants.len() >= 2,
         "expected ≥2 grants, got {}",
@@ -610,10 +592,8 @@ async fn root_session_can_list_and_revoke_scoped_grant() {
     );
 
     // Root revokes the scoped grant.
-    root_session
-        .as_grant()
-        .unwrap()
-        .revoke_grant(&scoped_gid)
+    GrantManager::new(&root_session)
+        .revoke(&scoped_gid)
         .await
         .unwrap();
 
@@ -648,12 +628,7 @@ async fn root_session_can_list_and_revoke_scoped_grant() {
         .unwrap();
 
     // List shows only one grant now.
-    let grants_after = root_session
-        .as_grant()
-        .unwrap()
-        .list_grants()
-        .await
-        .unwrap();
+    let grants_after = GrantManager::new(&root_session).list().await.unwrap();
     assert!(
         grants_after.len() < grants.len(),
         "expected fewer grants after revocation, got {}",

--- a/e2e/src/tests/auth/mod.rs
+++ b/e2e/src/tests/auth/mod.rs
@@ -10,8 +10,8 @@ use pubky_testnet::pubky::IntoPubkyResource;
 #[allow(deprecated, reason = "E2E tests cover the deprecated cookie flow")]
 use pubky_testnet::pubky::PubkyCookieAuthFlow;
 use pubky_testnet::pubky::{
-    AuthFlowKind, ClientId, Keypair, Method, PubkyGrantAuthFlow, PubkyHttpClient, PubkySession,
-    StatusCode,
+    AuthFlowKind, ClientId, GrantManager, Keypair, Method, PubkyGrantAuthFlow, PubkyHttpClient,
+    PubkySession, StatusCode,
 };
 use pubky_testnet::pubky_common::capabilities::{Capabilities, Capability};
 use pubky_testnet::{

--- a/pubky-sdk/README.md
+++ b/pubky-sdk/README.md
@@ -81,6 +81,7 @@ Use a shared `Pubky` (via cloning it, passing down as argument or behind `OnceCe
 - `Pubky` - facade, always start here! Owns the transport and constructs actors.
 - `PubkySigner` - local key holder. Can `signup`, `signin`, approve QR auth, publish PKDNS.
 - `PubkySession` - authenticated “as me” handle. Exposes session-scoped storage.
+- `GrantManager` - account-level grant listing and revocation using an authenticated root session.
 - `PublicStorage` - unauthenticated reads of others’ public data.
 - `Pkdns` - resolve/publish `_pubky` records.
 

--- a/pubky-sdk/bindings/js/pkg/tests/session.ts
+++ b/pubky-sdk/bindings/js/pkg/tests/session.ts
@@ -4,6 +4,7 @@ import {
   AuthFlowKind,
   CookieSession,
   GrantInfo,
+  GrantManager,
   GrantSession,
   GrantSessionInfo,
   Keypair,
@@ -51,8 +52,8 @@ type _SessionCookie = Assert<
 type _GrantSessionInfo = Assert<
   IsExact<ReturnType<GrantSession["sessionInfo"]>, Promise<GrantSessionInfo>>
 >;
-type _GrantListGrants = Assert<
-  IsExact<ReturnType<GrantSession["listGrants"]>, Promise<GrantInfo[]>>
+type _GrantManagerList = Assert<
+  IsExact<ReturnType<GrantManager["list"]>, Promise<GrantInfo[]>>
 >;
 type _CookieExportSecret = Assert<
   IsExact<ReturnType<CookieSession["exportSecret"]>, Promise<string>>
@@ -143,7 +144,7 @@ test("Session: cookie exportSecret restores from secret token", async (t) => {
   t.end();
 });
 
-test("Session: grant-only view exposes grant metadata and management", async (t) => {
+test("Session: grant-only view exposes metadata; GrantManager manages grants", async (t) => {
   const sdk = Pubky.testnet();
   const signer = sdk.signer(Keypair.random());
   const signupToken = await createSignupToken();
@@ -190,13 +191,14 @@ test("Session: grant-only view exposes grant metadata and management", async (t)
     "restored grant keeps identity",
   );
 
-  const grants = await restoredGrant.listGrants();
+  const grantManager = new GrantManager(restored);
+  const grants = await grantManager.list();
   t.ok(
     grants.some((entry) => entry.grantId === info.grantId && entry.clientId === clientId),
-    "listGrants includes the active grant",
+    "GrantManager.list includes the active grant",
   );
 
-  await restoredGrant.revokeGrant(info.grantId);
+  await grantManager.revoke(info.grantId);
   try {
     await sdk.restoreSession(exported);
     t.fail("restoring a revoked grant should fail");
@@ -251,23 +253,24 @@ test("Session: non-root grant management calls return homeserver 403", async (t)
   }
 
   const info = await grant.sessionInfo();
+  const grantManager = new GrantManager(session);
 
   try {
-    await grant.listGrants();
-    t.fail("non-root listGrants should fail");
+    await grantManager.list();
+    t.fail("non-root GrantManager.list should fail");
   } catch (error) {
-    assertPubkyError(t, error, "listGrants throws PubkyError");
-    t.equal(error.name, "RequestError", "listGrants maps to RequestError");
-    t.equal(getStatusCode(error), 403, "listGrants status code is 403");
+    assertPubkyError(t, error, "GrantManager.list throws PubkyError");
+    t.equal(error.name, "RequestError", "GrantManager.list maps to RequestError");
+    t.equal(getStatusCode(error), 403, "GrantManager.list status code is 403");
   }
 
   try {
-    await grant.revokeGrant(info.grantId);
-    t.fail("non-root revokeGrant should fail");
+    await grantManager.revoke(info.grantId);
+    t.fail("non-root GrantManager.revoke should fail");
   } catch (error) {
-    assertPubkyError(t, error, "revokeGrant throws PubkyError");
-    t.equal(error.name, "RequestError", "revokeGrant maps to RequestError");
-    t.equal(getStatusCode(error), 403, "revokeGrant status code is 403");
+    assertPubkyError(t, error, "GrantManager.revoke throws PubkyError");
+    t.equal(error.name, "RequestError", "GrantManager.revoke maps to RequestError");
+    t.equal(getStatusCode(error), 403, "GrantManager.revoke status code is 403");
   }
 
   t.end();
@@ -289,7 +292,7 @@ test("Session: invalid grant id throws InvalidInput", async (t) => {
   }
 
   try {
-    await grant.revokeGrant("");
+    await new GrantManager(session).revoke("");
     t.fail("empty grant id should fail");
   } catch (error) {
     assertPubkyError(t, error, "invalid grant id throws PubkyError");

--- a/pubky-sdk/bindings/js/src/actors/grant_manager.rs
+++ b/pubky-sdk/bindings/js/src/actors/grant_manager.rs
@@ -1,0 +1,51 @@
+use wasm_bindgen::prelude::*;
+
+use super::{grant_session::GrantInfo, session::Session};
+use crate::js_error::{JsResult, PubkyError, PubkyErrorName};
+use pubky_common::auth::jws::GrantId;
+
+/// Account-level grant management for a signed-in user.
+#[wasm_bindgen]
+pub struct GrantManager(pub(crate) pubky::GrantManager);
+
+#[wasm_bindgen]
+impl GrantManager {
+    /// Create a grant manager authenticated by a session.
+    ///
+    /// @param {Session} session
+    /// @returns {GrantManager}
+    #[wasm_bindgen(constructor)]
+    pub fn new(session: &Session) -> Self {
+        Self(pubky::GrantManager::new(&session.0))
+    }
+
+    /// List all active grants for this user.
+    ///
+    /// Requires a root-capability session. Non-root sessions surface the
+    /// homeserver `403` as the standard request error.
+    ///
+    /// @returns {Promise<GrantInfo[]>}
+    #[wasm_bindgen]
+    pub async fn list(&self) -> JsResult<Vec<GrantInfo>> {
+        Ok(self.0.list().await?.into_iter().map(GrantInfo).collect())
+    }
+
+    /// Revoke a specific grant by id.
+    ///
+    /// Requires a root-capability session. Malformed ids throw
+    /// `InvalidInput`.
+    ///
+    /// @param {string} grantId
+    /// @returns {Promise<void>}
+    #[wasm_bindgen]
+    pub async fn revoke(&self, grant_id: String) -> JsResult<()> {
+        let grant_id = GrantId::parse(&grant_id).map_err(|e| {
+            PubkyError::new(
+                PubkyErrorName::InvalidInput,
+                format!("Invalid grant id: {e}"),
+            )
+        })?;
+        self.0.revoke(&grant_id).await?;
+        Ok(())
+    }
+}

--- a/pubky-sdk/bindings/js/src/actors/grant_session.rs
+++ b/pubky-sdk/bindings/js/src/actors/grant_session.rs
@@ -2,12 +2,11 @@ use wasm_bindgen::prelude::*;
 
 use crate::js_error::{JsResult, PubkyError, PubkyErrorName};
 use crate::wrappers::keys::PublicKey;
-use pubky_common::auth::jws::GrantId;
 
 /// Grant-only view over a grant-backed `Session`.
 ///
 /// Cookie-backed sessions do not expose this view; use `session.grant` and
-/// check for `undefined` before calling grant management methods.
+/// check for `undefined` before calling grant-session methods.
 #[wasm_bindgen]
 pub struct GrantSession(pub(crate) pubky::PubkySession);
 
@@ -29,43 +28,6 @@ impl GrantSession {
     pub async fn grant_id(&self) -> JsResult<String> {
         let grant = self.as_grant()?;
         Ok(grant.grant_id().await.to_string())
-    }
-
-    /// List all active grants for this user.
-    ///
-    /// Requires a root-capability grant session. Non-root sessions surface the
-    /// homeserver `403` as the standard request error.
-    ///
-    /// @returns {Promise<GrantInfo[]>}
-    #[wasm_bindgen(js_name = "listGrants")]
-    pub async fn list_grants(&self) -> JsResult<Vec<GrantInfo>> {
-        let grant = self.as_grant()?;
-        Ok(grant
-            .list_grants()
-            .await?
-            .into_iter()
-            .map(GrantInfo)
-            .collect())
-    }
-
-    /// Revoke a specific grant by id.
-    ///
-    /// Requires a root-capability grant session. Malformed ids throw
-    /// `InvalidInput`.
-    ///
-    /// @param {string} grantId
-    /// @returns {Promise<void>}
-    #[wasm_bindgen(js_name = "revokeGrant")]
-    pub async fn revoke_grant(&self, grant_id: String) -> JsResult<()> {
-        let grant_id = GrantId::parse(&grant_id).map_err(|e| {
-            PubkyError::new(
-                PubkyErrorName::InvalidInput,
-                format!("Invalid grant id: {e}"),
-            )
-        })?;
-        let grant = self.as_grant()?;
-        grant.revoke_grant(&grant_id).await?;
-        Ok(())
     }
 
     /// Export the durable refresh material needed to restore this grant session.
@@ -92,7 +54,7 @@ impl GrantSession {
     }
 }
 
-/// Summary of an active grant returned by `grant.listGrants()`.
+/// Summary of an active grant returned by `GrantManager.list()`.
 #[wasm_bindgen]
 pub struct GrantInfo(pub(crate) pubky_common::auth::grant_session_responses::GrantInfo);
 

--- a/pubky-sdk/bindings/js/src/actors/mod.rs
+++ b/pubky-sdk/bindings/js/src/actors/mod.rs
@@ -3,6 +3,7 @@ pub mod cookie_session;
 pub mod deep_links;
 pub mod event_stream;
 pub mod grant_auth_flow;
+pub mod grant_manager;
 pub mod grant_session;
 mod in_flight;
 pub mod pkdns;

--- a/pubky-sdk/src/actors/auth/grant/grant_exchange.rs
+++ b/pubky-sdk/src/actors/auth/grant/grant_exchange.rs
@@ -6,11 +6,8 @@
 //! - [`signup_account_from_grant`] creates a user via grant + `PoP` without
 //!   minting a session.
 //!
-//! All grant-management operations (`list_grants`, `revoke_grant`,
-//! `current_bearer`, `force_refresh`, `grant_id`) live on
-//! [`super::view::GrantSessionView`] — they are reachable via
-//! [`PubkySession::as_grant`](crate::actors::session::core::PubkySession::as_grant)
-//! and only compile when the credential is grant-based.
+//! Current grant-session operations (`current_bearer`, `force_refresh`,
+//! `grant_id`) live on [`super::view::GrantSessionView`].
 
 use pubky_common::{
     auth::{grant::GrantClaims, grant_session_responses::GrantSessionResponse},

--- a/pubky-sdk/src/actors/auth/grant/manager.rs
+++ b/pubky-sdk/src/actors/auth/grant/manager.rs
@@ -1,0 +1,89 @@
+//! Account-level grant management.
+//!
+//! [`GrantManager`] is authenticated by a [`PubkySession`], but is not tied to
+//! grant-backed sessions. The homeserver decides whether the session has the
+//! root capability required to list and revoke grants.
+
+use pubky_common::auth::{grant_session_responses::GrantInfo, jws::GrantId};
+use pubky_common::crypto::PublicKey;
+use reqwest::Method;
+use std::sync::Arc;
+
+use crate::actors::session::credential::SessionCredential;
+use crate::actors::storage::resource::resolve_pubky;
+use crate::errors::{RequestError, Result};
+use crate::util::check_http_status;
+use crate::{PubkyHttpClient, PubkySession};
+
+/// Account-level grant management for a signed-in user.
+/// Requires a session with the root capability; non-root sessions get `403
+/// Forbidden` from the homeserver.
+#[derive(Debug, Clone)]
+pub struct GrantManager {
+    client: PubkyHttpClient,
+    user: PublicKey,
+    credential: Arc<dyn SessionCredential>,
+}
+
+impl GrantManager {
+    /// Construct a grant manager authenticated by `session`.
+    #[must_use]
+    pub fn new(session: &PubkySession) -> Self {
+        Self {
+            client: session.client().clone(),
+            user: session.info().public_key().clone(),
+            credential: Arc::clone(session.credential()),
+        }
+    }
+
+    /// List all active grants for this user.
+    ///
+    /// Calls `GET /auth/grant/sessions`. Requires a root-capability session;
+    /// non-root sessions get `403 Forbidden` from the homeserver.
+    ///
+    /// # Errors
+    /// - Propagates HTTP errors from the homeserver (`401`/`403` for invalid
+    ///   auth or missing root capability).
+    pub async fn list(&self) -> Result<Vec<GrantInfo>> {
+        let url = format!("pubky://{}/auth/grant/sessions", self.user.z32());
+        let resolved = resolve_pubky(&url)?;
+        let rb = self.client.cross_request(Method::GET, resolved).await?;
+        let resp = self
+            .credential
+            .attach(rb, &self.client)
+            .await?
+            .send()
+            .await?;
+        let resp = check_http_status(resp).await?;
+        let grants: Vec<GrantInfo> = resp.json().await.map_err(|e| RequestError::DecodeJson {
+            message: format!("decoding /auth/grant/sessions response: {e}"),
+        })?;
+        Ok(grants)
+    }
+
+    /// Revoke a specific grant by id, killing all of its sessions.
+    ///
+    /// Calls `DELETE /auth/grant/session/{gid}`. Requires a root-capability
+    /// session.
+    ///
+    /// # Errors
+    /// - Propagates HTTP errors from the homeserver (`401`/`403` for invalid
+    ///   auth or missing root capability).
+    pub async fn revoke(&self, grant_id: &GrantId) -> Result<()> {
+        let url = format!(
+            "pubky://{}/auth/grant/session/{}",
+            self.user.z32(),
+            grant_id.as_str()
+        );
+        let resolved = resolve_pubky(&url)?;
+        let rb = self.client.cross_request(Method::DELETE, resolved).await?;
+        let resp = self
+            .credential
+            .attach(rb, &self.client)
+            .await?
+            .send()
+            .await?;
+        check_http_status(resp).await?;
+        Ok(())
+    }
+}

--- a/pubky-sdk/src/actors/auth/grant/mod.rs
+++ b/pubky-sdk/src/actors/auth/grant/mod.rs
@@ -10,8 +10,10 @@ pub(crate) mod constants;
 pub(crate) mod credential;
 pub(crate) mod flow;
 pub(crate) mod grant_exchange;
+pub mod manager;
 pub mod view;
 
 pub use credential::GrantCredential;
 pub use flow::{GrantAuthFlowState, PubkyGrantAuthFlow};
+pub use manager::GrantManager;
 pub use view::GrantSessionView;

--- a/pubky-sdk/src/actors/auth/grant/view.rs
+++ b/pubky-sdk/src/actors/auth/grant/view.rs
@@ -5,17 +5,11 @@
 //! The view borrows the session, so it cannot outlive it; this is what makes
 //! the grant-only API impossible to misuse against a cookie session.
 
-use pubky_common::auth::{
-    grant_session_responses::{GrantInfo, GrantSessionInfo},
-    jws::GrantId,
-};
-use reqwest::Method;
+use pubky_common::auth::{grant_session_responses::GrantSessionInfo, jws::GrantId};
 
 use super::GrantCredential;
 use crate::actors::session::core::PubkySession;
-use crate::actors::storage::resource::resolve_pubky;
-use crate::errors::{RequestError, Result};
-use crate::util::check_http_status;
+use crate::errors::Result;
 
 /// grant-only operations on a [`PubkySession`].
 #[derive(Debug)]
@@ -27,9 +21,9 @@ pub struct GrantSessionView<'a> {
 impl PubkySession {
     /// Returns a [`GrantSessionView`] if this session is grant-backed.
     ///
-    /// grant-only operations (`list_grants`, `revoke_grant`, `current_bearer`,
-    /// `force_refresh`, `grant_id`) live on the view. Cookie-backed sessions
-    /// return `None`.
+    /// grant-only operations (`session_info`, `export_secret`,
+    /// `current_bearer`, `force_refresh`, `grant_id`) live on the view.
+    /// Cookie-backed sessions return `None`.
     #[must_use]
     pub fn as_grant(&self) -> Option<GrantSessionView<'_>> {
         self.try_downcast_credential::<GrantCredential>()
@@ -62,68 +56,6 @@ impl<'a> GrantSessionView<'a> {
     /// it as a bearer-equivalent secret until the grant expires or is revoked.
     pub async fn export_secret(&self) -> String {
         self.credential.export_secret().await
-    }
-
-    /// List all active grants for this user.
-    ///
-    /// Calls `GET /auth/grant/sessions`. Requires the underlying session to
-    /// have the **root** capability — non-root sessions get `403 Forbidden`
-    /// from the homeserver.
-    ///
-    /// # Errors
-    /// - Propagates HTTP errors from the homeserver (`401`/`403` for invalid
-    ///   auth or missing root capability).
-    pub async fn list_grants(&self) -> Result<Vec<GrantInfo>> {
-        let (user, bearer) = {
-            let g = self.credential.state.lock().await;
-            (g.grant_claims.iss.clone(), g.bearer.clone())
-        };
-        let url = format!("pubky://{}/auth/grant/sessions", user.z32());
-        let resolved = resolve_pubky(&url)?;
-        let resp = self
-            .session
-            .client()
-            .cross_request(Method::GET, resolved)
-            .await?
-            .bearer_auth(&bearer)
-            .send()
-            .await?;
-        let resp = check_http_status(resp).await?;
-        let grants: Vec<GrantInfo> = resp.json().await.map_err(|e| RequestError::DecodeJson {
-            message: format!("decoding /auth/grant/sessions response: {e}"),
-        })?;
-        Ok(grants)
-    }
-
-    /// Revoke a specific grant by id, killing all of its sessions.
-    ///
-    /// Calls `DELETE /auth/grant/session/{gid}`. Requires the **root**
-    /// capability on this session.
-    ///
-    /// # Errors
-    /// - Propagates HTTP errors from the homeserver (`401`/`403` for invalid
-    ///   auth or missing root capability).
-    pub async fn revoke_grant(&self, grant_id: &GrantId) -> Result<()> {
-        let (user, bearer) = {
-            let g = self.credential.state.lock().await;
-            (g.grant_claims.iss.clone(), g.bearer.clone())
-        };
-        let url = format!(
-            "pubky://{}/auth/grant/session/{}",
-            user.z32(),
-            grant_id.as_str()
-        );
-        let resolved = resolve_pubky(&url)?;
-        let resp = self
-            .session
-            .client()
-            .cross_request(Method::DELETE, resolved)
-            .await?
-            .bearer_auth(&bearer)
-            .send()
-            .await?;
-        check_http_status(resp).await?;
-        Ok(())
     }
 
     /// Returns the current opaque bearer for this session.

--- a/pubky-sdk/src/actors/mod.rs
+++ b/pubky-sdk/src/actors/mod.rs
@@ -11,7 +11,7 @@ pub use auth::cookie::PubkyCookieAuthFlow;
 pub use auth::cookie::{CookieCredential, CookieSessionView};
 pub use auth::deep_links;
 pub use auth::grant::{GrantAuthFlowState, PubkyGrantAuthFlow};
-pub use auth::grant::{GrantCredential, GrantSessionView};
+pub use auth::grant::{GrantCredential, GrantManager, GrantSessionView};
 pub use auth::relay::http_relay_inbox_channel::{
     DEFAULT_HTTP_RELAY_INBOX, EncryptedHttpRelayInboxChannel, HttpRelayInboxChannel,
 };

--- a/pubky-sdk/src/lib.rs
+++ b/pubky-sdk/src/lib.rs
@@ -45,7 +45,9 @@ pub use actors::SessionInfo;
 #[doc(inline)]
 pub use actors::deep_links;
 #[doc(inline)]
-pub use actors::{CookieCredential, CookieSessionView, GrantCredential, GrantSessionView};
+pub use actors::{
+    CookieCredential, CookieSessionView, GrantCredential, GrantManager, GrantSessionView,
+};
 #[doc(inline)]
 pub use actors::{Event, EventCursor, EventStreamBuilder, EventType};
 #[doc(inline)]


### PR DESCRIPTION
Refactors grant management out of grant-backed session views and into a dedicated `GrantManager` API for both Rust and JS SDKs.

Grant/session-specific APIs remain on `GrantSessionView / session.grant`, while account-level grant listing and revocation now live on GrantManager.

## Changes

- Adds Rust `GrantManager::new(&session)` with:
    - list()
    - revoke(&grant_id)
- Adds JS `new GrantManager(session)` with:
    - list()
    - revoke(grantId)
- Removes grant listing/revocation from:
    - Rust GrantSessionView
    - JS GrantSession
- Keeps session.signout() as the current-session revocation path.
- Updates Rust e2e and JS package tests to use GrantManager.
- Updates SDK docs/comments to clarify that session.grant is for grant-session metadata/secret export, not account-level grant management.

## API Impact

Before:

```
session.as_grant().unwrap().list_grants().await?;
session.as_grant().unwrap().revoke_grant(&grant_id).await?;
```

After:

```
let manager = GrantManager::new(&session);
manager.list().await?;
manager.revoke(&grant_id).await?;
```

Before:

```
await session.grant?.listGrants();
await session.grant?.revokeGrant(grantId);
```

After:

```
const grants = new GrantManager(session);
await grants.list();
await grants.revoke(grantId);
```