### PR TITLE
chore(cargo): centralize workspace manifest metadata

### DIFF
--- a/.scripts/set-version.sh
+++ b/.scripts/set-version.sh
@@ -9,11 +9,20 @@ set -e # fail the script if any command fails
 set -u # fail the script if any variable is not set
 set -o pipefail # fail the script if any pipe command fails
 
-# Check if cargo-set-version is installed
-if ! cargo --list | grep -q "set-version"; then
-  echo "Error: cargo-set-version is not installed but required."
-  echo "Please install it first by running:"
-  echo "  cargo install cargo-set-version"
+# Check if cargo set-version is installed from cargo-edit.
+if ! SET_VERSION_OUTPUT=$(cargo set-version --version 2>/dev/null); then
+  echo "Error: cargo set-version is not installed but required."
+  echo "Please install it from cargo-edit first by running:"
+  echo "  cargo install cargo-edit --no-default-features --features set-version"
+  exit 1
+fi
+
+if [[ ! "$SET_VERSION_OUTPUT" =~ ^cargo-edit-set-version[[:space:]][0-9] ]]; then
+  echo "Error: cargo set-version must be provided by cargo-edit."
+  echo "Expected 'cargo set-version --version' to return 'cargo-edit-set-version <version>'."
+  echo "Found: $SET_VERSION_OUTPUT"
+  echo "Please install it from cargo-edit by running:"
+  echo "  cargo install cargo-edit --no-default-features --features set-version"
   exit 1
 fi
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
+version = "0.9.0"
 rust-version = "1.89"
 edition = "2021"
 authors = [
@@ -38,16 +39,34 @@ opt-level = 'z'
 
 [workspace.dependencies]
 anyhow = "1"
+async-trait = "0.1"
 axum = "0.8"
 axum-server = "0.8"
+base32 = "0.5"
+base64 = "0.22"
+bytes = "1"
 clap = "4"
+dirs = "6"
+eventsource-stream = "0.2"
+futures-util = "0.3"
 http-relay = "0.7"
+httpdate = "1"
+js-sys = "0.3"
 log = "0.4"
 mainline = { version = "6" }
+once_cell = "1"
 pkarr = { version = "6", default-features = false }
 pkarr-relay = { version = "0.12" }
+pubky = { path = "pubky-sdk", version = "0.9", default-features = false }
+pubky-common = { path = "pubky-common", version = "0.9" }
+pubky-homeserver = { path = "pubky-homeserver", version = "0.9", default-features = false }
+pubky-testnet = { path = "pubky-testnet", version = "0.9" }
+pubky_test_utils = { path = "test_utils/pubky_test", version = "0.1" }
 rand = "0.10"
 reqwest = { version = "0.13", default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tempfile = "3"
 thiserror = "2"
 # pubky-testnet's docker-postgres feature uses tokio::sync::OnceCell::const_new,
 # which is generally available starting in Tokio 1.30.0 (released 2023-08-09).
@@ -56,5 +75,6 @@ tower-http = "0.6"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 url = "2"
+wasm-bindgen-futures = "0.4"
 # Same version as used by reqwest version defined above
 wasm-streams = "0.5"

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -2,22 +2,26 @@
 name = "e2e"
 edition.workspace = true
 rust-version.workspace = true
-version = "0.9.0"
+version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 publish = false
 
 [dependencies]
-pubky-testnet = { path = "../pubky-testnet", version = "0.9" }
-pubky-common = { path = "../pubky-common", version = "0.9" }
-base64 = "0.22"
+base64.workspace = true
+bytes.workspace = true
+pkarr = { workspace = true }
+pubky-common.workspace = true
+pubky-testnet.workspace = true
+rand = { workspace = true }
+serde.workspace = true
+serde_json.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }
 tracing-subscriber.workspace = true
-pkarr = { workspace = true }
-bytes = "1"
-rand = { workspace = true }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 url.workspace = true
 
 [dev-dependencies]
-eventsource-stream = "0.2"
+eventsource-stream.workspace = true
 futures = "0.3"

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -1,8 +1,12 @@
 [package]
 name = "pubky-core-examples"
-version = "0.9.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 publish = false
 
 [[bin]]
@@ -48,13 +52,13 @@ docker-postgres = ["pubky-testnet/docker-postgres"]
 embedded-postgres = ["docker-postgres"]
 
 [dependencies]
-futures-util = "0.3"
 anyhow.workspace = true
-base64 = "0.22"
+base64.workspace = true
 clap = { workspace = true, features = ["derive"] }
-pubky = { path = "../../pubky-sdk", version = "0.9" }
-pubky-testnet = { path = "../../pubky-testnet", version = "0.9" }
-pubky-common = { path = "../../pubky-common", version = "0.9" }
+futures-util.workspace = true
+pubky-common.workspace = true
+pubky-testnet.workspace = true
+pubky.workspace = true
 reqwest.workspace = true
 rpassword = "7"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/pubky-common/Cargo.toml
+++ b/pubky-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubky-common"
 description = "Types and struct in common between Pubky client and homeserver"
-version = "0.9.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -12,22 +12,22 @@ keywords = ["pkarr", "pubky", "auth", "pubkey"]
 categories = ["web-programming", "authentication", "cryptography"]
 
 [dependencies]
-base32 = "0.5"
+base32.workspace = true
 blake3 = "1"
 ed25519-dalek = { version = "3.0.0-pre.1", features = ["serde"] }
-once_cell = "1"
+once_cell.workspace = true
 rand.workspace = true
 thiserror.workspace = true
 postcard = { version = "1", features = ["alloc"] }
 crypto_secretbox = { version = "0.1", features = ["std"] }
 argon2 = { version = "0.5", features = ["std"] }
 pubky-timestamp = { version = "0.4", features = ["full"] }
-serde = { version = "1", features = ["derive"] }
+serde.workspace = true
 pkarr = { workspace = true, features = ["keys"] }
 url.workspace = true
-serde_json = "1"
-base64 = "0.22"
+serde_json.workspace = true
+base64.workspace = true
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.3", features = ["wasm_js"] }
-js-sys = "0.3"
+js-sys.workspace = true

--- a/pubky-homeserver/Cargo.toml
+++ b/pubky-homeserver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubky-homeserver"
 description = "Pubky core's homeserver."
-version = "0.9.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -23,19 +23,19 @@ axum-extra = { version = "0.10", features = [
     "typed-header",
     "async-read-body",
 ] }
