### PR TITLE
feat: add list signup tokens endpoint

### DIFF
--- a/pubky-homeserver/src/admin_server/app.rs
+++ b/pubky-homeserver/src/admin_server/app.rs
@@ -278,6 +278,33 @@ mod tests {
         assert_eq!(body["next_cursor"], serde_json::Value::Null);
     }
 
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_list_signup_tokens_query_params_success() {
+        let context = AppContext::test().await;
+        let server = create_test_server(&context);
+
+        let response = server
+            .get("/generate_signup_token")
+            .add_header("X-Admin-Password", "test")
+            .expect_success()
+            .await;
+        let token = response.text();
+
+        let response = server
+            .get("/signup_tokens?state=unused&limit=1")
+            .add_header("X-Admin-Password", "test")
+            .expect_success()
+            .await;
+        response.assert_status_ok();
+
+        let body: serde_json::Value = response.json();
+        let items = body["items"].as_array().unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0]["token"], token);
+        assert_eq!(body["next_cursor"], serde_json::Value::Null);
+    }
+
     fn auth_header() -> String {
         // AppState is created with password "" in create_test_server
         let auth = base64::engine::general_purpose::STANDARD.encode("admin:");

--- a/pubky-homeserver/src/admin_server/app.rs
+++ b/pubky-homeserver/src/admin_server/app.rs
@@ -188,9 +188,12 @@ mod tests {
     use axum::http::Method;
     use axum_test::TestServer;
     use base64::Engine;
+    use pubky_common::crypto::Keypair;
 
     use crate::data_directory::quota_config::BandwidthQuota;
     use crate::persistence::files::FileService;
+    use crate::persistence::sql::signup_code::{SignupCode, SignupCodeRepository};
+    use crate::shared::user_quota::UserQuota;
 
     use super::*;
 
@@ -284,13 +287,28 @@ mod tests {
         let context = AppContext::test().await;
         let server = create_test_server(&context);
 
-        let response = server
-            .get("/generate_signup_token")
-            .add_header("X-Admin-Password", "test")
-            .expect_success()
-            .await;
-        let token = response.text();
+        let token1 = SignupCode::new("0000-0000-0001".to_string()).unwrap();
+        let token2 = SignupCode::new("0000-0000-0002".to_string()).unwrap();
+        let token3 = SignupCode::new("0000-0000-0003".to_string()).unwrap();
+        let token4 = SignupCode::new("0000-0000-0004".to_string()).unwrap();
 
+        for token in [&token1, &token2, &token3, &token4] {
+            SignupCodeRepository::create(
+                token,
+                &UserQuota::default(),
+                &mut context.sql_db.pool().into(),
+            )
+            .await
+            .unwrap();
+        }
+
+        let used_by = Keypair::random().public_key();
+        SignupCodeRepository::mark_as_used(&token1, &used_by, &mut context.sql_db.pool().into())
+            .await
+            .unwrap();
+
+        // With three unused tokens, limit=1 proves the page size is applied and
+        // returns the last item in the page as the cursor.
         let response = server
             .get("/signup_tokens?state=unused&limit=1")
             .add_header("X-Admin-Password", "test")
@@ -301,7 +319,55 @@ mod tests {
         let body: serde_json::Value = response.json();
         let items = body["items"].as_array().unwrap();
         assert_eq!(items.len(), 1);
-        assert_eq!(items[0]["token"], token);
+        assert_eq!(items[0]["token"], token2.to_string());
+        assert_eq!(body["next_cursor"], token2.to_string());
+
+        // Increasing the limit changes the page size and advances the cursor.
+        let response = server
+            .get("/signup_tokens?state=unused&limit=2")
+            .add_header("X-Admin-Password", "test")
+            .expect_success()
+            .await;
+        response.assert_status_ok();
+
+        let body: serde_json::Value = response.json();
+        let items = body["items"].as_array().unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0]["token"], token2.to_string());
+        assert_eq!(items[1]["token"], token3.to_string());
+        assert_eq!(body["next_cursor"], token3.to_string());
+
+        // When the limit reaches all remaining unused tokens, there is no next page.
+        let response = server
+            .get("/signup_tokens?state=unused&limit=3")
+            .add_header("X-Admin-Password", "test")
+            .expect_success()
+            .await;
+        response.assert_status_ok();
+
+        let body: serde_json::Value = response.json();
+        let items = body["items"].as_array().unwrap();
+        assert_eq!(items.len(), 3);
+        assert_eq!(items[0]["token"], token2.to_string());
+        assert_eq!(items[1]["token"], token3.to_string());
+        assert_eq!(items[2]["token"], token4.to_string());
+        assert_eq!(body["next_cursor"], serde_json::Value::Null);
+
+        // The cursor starts after the token it names, while keeping the unused filter.
+        let response = server
+            .get(&format!(
+                "/signup_tokens?state=unused&limit=2&cursor={token2}"
+            ))
+            .add_header("X-Admin-Password", "test")
+            .expect_success()
+            .await;
+        response.assert_status_ok();
+
+        let body: serde_json::Value = response.json();
+        let items = body["items"].as_array().unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0]["token"], token3.to_string());
+        assert_eq!(items[1]["token"], token4.to_string());
         assert_eq!(body["next_cursor"], serde_json::Value::Null);
     }
 

