### PR TITLE
chore(deps): separate library dependency ranges

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4148,7 +4148,7 @@ dependencies = [
  "prometheus",
  "pubky-common",
  "pubky_test_utils",
- "rand 0.9.4",
+ "rand 0.10.1",
  "reqwest 0.13.4",
  "sea-query",
  "sea-query-binder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,25 +37,24 @@ opt-level = 'z'
 
 
 [workspace.dependencies]
-# Setting "default-features = false" because cargo doesn't allow member crates to override the root "default-features" flag, which if not set, is implied to be true.
-# Member crates that need "default-features = false" should leave it out of their dependency specification, as it's inherited from here.
-# Member crates that need "default-features = true" should add a "default" feature to the features list, which is equivalent.
-pkarr = { version = "6.0.1", default-features = false }
-mainline = { version = "6.2.0" }
+anyhow = "1"
+axum = "0.8"
+axum-server = "0.8"
+clap = "4"
+http-relay = "0.7"
+log = "0.4"
+mainline = { version = "6" }
+pkarr = { version = "6", default-features = false }
 pkarr-relay = { version = "0.12" }
-log = "0.4.30"
-url = "2.5.8"
-anyhow = "1.0.101"
-axum = "0.8.8"
-axum-server = "0.8.0"
-reqwest = { version = "0.13.4", default-features = false }
-tracing = "0.1.44"
-tracing-subscriber = "0.3.23"
-tokio = "1.52.3"
-tower-http = "0.6.11"
-thiserror = "2.0.18"
-clap = "4.6.0"
-http-relay = "0.7.0"
 rand = "0.10"
+reqwest = { version = "0.13", default-features = false }
+thiserror = "2"
+# pubky-testnet's docker-postgres feature uses tokio::sync::OnceCell::const_new,
+# which is generally available starting in Tokio 1.30.0 (released 2023-08-09).
+tokio = "1.30"
+tower-http = "0.6"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+url = "2"
 # Same version as used by reqwest version defined above
 wasm-streams = "0.5"

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -6,13 +6,13 @@ version = "0.9.0"
 publish = false
 
 [dependencies]
-pubky-testnet = { path = "../pubky-testnet" , version = "0.9.0" }
-pubky-common = { path = "../pubky-common" , version = "0.9.0" }
+pubky-testnet = { path = "../pubky-testnet", version = "0.9" }
+pubky-common = { path = "../pubky-common", version = "0.9" }
 base64 = "0.22"
 tokio = { workspace = true, features = ["full", "test-util"] }
 tracing-subscriber.workspace = true
 pkarr = { workspace = true }
-bytes = "1.10.1"
+bytes = "1"
 rand = { workspace = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -48,15 +48,15 @@ docker-postgres = ["pubky-testnet/docker-postgres"]
 embedded-postgres = ["docker-postgres"]
 
 [dependencies]
-futures-util = "0.3.31"
+futures-util = "0.3"
 anyhow.workspace = true
-base64 = "0.22.1"
-clap = { version = "4.6.0", features = ["derive"] }
-pubky = { path = "../../pubky-sdk" , version = "0.9.0" }
-pubky-testnet = { path = "../../pubky-testnet" , version = "0.9.0" }
-pubky-common = { path = "../../pubky-common" , version = "0.9.0" }
+base64 = "0.22"
+clap = { workspace = true, features = ["derive"] }
+pubky = { path = "../../pubky-sdk", version = "0.9" }
+pubky-testnet = { path = "../../pubky-testnet", version = "0.9" }
+pubky-common = { path = "../../pubky-common", version = "0.9" }
 reqwest.workspace = true
-rpassword = "7.5.4"
+rpassword = "7"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing.workspace = true

--- a/pubky-common/Cargo.toml
+++ b/pubky-common/Cargo.toml
@@ -12,25 +12,22 @@ keywords = ["pkarr", "pubky", "auth", "pubkey"]
 categories = ["web-programming", "authentication", "cryptography"]
 
 [dependencies]
-base32 = "0.5.1"
-blake3 = "1.5.5"
+base32 = "0.5"
+blake3 = "1"
 ed25519-dalek = { version = "3.0.0-pre.1", features = ["serde"] }
-once_cell = "1.20.3"
+once_cell = "1"
 rand.workspace = true
 thiserror.workspace = true
-postcard = { version = "1.1.1", features = ["alloc"] }
-crypto_secretbox = { version = "0.1.1", features = ["std"] }
-argon2 = { version = "0.5.3", features = ["std"] }
-pubky-timestamp = { version = "0.4.0", features = ["full"] }
-serde = { version = "1.0.217", features = ["derive"] }
+postcard = { version = "1", features = ["alloc"] }
+crypto_secretbox = { version = "0.1", features = ["std"] }
+argon2 = { version = "0.5", features = ["std"] }
+pubky-timestamp = { version = "0.4", features = ["full"] }
+serde = { version = "1", features = ["derive"] }
 pkarr = { workspace = true, features = ["keys"] }
 url.workspace = true
 serde_json = "1"
 base64 = "0.22"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.3.4", features = ["wasm_js"] }
-js-sys = "0.3.77"
-
-[dev-dependencies]
-postcard = "1.1.1"
+getrandom = { version = "0.3", features = ["wasm_js"] }
+js-sys = "0.3"

--- a/pubky-homeserver/Cargo.toml
+++ b/pubky-homeserver/Cargo.toml
@@ -19,59 +19,59 @@ categories = [
 [dependencies]
 anyhow.workspace = true
 axum = { workspace = true, features = ["macros"] }
-axum-extra = { version = "0.10.0", features = [
+axum-extra = { version = "0.10", features = [
     "typed-header",
     "async-read-body",
 ] }
-base32 = "0.5.1"
-base64 = "0.22.1"
-bytes = "^1.10.0"
+base32 = "0.5"
+base64 = "0.22"
+bytes = "1"
 clap = { workspace = true, features = ["derive"] }
-flume = "0.11.1"
-futures-lite = "2.6.1"
-futures-util = "0.3.31"
-hex = "0.4.3"
-httpdate = "1.0.3"
+flume = "0.11"
+futures-lite = "2"
+futures-util = "0.3"
+hex = "0.4"
+httpdate = "1"
 pkarr = { workspace = true, features = ["default", "dht", "tls"] }
-pubky-common = { path = "../pubky-common" , version = "0.9.0" }
-serde = { version = "1.0.217", features = ["derive"] }
+pubky-common = { path = "../pubky-common", version = "0.9" }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { workspace = true, features = ["full"] }
-toml = "0.8.20"
-tower-cookies = "0.11.0"
+toml = "0.8"
+tower-cookies = "0.11"
 tower-http = { workspace = true, features = ["cors", "trace"] }
 tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 url = { workspace = true, features = ["serde"] }
 axum-server = { workspace = true, features = ["tls-rustls-no-provider"] }
-tower = "0.5.2"
+tower = "0.5"
 thiserror.workspace = true
-dirs = "6.0.0"
-hostname-validator = "1.1.1"
-axum-test = "17.2.0"
-tempfile = { version = "3.10.1" }
-dyn-clone = "1.0.19"
+dirs = "6"
+hostname-validator = "1"
+axum-test = "17"
+tempfile = "3"
+dyn-clone = "1"
 reqwest = { workspace = true, features = [
     "rustls",
 ] }
-governor = "0.10.0"
-fast-glob = "0.4.5"
-tokio-util = "0.7.15"
-percent-encoding = "2.3.1"
-serde_valid = "1.0.5"
-opendal = { version = "0.54.0", features = ["services-fs"] }
-infer = "0.19.0"
-mime_guess = "2.0.5"
-dav-server-opendalfs = "0.6.2"
-dav-server = "0.8.0"
-sea-query = { version = "0.32.6", features = ["with-chrono", "postgres-array"] }
-sea-query-binder = { version = "0.7.0", features = [
+governor = "0.10"
+fast-glob = "0.4"
+tokio-util = "0.7"
+percent-encoding = "2"
+serde_valid = "1"
+opendal = { version = "0.54", features = ["services-fs"] }
+infer = "0.19"
+mime_guess = "2"
+dav-server-opendalfs = "0.6"
+dav-server = "0.8"
+sea-query = { version = "0.32", features = ["with-chrono", "postgres-array"] }
+sea-query-binder = { version = "0.7", features = [
     "with-chrono",
     "runtime-tokio",
     "sqlx-postgres",
     "postgres-array",
 ] }
-sqlx = { version = "0.8.6", features = [
+sqlx = { version = "0.8", features = [
     "runtime-tokio",
     "postgres",
     "chrono",
@@ -82,8 +82,8 @@ dashmap = "6"
 async-trait = "0.1"
 async-dropper = { version = "0.3", features = ["tokio", "simple"] }
 async-stream = "0.3"
-uuid = { version = "1.7.0", features = ["v4"] }
-pubky_test_utils = { path = "../test_utils/pubky_test", version = "0.1.0" }
+uuid = { version = "1", features = ["v4"] }
+pubky_test_utils = { path = "../test_utils/pubky_test", version = "0.1" }
 opentelemetry = "0.29"
 opentelemetry_sdk = { version = "0.29", features = ["rt-tokio", "metrics"] }
 opentelemetry-prometheus = "0.29"
@@ -91,11 +91,11 @@ prometheus = "0.14"
 jsonwebtoken = "9"
 chrono = { version = "0.4", features = ["serde"] }
 sha2 = "0.10"
-rand = "0.9"
+rand.workspace = true
 
 [dev-dependencies]
+# The async_closure feature is not available in early 0.3.x releases.
 temp-env = { version = "0.3.6", features = ["async_closure"] }
-
 
 [features]
 default = ["storage-gcs"]

--- a/pubky-homeserver/src/client_server/auth/grant/crypto/session_token.rs
+++ b/pubky-homeserver/src/client_server/auth/grant/crypto/session_token.rs
@@ -1,6 +1,6 @@
 //! Session bearer token and its storage-side hash.
 //!
-//! The bearer is 32 random bytes from `OsRng`, base64url-encoded on the
+//! The bearer is 32 random bytes from `SysRng`, base64url-encoded on the
 //! wire (~43 chars). The homeserver persists only the SHA-256 hash, so a
 //! database leak cannot yield usable bearers.
 //!
@@ -9,7 +9,7 @@
 //! - [`SessionTokenHash`] — the 32-byte digest stored in `grant_sessions.token_hash`.
 
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
-use rand::{rngs::OsRng, TryRngCore};
+use rand::{rngs::SysRng, TryRng};
 use sha2::{Digest, Sha256};
 use std::fmt;
 
@@ -33,12 +33,12 @@ const BEARER_WIRE_LEN: usize = 43;
 pub struct SessionBearer(String);
 
 impl SessionBearer {
-    /// Mint a new bearer: 32 random bytes from `OsRng`, base64url-encoded.
+    /// Mint a new bearer: 32 random bytes from `SysRng`, base64url-encoded.
     pub fn generate() -> Self {
         let mut bytes = [0u8; BEARER_RAW_BYTES];
-        OsRng
+        SysRng
             .try_fill_bytes(&mut bytes)
-            .expect("OsRng must not fail");
+            .expect("SysRng must not fail");
         Self(URL_SAFE_NO_PAD.encode(bytes))
     }
 

--- a/pubky-sdk/Cargo.toml
+++ b/pubky-sdk/Cargo.toml
@@ -4,14 +4,10 @@ description = "Pubky SDK"
 version = "0.9.0"
 edition = "2024"
 rust-version.workspace = true
-authors = [
-    "SeverinAlexB <severin@synonym.to>",
-    "SHAcollision <shacollision@synonym.to>",
-    "Nuh <nuh@nuh.dev>",
-]
-license = "MIT"
-homepage = "https://github.com/pubky/pubky-core"
-repository = "https://github.com/pubky/pubky-core"
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 
 keywords = ["web", "dht", "dns", "decentralized", "identity"]
 categories = [
@@ -29,20 +25,20 @@ default = []
 json = ["dep:serde", "reqwest/json"]
 
 [dependencies]
-pubky-common = { path = "../pubky-common" , version = "0.9.0" }
+pubky-common = { path = "../pubky-common", version = "0.9" }
 thiserror.workspace = true
 async-trait = "0.1"
-eventsource-stream = "0.2.3"
+eventsource-stream = "0.2"
 url.workspace = true
-base64 = "0.22.1"
+base64 = "0.22"
 pkarr = { workspace = true, features = ["full"] }
-cookie = "0.18.1"
-flume = { version = "0.11.1", default-features = false, features = ["async"] }
-futures-util = "0.3.31"
+cookie = "0.18"
+flume = { version = "0.11", default-features = false, features = ["async"] }
+futures-util = "0.3"
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = "1"
 httpdate = "1"
-web-time = "1.1.0"
+web-time = "1"
 # Cross-target async sync primitives. The `sync` feature is portable to
 # `wasm32-unknown-unknown` (see tokio's platform support docs); the native
 # target adds the full feature set in its own section below.
@@ -61,11 +57,11 @@ tracing.workspace = true
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 reqwest = { workspace = true, features = ["json", "stream"] }
 log.workspace = true
-wasm-bindgen-futures = "0.4.50"
-futures-lite = { version = "2.6.0", default-features = false }
+wasm-bindgen-futures = "0.4"
+futures-lite = { version = "2", default-features = false }
 
 [dev-dependencies]
-pubky-testnet = { path = "../pubky-testnet" , version = "0.9.0" } # used in docstring tests
+pubky-testnet = { path = "../pubky-testnet", version = "0.9" } # used in docstring tests
 httpmock = "0.7"
 http-relay = { workspace = true, features = ["server", "link-compat"] }
 

--- a/pubky-sdk/bindings/js/Cargo.toml
+++ b/pubky-sdk/bindings/js/Cargo.toml
@@ -4,14 +4,10 @@ version = "0.9.0"
 edition = "2024"
 rust-version.workspace = true
 description = "Pubky-Core Client WASM bindings"
-authors = [
-    "SeverinAlexB <severin@synonym.to>",
-    "SHAcollision <shacollision@synonym.to>",
-    "Nuh <nuh@nuh.dev>",
-]
-license = "MIT"
-homepage = "https://github.com/pubky/pubky-core"
-repository = "https://github.com/pubky/pubky-core"
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 keywords = ["web", "dht", "dns", "decentralized", "identity"]
 categories = [
     "network-programming",
@@ -29,21 +25,22 @@ name = "bundle_npm"
 path = "scripts/bundle_npm.rs"
 
 [dependencies]
-wasm-bindgen = "0.2.108"
-console_log = { version = "1.0.0", features = ["color"] }
+wasm-bindgen = "0.2"
+console_log = { version = "1", features = ["color"] }
 log.workspace = true
-js-sys = "0.3.77"
-wasm-bindgen-futures = "0.4.54"
+js-sys = "0.3"
+wasm-bindgen-futures = "0.4"
 futures-util = "0.3"
-serde = { version = "1.0", features = ["derive"] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde-wasm-bindgen = "0.6"
-tsify = "0.5.5"
+tsify = "0.5"
 pubky = { path = "../../../pubky-sdk", default-features = false, features = [
     "json",
-] , version = "0.9.0" }
-pubky-common = { path = "../../../pubky-common" , version = "0.9.0" }
+] , version = "0.9" }
+pubky-common = { path = "../../../pubky-common", version = "0.9" }
 pkarr = { workspace = true, default-features = false }
+# ReadableStream is not available in early 0.3.x web-sys releases.
 web-sys = { version = "0.3.77", default-features = false, features = [
     "Request",
     "RequestInit",

--- a/pubky-testnet/Cargo.toml
+++ b/pubky-testnet/Cargo.toml
@@ -20,21 +20,21 @@ tokio = { workspace = true, features = ["full"] }
 tracing-subscriber.workspace = true
 url.workspace = true
 
-pubky = { path = "../pubky-sdk", features = ["json"] , version = "0.9.0" }
-pubky-common = { path = "../pubky-common" , version = "0.9.0" }
+pubky = { path = "../pubky-sdk", features = ["json"] , version = "0.9" }
+pubky-common = { path = "../pubky-common", version = "0.9" }
 pubky-homeserver = { path = "../pubky-homeserver", default-features = false, features = [
     "testing",
-] , version = "0.9.0" }
-pubky_test_utils = { path = "../test_utils/pubky_test", version = "0.1.0" }
+] , version = "0.9" }
+pubky_test_utils = { path = "../test_utils/pubky_test", version = "0.1" }
 # External http-relay: server + link-compat, no persist/cli (in-memory storage for tests)
 http-relay = { workspace = true, features = ["server", "link-compat"] }
-tempfile = "3.19.1"
+tempfile = "3"
 tracing.workspace = true
 pkarr = { workspace = true }
 mainline = { workspace = true }
 clap.workspace = true
-dirs = "6.0.0"
-once_cell = "1.21.3"
+dirs = "6"
+once_cell = "1"
 testcontainers = { version = "0.27", features = ["watchdog"], optional = true }
 testcontainers-modules = { version = "0.15", features = ["postgres"], optional = true }
 libc = { version = "0.2", optional = true }


### PR DESCRIPTION
Use broad dependency requirements in published library crates while
keeping workspace dependency versions for app and test crates.