-base32 = "0.5"
-base64 = "0.22"
-bytes = "1"
+base32.workspace = true
+base64.workspace = true
+bytes.workspace = true
 clap = { workspace = true, features = ["derive"] }
 flume = "0.11"
 futures-lite = "2"
-futures-util = "0.3"
+futures-util.workspace = true
 hex = "0.4"
-httpdate = "1"
+httpdate.workspace = true
 pkarr = { workspace = true, features = ["default", "dht", "tls"] }
-pubky-common = { path = "../pubky-common", version = "0.9" }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+pubky-common.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 tokio = { workspace = true, features = ["full"] }
 toml = "0.8"
 tower-cookies = "0.11"
@@ -46,10 +46,10 @@ url = { workspace = true, features = ["serde"] }
 axum-server = { workspace = true, features = ["tls-rustls-no-provider"] }
 tower = "0.5"
 thiserror.workspace = true
-dirs = "6"
+dirs.workspace = true
 hostname-validator = "1"
 axum-test = "17"
-tempfile = "3"
+tempfile.workspace = true
 dyn-clone = "1"
 reqwest = { workspace = true, features = [
     "rustls",
@@ -79,11 +79,11 @@ sqlx = { version = "0.8", features = [
     "json",
 ] }
 dashmap = "6"
-async-trait = "0.1"
+async-trait.workspace = true
 async-dropper = { version = "0.3", features = ["tokio", "simple"] }
 async-stream = "0.3"
 uuid = { version = "1", features = ["v4"] }
-pubky_test_utils = { path = "../test_utils/pubky_test", version = "0.1" }
+pubky_test_utils.workspace = true
 opentelemetry = "0.29"
 opentelemetry_sdk = { version = "0.29", features = ["rt-tokio", "metrics"] }
 opentelemetry-prometheus = "0.29"

--- a/pubky-sdk/Cargo.toml
+++ b/pubky-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubky"
 description = "Pubky SDK"
-version = "0.9.0"
+version.workspace = true
 edition = "2024"
 rust-version.workspace = true
 authors.workspace = true
@@ -25,19 +25,19 @@ default = []
 json = ["dep:serde", "reqwest/json"]
 
 [dependencies]
-pubky-common = { path = "../pubky-common", version = "0.9" }
+pubky-common.workspace = true
 thiserror.workspace = true
-async-trait = "0.1"
-eventsource-stream = "0.2"
+async-trait.workspace = true
+eventsource-stream.workspace = true
 url.workspace = true
-base64 = "0.22"
+base64.workspace = true
 pkarr = { workspace = true, features = ["full"] }
 cookie = "0.18"
 flume = { version = "0.11", default-features = false, features = ["async"] }
-futures-util = "0.3"
-serde = { version = "1", features = ["derive"], optional = true }
-serde_json = "1"
-httpdate = "1"
+futures-util.workspace = true
+serde = { workspace = true, optional = true }
+serde_json.workspace = true
+httpdate.workspace = true
 web-time = "1"
 # Cross-target async sync primitives. The `sync` feature is portable to
 # `wasm32-unknown-unknown` (see tokio's platform support docs); the native
@@ -57,11 +57,11 @@ tracing.workspace = true
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 reqwest = { workspace = true, features = ["json", "stream"] }
 log.workspace = true
-wasm-bindgen-futures = "0.4"
+wasm-bindgen-futures.workspace = true
 futures-lite = { version = "2", default-features = false }
 
 [dev-dependencies]
-pubky-testnet = { path = "../pubky-testnet", version = "0.9" } # used in docstring tests
+pubky-testnet.workspace = true # used in docstring tests
 httpmock = "0.7"
 http-relay = { workspace = true, features = ["server", "link-compat"] }
 

--- a/pubky-sdk/bindings/js/Cargo.toml
+++ b/pubky-sdk/bindings/js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky-wasm"
-version = "0.9.0"
+version.workspace = true
 edition = "2024"
 rust-version.workspace = true
 description = "Pubky-Core Client WASM bindings"
@@ -25,21 +25,23 @@ name = "bundle_npm"
 path = "scripts/bundle_npm.rs"
 
 [dependencies]
-wasm-bindgen = "0.2"
+base64.workspace = true
 console_log = { version = "1", features = ["color"] }
+futures-util.workspace = true
+js-sys.workspace = true
 log.workspace = true
-js-sys = "0.3"
-wasm-bindgen-futures = "0.4"
-futures-util = "0.3"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-serde-wasm-bindgen = "0.6"
-tsify = "0.5"
-pubky = { path = "../../../pubky-sdk", default-features = false, features = [
-    "json",
-] , version = "0.9" }
-pubky-common = { path = "../../../pubky-common", version = "0.9" }
 pkarr = { workspace = true, default-features = false }
+pubky = { workspace = true, features = [ "json" ] }
+pubky-common.workspace = true
+reqwest = { workspace = true, features = [ "stream" ] }
+serde.workspace = true
+serde-wasm-bindgen = "0.6"
+serde_json.workspace = true
+tsify = "0.5"
+url.workspace = true
+wasm-bindgen = "0.2"
+wasm-bindgen-futures.workspace = true
+wasm-streams.workspace = true
 # ReadableStream is not available in early 0.3.x web-sys releases.
 web-sys = { version = "0.3.77", default-features = false, features = [
     "Request",
@@ -51,12 +53,6 @@ web-sys = { version = "0.3.77", default-features = false, features = [
     "Headers",
     "ServiceWorkerGlobalScope",
 ] }
-url.workspace = true
-reqwest = { workspace = true, features = [
-    "stream",
-] }
-wasm-streams.workspace = true
-base64 = "0.22"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3"

--- a/pubky-testnet/Cargo.toml
+++ b/pubky-testnet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubky-testnet"
 description = "A local test network for Pubky Core development."
-version = "0.9.0"
+version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,29 +15,26 @@ categories = ["web-programming", "authentication", "cryptography"]
 
 [dependencies]
 anyhow.workspace = true
-pkarr-relay = { workspace = true }
-tokio = { workspace = true, features = ["full"] }
-tracing-subscriber.workspace = true
-url.workspace = true
-
-pubky = { path = "../pubky-sdk", features = ["json"] , version = "0.9" }
-pubky-common = { path = "../pubky-common", version = "0.9" }
-pubky-homeserver = { path = "../pubky-homeserver", default-features = false, features = [
-    "testing",
-] , version = "0.9" }
-pubky_test_utils = { path = "../test_utils/pubky_test", version = "0.1" }
+clap.workspace = true
+dirs.workspace = true
 # External http-relay: server + link-compat, no persist/cli (in-memory storage for tests)
 http-relay = { workspace = true, features = ["server", "link-compat"] }
-tempfile = "3"
-tracing.workspace = true
-pkarr = { workspace = true }
+libc = { version = "0.2", optional = true }
 mainline = { workspace = true }
-clap.workspace = true
-dirs = "6"
-once_cell = "1"
+once_cell.workspace = true
+pkarr = { workspace = true }
+pkarr-relay = { workspace = true }
+pubky = { workspace = true, features = ["json"] }
+pubky-common.workspace = true
+pubky-homeserver = { workspace = true, features = [ "testing" ] }
+pubky_test_utils.workspace = true
+tempfile.workspace = true
 testcontainers = { version = "0.27", features = ["watchdog"], optional = true }
 testcontainers-modules = { version = "0.15", features = ["postgres"], optional = true }
-libc = { version = "0.2", optional = true }
+tokio = { workspace = true, features = ["full"] }
+tracing-subscriber.workspace = true
+tracing.workspace = true
+url.workspace = true
 
 [features]
 default = []


### PR DESCRIPTION
Move repeated package version, author, license, repository, and
dependency declarations into the workspace manifest. Update member
crates to inherit shared Cargo metadata and dependency versions.