--- a/pubky-homeserver/src/admin_server/app.rs
+++ b/pubky-homeserver/src/admin_server/app.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use super::routes::{
     dav_handler, delete_entry,
     disable_users::{disable_user, enable_user},
-    generate_signup_token, info, root, user_quota,
+    generate_signup_token, info, root, signup_tokens, user_quota,
 };
 use super::trace::with_trace_layer;
 use super::{app_state::AppState, auth_middleware::AdminAuthLayer};
@@ -28,6 +28,7 @@ fn create_protected_router(password: &str) -> Router<AppState> {
                 .post(generate_signup_token::generate_signup_token_with_limits),
         )
         .route("/info", get(info::info))
+        .route("/signup_tokens", get(signup_tokens::list_signup_tokens))
         .route("/webdav/{*entry_path}", delete(delete_entry::delete_entry))
         .route("/users/{pubkey}/disable", post(disable_user))
         .route("/users/{pubkey}/enable", post(enable_user))
@@ -239,15 +240,42 @@ mod tests {
 
     #[tokio::test]
     #[pubky_test_utils::test]
-    async fn test_generate_signup_token_success() {
+    async fn test_list_signup_tokens_fail() {
         let context = AppContext::test().await;
         let server = create_test_server(&context);
+
+        let response = server.get("/signup_tokens").expect_failure().await;
+        response.assert_status_unauthorized();
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_create_and_list_signup_token_success() {
+        let context = AppContext::test().await;
+        let server = create_test_server(&context);
+
         let response = server
             .get("/generate_signup_token")
             .add_header("X-Admin-Password", "test")
             .expect_success()
             .await;
+        let token = response.text();
+
+        let response = server
+            .get("/signup_tokens")
+            .add_header("X-Admin-Password", "test")
+            .expect_success()
+            .await;
         response.assert_status_ok();
+
+        let body: serde_json::Value = response.json();
+        let items = body["items"].as_array().unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0]["token"], token);
+        assert!(items[0]["created_at"].as_str().is_some());
+        assert_eq!(items[0]["used_at"], serde_json::Value::Null);
+        assert_eq!(items[0]["used_by"], serde_json::Value::Null);
+        assert_eq!(body["next_cursor"], serde_json::Value::Null);
     }
 
     fn auth_header() -> String {

--- a/pubky-homeserver/src/admin_server/routes/mod.rs
+++ b/pubky-homeserver/src/admin_server/routes/mod.rs
@@ -4,4 +4,5 @@ pub(crate) mod disable_users;
 pub(crate) mod generate_signup_token;
 pub(crate) mod info;
 pub(crate) mod root;
+pub(crate) mod signup_tokens;
 pub(crate) mod user_quota;

--- a/pubky-homeserver/src/admin_server/routes/signup_tokens.rs
+++ b/pubky-homeserver/src/admin_server/routes/signup_tokens.rs
@@ -4,7 +4,7 @@ use crate::{
         SignupCode, SignupCodeEntity, SignupCodeListQuery, SignupCodeListState,
         SignupCodeRepository,
     },
-    shared::{HttpError, HttpResult},
+    shared::HttpResult,
 };
 use axum::{
     extract::{Query, State},
@@ -17,45 +17,23 @@ use sqlx::types::chrono::NaiveDateTime;
 #[derive(Deserialize)]
 pub(crate) struct SignupTokensQuery {
     limit: Option<u16>,
-    cursor: Option<String>,
-    state: Option<String>,
+    cursor: Option<SignupCode>,
+    state: Option<SignupCodeListState>,
 }
 
 impl SignupTokensQuery {
-    fn state(&self) -> HttpResult<SignupCodeListState> {
-        match self.state.as_deref().unwrap_or("all") {
-            "all" => Ok(SignupCodeListState::All),
-            "used" => Ok(SignupCodeListState::Used),
-            "unused" => Ok(SignupCodeListState::Unused),
-            _ => Err(HttpError::bad_request("Invalid state")),
-        }
-    }
-
-    fn cursor(&self) -> HttpResult<Option<SignupCode>> {
-        let Some(cursor) = self.cursor.as_deref() else {
-            return Ok(None);
-        };
-        if cursor.is_empty() {
-            return Ok(None);
-        }
-
-        SignupCode::new(cursor.to_string())
-            .map(Some)
-            .map_err(|_| HttpError::bad_request("Invalid cursor"))
-    }
-
-    fn list_query(&self) -> HttpResult<SignupCodeListQuery> {
-        Ok(SignupCodeListQuery {
-            state: self.state()?,
+    fn list_query(self) -> SignupCodeListQuery {
+        SignupCodeListQuery {
+            state: self.state.unwrap_or(SignupCodeListState::All),
             limit: self.limit,
-            cursor: self.cursor()?,
-        })
+            cursor: self.cursor,
+        }
     }
 }
 
 #[derive(Serialize)]
 pub(crate) struct SignupTokenItem {
-    token: String,
+    token: SignupCode,
     created_at: NaiveDateTime,
     used_at: Option<NaiveDateTime>,
     used_by: Option<String>,
@@ -64,7 +42,7 @@ pub(crate) struct SignupTokenItem {
 impl From<SignupCodeEntity> for SignupTokenItem {
     fn from(code: SignupCodeEntity) -> Self {
         Self {
-            token: code.id.to_string(),
+            token: code.id,
             created_at: code.created_at,
             used_at: code.used_at,
             used_by: code.used_by.map(|pubkey| pubkey.z32()),
@@ -75,7 +53,7 @@ impl From<SignupCodeEntity> for SignupTokenItem {
 #[derive(Serialize)]
 pub(crate) struct SignupTokensResponse {
     items: Vec<SignupTokenItem>,
-    next_cursor: Option<String>,
+    next_cursor: Option<SignupCode>,
 }
 
 /// List signup tokens with usage information.
@@ -84,14 +62,14 @@ pub async fn list_signup_tokens(
     Query(params): Query<SignupTokensQuery>,
 ) -> HttpResult<(StatusCode, Json<SignupTokensResponse>)> {
     let page =
-        SignupCodeRepository::list(params.list_query()?, &mut state.sql_db.pool().into()).await?;
+        SignupCodeRepository::list(params.list_query(), &mut state.sql_db.pool().into()).await?;
     let items = page.items.into_iter().map(SignupTokenItem::from).collect();
 
     Ok((
         StatusCode::OK,
         Json(SignupTokensResponse {
             items,
-            next_cursor: page.next_cursor.map(|cursor| cursor.to_string()),
+            next_cursor: page.next_cursor,
         }),
     ))
 }

--- a/pubky-homeserver/src/admin_server/routes/signup_tokens.rs
+++ b/pubky-homeserver/src/admin_server/routes/signup_tokens.rs
@@ -1,0 +1,286 @@
+use super::super::app_state::AppState;
+use crate::{
+    persistence::sql::signup_code::{
+        SignupCode, SignupCodeEntity, SignupCodeListQuery, SignupCodeListState,
+        SignupCodeRepository,
+    },
+    shared::{HttpError, HttpResult},
+};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    Json,
+};
+use serde::{Deserialize, Serialize};
+use sqlx::types::chrono::NaiveDateTime;
+
+#[derive(Deserialize)]
+pub(crate) struct SignupTokensQuery {
+    limit: Option<u16>,
+    cursor: Option<String>,
+    state: Option<String>,
+}
+
+impl SignupTokensQuery {
+    fn state(&self) -> HttpResult<SignupCodeListState> {
+        match self.state.as_deref().unwrap_or("all") {
+            "all" => Ok(SignupCodeListState::All),
+            "used" => Ok(SignupCodeListState::Used),
+            "unused" => Ok(SignupCodeListState::Unused),
+            _ => Err(HttpError::bad_request("Invalid state")),
+        }
+    }
+
+    fn cursor(&self) -> HttpResult<Option<SignupCode>> {
+        let Some(cursor) = self.cursor.as_deref() else {
+            return Ok(None);
+        };
+        if cursor.is_empty() {
+            return Ok(None);
+        }
+
+        SignupCode::new(cursor.to_string())
+            .map(Some)
+            .map_err(|_| HttpError::bad_request("Invalid cursor"))
+    }
+
+    fn list_query(&self) -> HttpResult<SignupCodeListQuery> {
+        Ok(SignupCodeListQuery {
+            state: self.state()?,
+            limit: self.limit,
+            cursor: self.cursor()?,
+        })
+    }
+}
+
+#[derive(Serialize)]
+pub(crate) struct SignupTokenItem {
+    token: String,
+    created_at: NaiveDateTime,
+    used_at: Option<NaiveDateTime>,
+    used_by: Option<String>,
+}
+
+impl From<SignupCodeEntity> for SignupTokenItem {
+    fn from(code: SignupCodeEntity) -> Self {
+        Self {
+            token: code.id.to_string(),
+            created_at: code.created_at,
+            used_at: code.used_at,
+            used_by: code.used_by.map(|pubkey| pubkey.z32()),
+        }
+    }
+}
+
+#[derive(Serialize)]
+pub(crate) struct SignupTokensResponse {
+    items: Vec<SignupTokenItem>,
+    next_cursor: Option<String>,
+}
+
+/// List signup tokens with usage information.
+pub async fn list_signup_tokens(
+    State(state): State<AppState>,
+    Query(params): Query<SignupTokensQuery>,
+) -> HttpResult<(StatusCode, Json<SignupTokensResponse>)> {
+    let page =
+        SignupCodeRepository::list(params.list_query()?, &mut state.sql_db.pool().into()).await?;
+    let items = page.items.into_iter().map(SignupTokenItem::from).collect();
+
+    Ok((
+        StatusCode::OK,
+        Json(SignupTokensResponse {
+            items,
+            next_cursor: page.next_cursor.map(|cursor| cursor.to_string()),
+        }),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum_test::TestServer;
+
+    use super::*;
+    use crate::{
+        admin_server::app::create_app,
+        persistence::{
+            files::FileService,
+            sql::signup_code::{SignupCode, SignupCodeRepository},
+        },
+        shared::user_quota::UserQuota,
+        AppContext,
+    };
+
+    fn create_test_server(context: &AppContext) -> TestServer {
+        TestServer::new(create_app(
+            AppState::new(
+                context.sql_db.clone(),
+                FileService::new_from_context(context).unwrap(),
+                "",
+                context.user_service.clone(),
+            ),
+            "test",
+        ))
+        .unwrap()
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_list_signup_tokens_returns_used_by_and_used_at() {
+        use pubky_common::crypto::Keypair;
+
+        let context = AppContext::test().await;
+        let server = create_test_server(&context);
+
+        let response = server
+            .get("/generate_signup_token")
+            .add_header("X-Admin-Password", "test")
+            .expect_success()
+            .await;
+        let token = response.text();
+
+        let used_by = Keypair::random().public_key();
+        let token_id = SignupCode::new(token.clone()).unwrap();
+        SignupCodeRepository::mark_as_used(&token_id, &used_by, &mut context.sql_db.pool().into())
+            .await
+            .unwrap();
+
+        let response = server
+            .get("/signup_tokens")
+            .add_header("X-Admin-Password", "test")
+            .expect_success()
+            .await;
+        response.assert_status_ok();
+
+        let body: serde_json::Value = response.json();
+        let items = body["items"].as_array().unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0]["token"], token);
+        assert_eq!(items[0]["used_by"], used_by.z32());
+        assert!(items[0]["used_at"].as_str().is_some());
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_list_signup_tokens_filters_by_state() {
+        use pubky_common::crypto::Keypair;
+
+        let context = AppContext::test().await;
+        let server = create_test_server(&context);
+
+        let used_token = server
+            .get("/generate_signup_token")
+            .add_header("X-Admin-Password", "test")
+            .expect_success()
+            .await
+            .text();
+        let unused_token = server
+            .get("/generate_signup_token")
+            .add_header("X-Admin-Password", "test")
+            .expect_success()
+            .await
+            .text();
+
+        let used_by = Keypair::random().public_key();
+        let used_token_id = SignupCode::new(used_token.clone()).unwrap();
+        SignupCodeRepository::mark_as_used(
+            &used_token_id,
+            &used_by,
+            &mut context.sql_db.pool().into(),
+        )
+        .await
+        .unwrap();
+
+        let response = server
+            .get("/signup_tokens?state=used")
+            .add_header("X-Admin-Password", "test")
+            .expect_success()
+            .await;
+        let body: serde_json::Value = response.json();
+        let used_items = body["items"].as_array().unwrap();
+        assert_eq!(used_items.len(), 1);
+        assert_eq!(used_items[0]["token"], used_token);
+
+        let response = server
+            .get("/signup_tokens?state=unused")
+            .add_header("X-Admin-Password", "test")
+            .expect_success()
+            .await;
+        let body: serde_json::Value = response.json();
+        let unused_items = body["items"].as_array().unwrap();
+        assert_eq!(unused_items.len(), 1);
+        assert_eq!(unused_items[0]["token"], unused_token);
+
+        let response = server
+            .get("/signup_tokens?state=all")
+            .add_header("X-Admin-Password", "test")
+            .expect_success()
+            .await;
+        let body: serde_json::Value = response.json();
+        assert_eq!(body["items"].as_array().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_list_signup_tokens_paginates_with_cursor() {
+        let context = AppContext::test().await;
+        let server = create_test_server(&context);
+        let token1 = SignupCode::new("0000-0000-0001".to_string()).unwrap();
+        let token2 = SignupCode::new("0000-0000-0002".to_string()).unwrap();
+        let token3 = SignupCode::new("0000-0000-0003".to_string()).unwrap();
+
+        for token in [&token1, &token2, &token3] {
+            SignupCodeRepository::create(
+                token,
+                &UserQuota::default(),
+                &mut context.sql_db.pool().into(),
+            )
+            .await
+            .unwrap();
+        }
+
+        let response = server
+            .get("/signup_tokens?limit=2")
+            .add_header("X-Admin-Password", "test")
+            .expect_success()
+            .await;
+        let body: serde_json::Value = response.json();
+        let items = body["items"].as_array().unwrap();
+        assert_eq!(items.len(), 2);
+        assert_eq!(items[0]["token"], token1.to_string());
+        assert_eq!(items[1]["token"], token2.to_string());
+        assert_eq!(body["next_cursor"], token2.to_string());
+
+        let response = server
+            .get(&format!("/signup_tokens?limit=2&cursor={token2}"))
+            .add_header("X-Admin-Password", "test")
+            .expect_success()
+            .await;
+        let body: serde_json::Value = response.json();
+        let items = body["items"].as_array().unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0]["token"], token3.to_string());
+        assert_eq!(body["next_cursor"], serde_json::Value::Null);
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_list_signup_tokens_rejects_bad_query() {
+        let context = AppContext::test().await;
+        let server = create_test_server(&context);
+
+        let response = server
+            .get("/signup_tokens?state=unknown")
+            .add_header("X-Admin-Password", "test")
+            .expect_failure()
+            .await;
+        response.assert_status_bad_request();
+
+        let response = server
+            .get("/signup_tokens?cursor=invalid")
+            .add_header("X-Admin-Password", "test")
+            .expect_failure()
+            .await;
+        response.assert_status_bad_request();
+    }
+}

--- a/pubky-homeserver/src/admin_server/routes/signup_tokens.rs
+++ b/pubky-homeserver/src/admin_server/routes/signup_tokens.rs
@@ -1,3 +1,5 @@
+use std::num::NonZeroU16;
+
 use super::super::app_state::AppState;
 use crate::{
     persistence::sql::signup_code::{
@@ -16,7 +18,7 @@ use sqlx::types::chrono::NaiveDateTime;
 
 #[derive(Deserialize)]
 pub(crate) struct SignupTokensQuery {
-    limit: Option<u16>,
+    limit: Option<NonZeroU16>,
     cursor: Option<SignupCode>,
     state: Option<SignupCodeListState>,
 }
@@ -25,7 +27,7 @@ impl SignupTokensQuery {
     fn list_query(self) -> SignupCodeListQuery {
         SignupCodeListQuery {
             state: self.state.unwrap_or(SignupCodeListState::All),
-            limit: self.limit,
+            limit: self.limit.map(NonZeroU16::get),
             cursor: self.cursor,
         }
     }
@@ -256,6 +258,13 @@ mod tests {
 
         let response = server
             .get("/signup_tokens?cursor=invalid")
+            .add_header("X-Admin-Password", "test")
+            .expect_failure()
+            .await;
+        response.assert_status_bad_request();
+
+        let response = server
+            .get("/signup_tokens?limit=0")
             .add_header("X-Admin-Password", "test")
             .expect_failure()
             .await;

--- a/pubky-homeserver/src/persistence/sql/entities/signup_code.rs
+++ b/pubky-homeserver/src/persistence/sql/entities/signup_code.rs
@@ -3,17 +3,48 @@ use std::{fmt::Display, str::FromStr};
 use base32::{decode, encode, Alphabet};
 use pubky_common::crypto::random_bytes;
 use pubky_common::crypto::PublicKey;
-use sea_query::{Expr, Iden, PostgresQueryBuilder, Query, SimpleExpr};
+use sea_query::{Expr, Iden, Order, PostgresQueryBuilder, Query, SimpleExpr};
 use sea_query_binder::SqlxBinder;
 use sqlx::{postgres::PgRow, FromRow, Row};
 
-use crate::persistence::sql::UnifiedExecutor;
 use crate::shared::user_quota::UserQuota;
+use crate::{
+    constants::{DEFAULT_LIST_LIMIT, DEFAULT_MAX_LIST_LIMIT},
+    persistence::sql::UnifiedExecutor,
+};
 
 pub const SIGNUP_CODE_TABLE: &str = "signup_codes";
 
 /// Repository that handles all the queries regarding the SignupCodeEntity.
 pub struct SignupCodeRepository;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignupCodeListState {
+    All,
+    Used,
+    Unused,
+}
+
+#[derive(Debug, Clone)]
+pub struct SignupCodeListQuery {
+    pub state: SignupCodeListState,
+    pub limit: Option<u16>,
+    pub cursor: Option<SignupCode>,
+}
+
+impl SignupCodeListQuery {
+    fn effective_limit(&self) -> u16 {
+        self.limit
+            .unwrap_or(DEFAULT_LIST_LIMIT)
+            .min(DEFAULT_MAX_LIST_LIMIT)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SignupCodeListPage {
+    pub items: Vec<SignupCodeEntity>,
+    pub next_cursor: Option<SignupCode>,
+}
 
 impl SignupCodeRepository {
     /// Create a new signup code with the given limits for users who redeem it.
@@ -74,6 +105,7 @@ impl SignupCodeRepository {
             .columns([
                 SignupCodeIden::Id,
                 SignupCodeIden::CreatedAt,
+                SignupCodeIden::UsedAt,
                 SignupCodeIden::UsedBy,
                 SignupCodeIden::QuotaStorageMb,
                 SignupCodeIden::QuotaRateRead,
@@ -88,6 +120,65 @@ impl SignupCodeRepository {
         let con = executor.get_con().await?;
         let code: SignupCodeEntity = sqlx::query_as_with(&query, values).fetch_one(con).await?;
         Ok(code)
+    }
+
+    /// List signup codes in token order.
+    /// The executor can either be db.pool() or a transaction.
+    pub async fn list<'a>(
+        list_query: SignupCodeListQuery,
+        executor: &mut UnifiedExecutor<'a>,
+    ) -> Result<SignupCodeListPage, sqlx::Error> {
+        let mut statement = Query::select()
+            .from(SIGNUP_CODE_TABLE)
+            .columns([
+                SignupCodeIden::Id,
+                SignupCodeIden::CreatedAt,
+                SignupCodeIden::UsedAt,
+                SignupCodeIden::UsedBy,
+                SignupCodeIden::QuotaStorageMb,
+                SignupCodeIden::QuotaRateRead,
+                SignupCodeIden::QuotaRateWrite,
+                SignupCodeIden::QuotaRateReadBurst,
+                SignupCodeIden::QuotaRateWriteBurst,
+                SignupCodeIden::AllowedWritePaths,
+            ])
+            .order_by(SignupCodeIden::Id, Order::Asc)
+            .to_owned();
+
+        statement = match list_query.state {
+            SignupCodeListState::All => statement,
+            SignupCodeListState::Used => statement
+                .and_where(Expr::col(SignupCodeIden::UsedBy).is_not_null())
+                .to_owned(),
+            SignupCodeListState::Unused => statement
+                .and_where(Expr::col(SignupCodeIden::UsedBy).is_null())
+                .to_owned(),
+        };
+
+        if let Some(cursor) = &list_query.cursor {
+            statement = statement
+                .and_where(Expr::col(SignupCodeIden::Id).gt(cursor.to_string()))
+                .to_owned();
+        }
+
+        let limit = list_query.effective_limit();
+        statement = statement.limit((limit as u64) + 1).to_owned();
+
+        let (query, values) = statement.build_sqlx(PostgresQueryBuilder);
+        let con = executor.get_con().await?;
+        let mut codes: Vec<SignupCodeEntity> =
+            sqlx::query_as_with(&query, values).fetch_all(con).await?;
+        let next_cursor = if codes.len() > limit as usize {
+            codes.truncate(limit as usize);
+            codes.last().map(|code| code.id.clone())
+        } else {
+            None
+        };
+
+        Ok(SignupCodeListPage {
+            items: codes,
+            next_cursor,
+        })
     }
 
     /// Get overview statistics for signup codes.
@@ -133,10 +224,13 @@ impl SignupCodeRepository {
     ) -> Result<SignupCodeEntity, sqlx::Error> {
         let statement = Query::update()
             .table(SIGNUP_CODE_TABLE)
-            .values(vec![(
-                SignupCodeIden::UsedBy,
-                SimpleExpr::Value(used_by.z32().into()),
-            )])
+            .values(vec![
+                (
+                    SignupCodeIden::UsedBy,
+                    SimpleExpr::Value(used_by.z32().into()),
+                ),
+                (SignupCodeIden::UsedAt, Expr::current_timestamp().into()),
+            ])
             .and_where(Expr::col(SignupCodeIden::Id).eq(id.to_string()))
             .and_where(Expr::col(SignupCodeIden::UsedBy).is_null())
             .returning_all()
@@ -156,6 +250,7 @@ impl SignupCodeRepository {
 pub enum SignupCodeIden {
     Id,
     CreatedAt,
+    UsedAt,
     UsedBy,
     QuotaStorageMb,
     QuotaRateRead,
@@ -231,6 +326,7 @@ pub struct SignupCodeOverview {
 pub struct SignupCodeEntity {
     pub id: SignupCode,
     pub created_at: sqlx::types::chrono::NaiveDateTime,
+    pub used_at: Option<sqlx::types::chrono::NaiveDateTime>,
     pub used_by: Option<PublicKey>,
     /// Per-user storage quota in MB. `None` = Default (resolved from system config at enforcement time).
     pub quota_storage_mb: Option<i32>,
@@ -271,6 +367,8 @@ impl FromRow<'_, PgRow> for SignupCodeEntity {
         })?;
         let created_at: sqlx::types::chrono::NaiveDateTime =
             row.try_get(SignupCodeIden::CreatedAt.to_string().as_str())?;
+        let used_at: Option<sqlx::types::chrono::NaiveDateTime> =
+            row.try_get(SignupCodeIden::UsedAt.to_string().as_str())?;
         let used_by_raw: Option<String> =
             row.try_get(SignupCodeIden::UsedBy.to_string().as_str())?;
         let used_by = used_by_raw
@@ -295,6 +393,7 @@ impl FromRow<'_, PgRow> for SignupCodeEntity {
         Ok(SignupCodeEntity {
             id,
             created_at,
+            used_at,
             used_by,
             quota_storage_mb,
             quota_rate_read,
@@ -313,6 +412,13 @@ mod tests {
 
     use super::*;
 
+    async fn current_db_timestamp(db: &SqlDb) -> sqlx::types::chrono::NaiveDateTime {
+        sqlx::query_scalar("SELECT CURRENT_TIMESTAMP::timestamp")
+            .fetch_one(db.pool())
+            .await
+            .unwrap()
+    }
+
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_create_get_signup_code() {
@@ -328,6 +434,7 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(code.id, signup_code_id);
+        assert_eq!(code.used_at, None);
         assert_eq!(code.used_by, None);
         // All-default quota: all fields should be Default
         assert_eq!(code.quota(), UserQuota::default());
@@ -337,6 +444,7 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(code.id, signup_code_id);
+        assert_eq!(code.used_at, None);
         assert_eq!(code.used_by, None);
         assert_eq!(code.quota(), UserQuota::default());
     }
@@ -385,14 +493,27 @@ mod tests {
 
         let user_pubkey = Keypair::random().public_key();
 
-        SignupCodeRepository::mark_as_used(&signup_code_id, &user_pubkey, &mut db.pool().into())
-            .await
-            .unwrap();
+        let before = current_db_timestamp(&db).await;
+        let marked_code = SignupCodeRepository::mark_as_used(
+            &signup_code_id,
+            &user_pubkey,
+            &mut db.pool().into(),
+        )
+        .await
+        .unwrap();
+        let after = current_db_timestamp(&db).await;
+        let used_at = marked_code.used_at.expect("used_at should be set");
+        assert!(
+            used_at >= before && used_at <= after,
+            "used_at {used_at} should be between DB timestamps {before} and {after}"
+        );
+
         let updated_code = SignupCodeRepository::get(&signup_code_id, &mut db.pool().into())
             .await
             .unwrap();
         assert_eq!(updated_code.id, signup_code_id);
         assert_eq!(updated_code.used_by, Some(user_pubkey));
+        assert_eq!(updated_code.used_at, Some(used_at));
     }
 
     #[tokio::test]

--- a/pubky-homeserver/src/persistence/sql/entities/signup_code.rs
+++ b/pubky-homeserver/src/persistence/sql/entities/signup_code.rs
@@ -5,6 +5,7 @@ use pubky_common::crypto::random_bytes;
 use pubky_common::crypto::PublicKey;
 use sea_query::{Expr, Iden, Order, PostgresQueryBuilder, Query, SimpleExpr};
 use sea_query_binder::SqlxBinder;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use sqlx::{postgres::PgRow, FromRow, Row};
 
 use crate::shared::user_quota::UserQuota;
@@ -18,7 +19,8 @@ pub const SIGNUP_CODE_TABLE: &str = "signup_codes";
 /// Repository that handles all the queries regarding the SignupCodeEntity.
 pub struct SignupCodeRepository;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum SignupCodeListState {
     All,
     Used,
@@ -312,6 +314,25 @@ impl FromStr for SignupCode {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Self::new(s.to_string())
+    }
+}
+
+impl Serialize for SignupCode {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for SignupCode {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = String::deserialize(deserializer)?;
+        Self::new(value).map_err(serde::de::Error::custom)
     }
 }
 

--- a/pubky-homeserver/src/persistence/sql/migrations/m20260609_add_signup_code_used_at.rs
+++ b/pubky-homeserver/src/persistence/sql/migrations/m20260609_add_signup_code_used_at.rs
@@ -1,0 +1,21 @@
+use async_trait::async_trait;
+use sqlx::Transaction;
+
+use crate::persistence::sql::migration::MigrationTrait;
+
+/// Adds the timestamp for signup token consumption.
+pub struct M20260609AddSignupCodeUsedAtMigration;
+
+#[async_trait]
+impl MigrationTrait for M20260609AddSignupCodeUsedAtMigration {
+    async fn up(&self, tx: &mut Transaction<'static, sqlx::Postgres>) -> anyhow::Result<()> {
+        sqlx::query("ALTER TABLE signup_codes ADD COLUMN IF NOT EXISTS used_at TIMESTAMP")
+            .execute(&mut **tx)
+            .await?;
+        Ok(())
+    }
+
+    fn name(&self) -> &str {
+        "m20260609_add_signup_code_used_at"
+    }
+}

--- a/pubky-homeserver/src/persistence/sql/migrations/m20260609_add_signup_code_used_at.rs
+++ b/pubky-homeserver/src/persistence/sql/migrations/m20260609_add_signup_code_used_at.rs
@@ -12,6 +12,11 @@ impl MigrationTrait for M20260609AddSignupCodeUsedAtMigration {
         sqlx::query("ALTER TABLE signup_codes ADD COLUMN IF NOT EXISTS used_at TIMESTAMP")
             .execute(&mut **tx)
             .await?;
+        sqlx::query(
+            "UPDATE signup_codes SET used_at = created_at WHERE used_by IS NOT NULL AND used_at IS NULL",
+        )
+        .execute(&mut **tx)
+        .await?;
         Ok(())
     }
 

--- a/pubky-homeserver/src/persistence/sql/migrations/mod.rs
+++ b/pubky-homeserver/src/persistence/sql/migrations/mod.rs
@@ -7,6 +7,7 @@ mod m20251014_events_table_index_and_content_hash;
 pub(crate) mod m20260325_create_grant_sessions;
 mod m20260327_add_quota_columns;
 mod m20260507_add_allowed_write_paths;
+mod m20260609_add_signup_code_used_at;
 
 pub(crate) use m20250806_create_user::M20250806CreateUserMigration;
 pub(crate) use m20250812_create_signup_code::M20250812CreateSignupCodeMigration;
@@ -17,3 +18,4 @@ pub(crate) use m20251014_events_table_index_and_content_hash::M20251014EventsTab
 pub(crate) use m20260325_create_grant_sessions::M20260325CreateGrantSessionsMigration;
 pub(crate) use m20260327_add_quota_columns::M20260327AddQuotaColumnsMigration;
 pub(crate) use m20260507_add_allowed_write_paths::M20260507AddAllowedWritePathsMigration;
+pub(crate) use m20260609_add_signup_code_used_at::M20260609AddSignupCodeUsedAtMigration;

--- a/pubky-homeserver/src/persistence/sql/migrator.rs
+++ b/pubky-homeserver/src/persistence/sql/migrator.rs
@@ -9,7 +9,7 @@ use crate::persistence::sql::{
         M20250813CreateSessionMigration, M20250814CreateEventMigration,
         M20250815CreateEntryMigration, M20251014EventsTableIndexAndContentHashMigration,
         M20260325CreateGrantSessionsMigration, M20260327AddQuotaColumnsMigration,
-        M20260507AddAllowedWritePathsMigration,
+        M20260507AddAllowedWritePathsMigration, M20260609AddSignupCodeUsedAtMigration,
     },
     sql_db::SqlDb,
 };
@@ -42,6 +42,7 @@ impl<'a> Migrator<'a> {
             Box::new(M20260325CreateGrantSessionsMigration),
             Box::new(M20260327AddQuotaColumnsMigration),
             Box::new(M20260507AddAllowedWritePathsMigration),
+            Box::new(M20260609AddSignupCodeUsedAtMigration),
         ]
     }
 


### PR DESCRIPTION
## Summary

Closes #402.

Adds an authenticated admin endpoint to list signup tokens with pagination and usage metadata.

## What Changed

- Added `GET /signup_tokens` to the admin API.
- Supports query params:
  - `state=all|used|unused`
  - `limit`
  - `cursor`
- Returns signup token records with:
  - `token`
  - `created_at`
  - `used_at`
  - `used_by`
- Added `used_at` tracking when a signup token is marked as used.
- Added a migration to add nullable `signup_codes.used_at`.

## Notes on open questions

Signup tokens remain single-use: `used_by` is still scalar. This PR does not add TTL or expiration behavior.
