### PR TITLE
fix: path collisions

### DIFF
--- a/e2e/src/tests/storage/listing.rs
+++ b/e2e/src/tests/storage/listing.rs
@@ -189,7 +189,9 @@ async fn list_shallow() {
             vec![
                 format!("{public_key}/pub/a.com/").parse().unwrap(),
                 format!("{public_key}/pub/example.com/").parse().unwrap(),
-                format!("{public_key}/pub/example.con-file").parse().unwrap(),
+                format!("{public_key}/pub/example.con-file")
+                    .parse()
+                    .unwrap(),
                 format!("{public_key}/pub/example.con/").parse().unwrap(),
                 format!("{public_key}/pub/file").parse().unwrap(),
                 format!("{public_key}/pub/file2").parse().unwrap(),
@@ -236,7 +238,9 @@ async fn list_shallow() {
     assert_eq!(
         list1,
         vec![
-            format!("{public_key}/pub/example.con-file").parse().unwrap(),
+            format!("{public_key}/pub/example.con-file")
+                .parse()
+                .unwrap(),
             format!("{public_key}/pub/example.con/").parse().unwrap(),
         ],
         "normal list shallow with limit and a file cursor"
@@ -274,7 +278,9 @@ async fn list_shallow() {
         assert_eq!(
             list,
             vec![
-                format!("{public_key}/pub/example.con-file").parse().unwrap(),
+                format!("{public_key}/pub/example.con-file")
+                    .parse()
+                    .unwrap(),
                 format!("{public_key}/pub/example.con/").parse().unwrap(),
                 format!("{public_key}/pub/file").parse().unwrap(),
             ],

--- a/e2e/src/tests/storage/listing.rs
+++ b/e2e/src/tests/storage/listing.rs
@@ -162,7 +162,7 @@ async fn list_shallow() {
         format!("/pub/example.com/c.txt"),
         format!("/pub/example.com/d.txt"),
         format!("/pub/example.con/d.txt"),
-        format!("/pub/example.con"),
+        format!("/pub/example.con-file"),
         format!("/pub/file"),
         format!("/pub/file2"),
         format!("/pub/z.com/a.txt"),
@@ -189,7 +189,7 @@ async fn list_shallow() {
             vec![
                 format!("{public_key}/pub/a.com/").parse().unwrap(),
                 format!("{public_key}/pub/example.com/").parse().unwrap(),
-                format!("{public_key}/pub/example.con").parse().unwrap(),
+                format!("{public_key}/pub/example.con-file").parse().unwrap(),
                 format!("{public_key}/pub/example.con/").parse().unwrap(),
                 format!("{public_key}/pub/file").parse().unwrap(),
                 format!("{public_key}/pub/file2").parse().unwrap(),
@@ -236,7 +236,7 @@ async fn list_shallow() {
     assert_eq!(
         list1,
         vec![
-            format!("{public_key}/pub/example.con").parse().unwrap(),
+            format!("{public_key}/pub/example.con-file").parse().unwrap(),
             format!("{public_key}/pub/example.con/").parse().unwrap(),
         ],
         "normal list shallow with limit and a file cursor"
@@ -274,7 +274,7 @@ async fn list_shallow() {
         assert_eq!(
             list,
             vec![
-                format!("{public_key}/pub/example.con").parse().unwrap(),
+                format!("{public_key}/pub/example.con-file").parse().unwrap(),
                 format!("{public_key}/pub/example.con/").parse().unwrap(),
                 format!("{public_key}/pub/file").parse().unwrap(),
             ],

--- a/e2e/src/tests/storage/objects.rs
+++ b/e2e/src/tests/storage/objects.rs
@@ -1,4 +1,17 @@
 use super::*;
+use base64::Engine;
+
+fn assert_server_status(error: Error, expected: StatusCode) {
+    assert!(
+        matches!(error, Error::Request(RequestError::Server { status, .. }) if status == expected),
+        "expected server status {expected}, got {error:?}"
+    );
+}
+
+fn admin_basic_auth(password: &str) -> String {
+    let auth = base64::engine::general_purpose::STANDARD.encode(format!("admin:{password}"));
+    format!("Basic {auth}")
+}
 
 #[tokio::test]
 #[pubky_testnet::test]
@@ -75,6 +88,124 @@ async fn put_get_delete() {
 
     // Should not exist, PubkyError of 404 type
     assert!(session.storage().get(path).await.is_err());
+}
+
+#[tokio::test]
+#[pubky_testnet::test]
+async fn path_collisions_return_conflict_and_recover_after_delete() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+
+    let signer = pubky.signer(Keypair::random());
+    let session = signer
+        .signup_cookie(&server.public_key(), None)
+        .await
+        .unwrap();
+
+    let exact = "/pub/app/foo";
+    let descendant = "/pub/app/foo/bar.json";
+
+    session.storage().put(exact, vec![1]).await.unwrap();
+
+    let err = session
+        .storage()
+        .put(descendant, vec![2])
+        .await
+        .expect_err("descendant write should conflict with exact file");
+    assert_server_status(err, StatusCode::CONFLICT);
+    let err = session
+        .storage()
+        .get(descendant)
+        .await
+        .expect_err("rejected descendant should not be readable");
+    assert_server_status(err, StatusCode::NOT_FOUND);
+
+    session.storage().delete(exact).await.unwrap();
+    session.storage().put(descendant, vec![3]).await.unwrap();
+
+    let err = session
+        .storage()
+        .put(exact, vec![4])
+        .await
+        .expect_err("exact-file write should conflict with descendant");
+    assert_server_status(err, StatusCode::CONFLICT);
+    let err = session
+        .storage()
+        .get(exact)
+        .await
+        .expect_err("rejected exact file should not be readable");
+    assert_server_status(err, StatusCode::NOT_FOUND);
+
+    session.storage().delete(descendant).await.unwrap();
+    session.storage().put(exact, vec![5]).await.unwrap();
+}
+
+#[tokio::test]
+#[pubky_testnet::test]
+async fn deleting_legacy_exact_file_does_not_delete_descendants() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+
+    let signer = pubky.signer(Keypair::random());
+    let session = signer
+        .signup_cookie(&server.public_key(), None)
+        .await
+        .unwrap();
+    let user = session.public_key().z32();
+
+    let admin_password = pubky_testnet::pubky_homeserver::ConfigToml::default_test_config()
+        .admin
+        .admin_password;
+    let admin_auth = admin_basic_auth(&admin_password);
+    let admin_socket = server
+        .admin_server()
+        .expect("admin server should be enabled")
+        .listen_socket();
+    let admin_client = pubky_testnet::pubky::PubkyHttpClient::new().unwrap();
+
+    let exact_url = format!("http://{admin_socket}/dav/{user}/pub/app/foo");
+    let descendant_url = format!("http://{admin_socket}/dav/{user}/pub/app/foo/bar.json");
+    let exact = "/pub/app/foo";
+    let descendant = "/pub/app/foo/bar.json";
+
+    let response = admin_client
+        .request(Method::PUT, &exact_url)
+        .header("Authorization", &admin_auth)
+        .body(vec![1])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    let response = admin_client
+        .request(Method::PUT, &descendant_url)
+        .header("Authorization", &admin_auth)
+        .body(vec![2])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+
+    session.storage().delete(exact).await.unwrap();
+
+    let err = session
+        .storage()
+        .get(exact)
+        .await
+        .expect_err("deleted exact file should not be readable");
+    assert_server_status(err, StatusCode::NOT_FOUND);
+
+    let descendant_bytes = session
+        .storage()
+        .get(descendant)
+        .await
+        .unwrap()
+        .bytes()
+        .await
+        .unwrap();
+    assert_eq!(descendant_bytes.as_ref(), &[2]);
 }
 
 use serde::{Deserialize, Serialize};

--- a/pubky-homeserver/src/persistence/files/file/file_io_error.rs
+++ b/pubky-homeserver/src/persistence/files/file/file_io_error.rs
@@ -17,6 +17,8 @@ pub enum FileIoError {
     DiskSpaceQuotaExceeded,
     #[error("Write to path is forbidden")]
     WritePathForbidden,
+    #[error("File/folder path collision")]
+    PathCollision,
 }
 
 impl From<opendal::Error> for FileIoError {
@@ -30,6 +32,7 @@ impl From<opendal::Error> for FileIoError {
             return match domain {
                 LayerDomainError::WritePathForbidden => FileIoError::WritePathForbidden,
                 LayerDomainError::DiskSpaceQuotaExceeded => FileIoError::DiskSpaceQuotaExceeded,
+                LayerDomainError::PathCollision => FileIoError::PathCollision,
             };
         }
         match e.kind() {

--- a/pubky-homeserver/src/persistence/files/file/file_service.rs
+++ b/pubky-homeserver/src/persistence/files/file/file_service.rs
@@ -350,6 +350,80 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_rejects_descendant_when_exact_file_exists() {
+        let context = AppContext::test().await;
+        let file_service = FileService::new_from_context(&context).unwrap();
+        let db = context.sql_db.clone();
+
+        let pubkey = pubky_common::crypto::Keypair::random().public_key();
+        UserRepository::create(&pubkey, &mut db.pool().into())
+            .await
+            .unwrap();
+
+        let exact_path = EntryPath::new(pubkey.clone(), WebDavPath::new("/pub/app/foo").unwrap());
+        let descendant_path = EntryPath::new(
+            pubkey.clone(),
+            WebDavPath::new("/pub/app/foo/bar.json").unwrap(),
+        );
+
+        file_service
+            .write(&exact_path, Buffer::from(vec![1; 10]))
+            .await
+            .unwrap();
+        let err = file_service
+            .write(&descendant_path, Buffer::from(vec![2; 10]))
+            .await
+            .expect_err("descendant write should be rejected");
+
+        assert!(matches!(err, FileIoError::PathCollision));
+        file_service
+            .get_info(&descendant_path, &mut db.pool().into())
+            .await
+            .expect_err("Rejected descendant should not create metadata");
+        file_service
+            .get(&descendant_path)
+            .await
+            .expect_err("Rejected descendant should not create a blob");
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_rejects_exact_file_when_descendant_exists() {
+        let context = AppContext::test().await;
+        let file_service = FileService::new_from_context(&context).unwrap();
+        let db = context.sql_db.clone();
+
+        let pubkey = pubky_common::crypto::Keypair::random().public_key();
+        UserRepository::create(&pubkey, &mut db.pool().into())
+            .await
+            .unwrap();
+
+        let exact_path = EntryPath::new(pubkey.clone(), WebDavPath::new("/pub/app/foo").unwrap());
+        let descendant_path =
+            EntryPath::new(pubkey, WebDavPath::new("/pub/app/foo/bar.json").unwrap());
+
+        file_service
+            .write(&descendant_path, Buffer::from(vec![1; 10]))
+            .await
+            .unwrap();
+        let err = file_service
+            .write(&exact_path, Buffer::from(vec![2; 10]))
+            .await
+            .expect_err("exact-file write should be rejected");
+
+        assert!(matches!(err, FileIoError::PathCollision));
+        file_service
+            .get_info(&exact_path, &mut db.pool().into())
+            .await
+            .expect_err("Rejected exact file should not create metadata");
+        file_service
+            .get(&exact_path)
+            .await
+            .expect_err("Rejected exact file should not create a blob");
+    }
+
     /// Write a file that is exactly at the quota and check if the data usage is updated correctly.
     #[tokio::test]
     #[pubky_test_utils::test]

--- a/pubky-homeserver/src/persistence/files/layer_domain_error.rs
+++ b/pubky-homeserver/src/persistence/files/layer_domain_error.rs
@@ -10,4 +10,6 @@ pub enum LayerDomainError {
     WritePathForbidden,
     #[error("disk_space_quota_exceeded")]
     DiskSpaceQuotaExceeded,
+    #[error("path_collision")]
+    PathCollision,
 }

--- a/pubky-homeserver/src/persistence/files/mod.rs
+++ b/pubky-homeserver/src/persistence/files/mod.rs
@@ -4,10 +4,11 @@
 //! backends). Operations pass through a layered middleware stack (outermost first):
 //!
 //! 1. **[`write_path_layer`]** — enforces per-user allowed write paths (outermost, runs first).
-//! 2. **[`events`]** — creates event records (PUT/DEL) after inner layers complete on close.
-//! 3. **[`entry`]** — updates file metadata (blake3 hash, size, MIME type) in Postgres.
-//! 4. **[`user_quota_layer`]** — enforces per-user storage quotas.
-//! 5. **OpenDAL base** — physical storage I/O.
+//! 2. **[`path_collision_layer`]** — rejects file/folder path collisions before backend writes.
+//! 3. **[`events`]** — creates event records (PUT/DEL) after inner layers complete on close.
+//! 4. **[`entry`]** — updates file metadata (blake3 hash, size, MIME type) in Postgres.
+//! 5. **[`user_quota_layer`]** — enforces per-user storage quotas.
+//! 6. **OpenDAL base** — physical storage I/O.
 //!
 //! [`file`] provides the high-level [`FileService`](file::file_service::FileService)
 //! used by route handlers.
@@ -18,6 +19,7 @@ mod layer_domain_error;
 mod opendal;
 
 pub(crate) mod events;
+pub(crate) mod path_collision_layer;
 pub(crate) mod user_quota_layer;
 pub(crate) mod write_path_layer;
 

--- a/pubky-homeserver/src/persistence/files/opendal/opendal_service.rs
+++ b/pubky-homeserver/src/persistence/files/opendal/opendal_service.rs
@@ -7,6 +7,7 @@ use crate::{
         files::{
             entry::entry_layer::EntryLayer,
             events::{EventsLayer, EventsService},
+            path_collision_layer::PathCollisionLayer,
             user_quota_layer::UserQuotaLayer,
             write_path_layer::WritePathLayer,
         },
@@ -43,9 +44,9 @@ pub fn build_storage_operators(
     let events_layer = EventsLayer::new(db.clone(), events_service);
     // Note: Layers ordering is important:
     // Layers are applied last-to-first: write_path_layer (outermost) runs first,
-    // rejecting disallowed writes before they reach quota/entry/event layers.
-    // events_layer runs after entry_layer.close() completes, guaranteeing the
-    // file is written before the Event is created.
+    // then path_collision_layer rejects file/folder collisions
+    // before they reach storage. events_layer runs after entry_layer.close()
+    // completes, guaranteeing the file is written before the Event is created.
     let admin_operator = match &storage_config.backend {
         StorageConfigToml::FileSystem => {
             let files_dir = match data_directory.join("data/files").to_str() {
@@ -91,6 +92,7 @@ pub fn build_storage_operators(
 
     let operator = admin_operator
         .clone()
+        .layer(PathCollisionLayer::new(db.clone()))
         .layer(WritePathLayer::new(user_service));
     Ok((operator, admin_operator))
 }

--- a/pubky-homeserver/src/persistence/files/path_collision_layer.rs
+++ b/pubky-homeserver/src/persistence/files/path_collision_layer.rs
@@ -73,6 +73,7 @@ impl<A: Access> LayeredAccess for PathCollisionAccessor<A> {
     }
 
     async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
+        self.check_no_path_collision(path).await?;
         self.inner.create_dir(path, args).await
     }
 

--- a/pubky-homeserver/src/persistence/files/path_collision_layer.rs
+++ b/pubky-homeserver/src/persistence/files/path_collision_layer.rs
@@ -1,0 +1,113 @@
+use std::sync::Arc;
+
+use crate::persistence::files::layer_domain_error::LayerDomainError;
+use crate::persistence::sql::{entry::EntryRepository, SqlDb};
+use crate::shared::webdav::EntryPath;
+use opendal::raw::*;
+use opendal::Result;
+
+/// OpenDAL layer that rejects app-facing file/folder path collisions before
+/// opening a backend writer.
+#[derive(Clone)]
+pub struct PathCollisionLayer {
+    db: SqlDb,
+}
+
+impl PathCollisionLayer {
+    pub fn new(db: SqlDb) -> Self {
+        Self { db }
+    }
+}
+
+impl<A: Access> Layer<A> for PathCollisionLayer {
+    type LayeredAccess = PathCollisionAccessor<A>;
+
+    fn layer(&self, inner: A) -> Self::LayeredAccess {
+        PathCollisionAccessor {
+            inner: Arc::new(inner),
+            db: self.db.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PathCollisionAccessor<A: Access> {
+    inner: Arc<A>,
+    db: SqlDb,
+}
+
+impl<A: Access> PathCollisionAccessor<A> {
+    async fn check_no_path_collision(&self, path: &str) -> Result<()> {
+        let entry_path = EntryPath::parse_opendal(path)?;
+        let has_collision =
+            EntryRepository::has_file_folder_collision(&entry_path, &mut self.db.pool().into())
+                .await
+                .map_err(|e| {
+                    opendal::Error::new(
+                        opendal::ErrorKind::Unexpected,
+                        format!("Failed to check path collision for {entry_path}: {e}"),
+                    )
+                })?;
+
+        if has_collision {
+            return Err(opendal::Error::new(
+                opendal::ErrorKind::AlreadyExists,
+                format!("File/folder path collision for {entry_path}"),
+            )
+            .set_source(LayerDomainError::PathCollision));
+        }
+
+        Ok(())
+    }
+}
+
+impl<A: Access> LayeredAccess for PathCollisionAccessor<A> {
+    type Inner = A;
+    type Reader = A::Reader;
+    type Writer = A::Writer;
+    type Lister = A::Lister;
+    type Deleter = A::Deleter;
+
+    fn inner(&self) -> &Self::Inner {
+        &self.inner
+    }
+
+    async fn create_dir(&self, path: &str, args: OpCreateDir) -> Result<RpCreateDir> {
+        self.inner.create_dir(path, args).await
+    }
+
+    async fn read(&self, path: &str, args: OpRead) -> Result<(RpRead, Self::Reader)> {
+        self.inner.read(path, args).await
+    }
+
+    async fn write(&self, path: &str, args: OpWrite) -> Result<(RpWrite, Self::Writer)> {
+        self.check_no_path_collision(path).await?;
+        self.inner.write(path, args).await
+    }
+
+    async fn copy(&self, from: &str, to: &str, args: OpCopy) -> Result<RpCopy> {
+        self.check_no_path_collision(to).await?;
+        self.inner.copy(from, to, args).await
+    }
+
+    async fn rename(&self, from: &str, to: &str, args: OpRename) -> Result<RpRename> {
+        self.check_no_path_collision(to).await?;
+        self.inner.rename(from, to, args).await
+    }
+
+    async fn stat(&self, path: &str, args: OpStat) -> Result<RpStat> {
+        self.inner.stat(path, args).await
+    }
+
+    async fn delete(&self) -> Result<(RpDelete, Self::Deleter)> {
+        self.inner.delete().await
+    }
+
+    async fn list(&self, path: &str, args: OpList) -> Result<(RpList, Self::Lister)> {
+        self.inner.list(path, args).await
+    }
+
+    async fn presign(&self, path: &str, args: OpPresign) -> Result<RpPresign> {
+        self.inner.presign(path, args).await
+    }
+}

--- a/pubky-homeserver/src/persistence/sql/entities/entry/repository.rs
+++ b/pubky-homeserver/src/persistence/sql/entities/entry/repository.rs
@@ -226,6 +226,67 @@ impl EntryRepository {
         Ok(count > 0)
     }
 
+    /// Check if writing `path` would make an exact file path collide with an
+    /// implicit folder path for the same user.
+    pub async fn has_file_folder_collision<'a>(
+        path: &EntryPath,
+        executor: &mut UnifiedExecutor<'a>,
+    ) -> Result<bool, sqlx::Error> {
+        let path_str = path.path().as_str();
+        let descendant_prefix = if path_str.ends_with('/') {
+            path_str.to_string()
+        } else {
+            format!("{path_str}/")
+        };
+        let ancestor_paths = Self::ancestor_file_paths(path_str);
+
+        // Reject both collision directions for the same user:
+        // - existing descendants under `path/`
+        // - existing exact-file ancestors of `path`
+        let con = executor.get_con().await?;
+        sqlx::query_scalar(
+            r#"
+            SELECT EXISTS (
+                SELECT 1
+                FROM entries
+                JOIN users
+                  ON users.id = entries."user"
+                WHERE users.public_key = $1
+                  AND (
+                    (
+                      entries.path <> $3
+                      AND substr(entries.path, 1, length($2)) = $2
+                    )
+                    OR entries.path = ANY($4::text[])
+                  )
+            )
+            "#,
+        )
+        .bind(path.pubkey().z32())
+        .bind(descendant_prefix)
+        .bind(path_str)
+        .bind(ancestor_paths)
+        .fetch_one(con)
+        .await
+    }
+
+    fn ancestor_file_paths(path: &str) -> Vec<String> {
+        let path = path.trim_end_matches('/');
+        if path.is_empty() || path == "/" {
+            return Vec::new();
+        }
+
+        path.char_indices()
+            .filter_map(|(idx, ch)| {
+                if ch == '/' && idx > 0 {
+                    Some(path[..idx].to_string())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
     /// List shallow files + folders.
     /// Path is the path to the folder.
     /// Limit is the maximum number of entries to return.
@@ -467,6 +528,118 @@ mod tests {
         EntryRepository::get_by_path(&entry.path, &mut db.pool().into())
             .await
             .expect_err("Entry should be deleted");
+    }
+
+    async fn create_entry_for_path(db: &SqlDb, user_id: i32, path: &str) {
+        EntryRepository::create(
+            user_id,
+            &WebDavPath::new(path).unwrap(),
+            &pubky_common::crypto::Hash::from_bytes([0; 32]),
+            100,
+            "text/plain",
+            &mut db.pool().into(),
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_file_folder_collision_when_descendant_exists() {
+        let db = SqlDb::test().await;
+        let user_pubkey = Keypair::random().public_key();
+        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
+            .await
+            .unwrap();
+        create_entry_for_path(&db, user.id, "/test/sub1/1.txt").await;
+
+        let target = EntryPath::new(user_pubkey, WebDavPath::new("/test/sub1").unwrap());
+        let has_collision =
+            EntryRepository::has_file_folder_collision(&target, &mut db.pool().into())
+                .await
+                .unwrap();
+
+        assert!(has_collision);
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_file_folder_collision_when_ancestor_file_exists() {
+        let db = SqlDb::test().await;
+        let user_pubkey = Keypair::random().public_key();
+        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
+            .await
+            .unwrap();
+        create_entry_for_path(&db, user.id, "/test/sub1").await;
+
+        let target = EntryPath::new(user_pubkey, WebDavPath::new("/test/sub1/1.txt").unwrap());
+        let has_collision =
+            EntryRepository::has_file_folder_collision(&target, &mut db.pool().into())
+                .await
+                .unwrap();
+
+        assert!(has_collision);
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_file_folder_collision_allows_exact_overwrite() {
+        let db = SqlDb::test().await;
+        let user_pubkey = Keypair::random().public_key();
+        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
+            .await
+            .unwrap();
+        create_entry_for_path(&db, user.id, "/test/sub1").await;
+
+        let target = EntryPath::new(user_pubkey, WebDavPath::new("/test/sub1").unwrap());
+        let has_collision =
+            EntryRepository::has_file_folder_collision(&target, &mut db.pool().into())
+                .await
+                .unwrap();
+
+        assert!(!has_collision);
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_file_folder_collision_does_not_match_siblings() {
+        let db = SqlDb::test().await;
+        let user_pubkey = Keypair::random().public_key();
+        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
+            .await
+            .unwrap();
+        create_entry_for_path(&db, user.id, "/test/sub11/file.txt").await;
+
+        let target = EntryPath::new(user_pubkey, WebDavPath::new("/test/sub1").unwrap());
+        let has_collision =
+            EntryRepository::has_file_folder_collision(&target, &mut db.pool().into())
+                .await
+                .unwrap();
+
+        assert!(!has_collision);
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_file_folder_collision_is_scoped_to_user() {
+        let db = SqlDb::test().await;
+        let user_a_pubkey = Keypair::random().public_key();
+        let user_a = UserRepository::create(&user_a_pubkey, &mut db.pool().into())
+            .await
+            .unwrap();
+        let user_b_pubkey = Keypair::random().public_key();
+        UserRepository::create(&user_b_pubkey, &mut db.pool().into())
+            .await
+            .unwrap();
+        create_entry_for_path(&db, user_a.id, "/test/sub1").await;
+
+        let target = EntryPath::new(user_b_pubkey, WebDavPath::new("/test/sub1/1.txt").unwrap());
+        let has_collision =
+            EntryRepository::has_file_folder_collision(&target, &mut db.pool().into())
+                .await
+                .unwrap();
+
+        assert!(!has_collision);
     }
 
     #[tokio::test]

--- a/pubky-homeserver/src/persistence/sql/entities/entry/repository.rs
+++ b/pubky-homeserver/src/persistence/sql/entities/entry/repository.rs
@@ -238,7 +238,14 @@ impl EntryRepository {
         } else {
             format!("{path_str}/")
         };
-        let ancestor_paths = Self::ancestor_file_paths(path_str);
+        let mut ancestor_paths = Self::ancestor_file_paths(path_str);
+        // If the path ends with a trailing slash (a directory-style path),
+        // also reject.
+        if let Some(without_trailing_slash) = path_str.strip_suffix('/') {
+            if !without_trailing_slash.is_empty() {
+                ancestor_paths.push(without_trailing_slash.to_string());
+            }
+        }
 
         // Reject both collision directions for the same user:
         // - existing descendants under `path/`
@@ -271,20 +278,20 @@ impl EntryRepository {
     }
 
     fn ancestor_file_paths(path: &str) -> Vec<String> {
-        let path = path.trim_end_matches('/');
-        if path.is_empty() || path == "/" {
+        let mut path = path.trim_end_matches('/');
+        if path.is_empty() {
             return Vec::new();
         }
 
-        path.char_indices()
-            .filter_map(|(idx, ch)| {
-                if ch == '/' && idx > 0 {
-                    Some(path[..idx].to_string())
-                } else {
-                    None
-                }
-            })
-            .collect()
+        let mut paths = Vec::new();
+        while let Some((parent, _)) = path.rsplit_once('/') {
+            if parent.is_empty() {
+                break;
+            }
+            paths.push(parent.to_string());
+            path = parent;
+        }
+        paths
     }
 
     /// List shallow files + folders.
@@ -573,6 +580,26 @@ mod tests {
         create_entry_for_path(&db, user.id, "/test/sub1").await;
 
         let target = EntryPath::new(user_pubkey, WebDavPath::new("/test/sub1/1.txt").unwrap());
+        let has_collision =
+            EntryRepository::has_file_folder_collision(&target, &mut db.pool().into())
+                .await
+                .unwrap();
+
+        assert!(has_collision);
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_file_folder_collision_when_writing_directory_over_existing_file() {
+        let db = SqlDb::test().await;
+        let user_pubkey = Keypair::random().public_key();
+        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
+            .await
+            .unwrap();
+        create_entry_for_path(&db, user.id, "/test/sub1").await;
+
+        // Directory-style target (trailing slash) over an existing exact file.
+        let target = EntryPath::new(user_pubkey, WebDavPath::new("/test/sub1/").unwrap());
         let has_collision =
             EntryRepository::has_file_folder_collision(&target, &mut db.pool().into())
                 .await

--- a/pubky-homeserver/src/shared/http_error.rs
+++ b/pubky-homeserver/src/shared/http_error.rs
@@ -122,6 +122,9 @@ impl From<FileIoError> for HttpError {
             FileIoError::WritePathForbidden => {
                 Self::forbidden_with_message("Write to this path is not allowed")
             }
+            FileIoError::PathCollision => {
+                Self::new_with_message(StatusCode::CONFLICT, "File/folder path collision")
+            }
             FileIoError::StreamBroken(_) => Self::bad_request("Stream broken"),
             e => Self::internal_server_and_log(format!("FileIoError: {}", e)),
         }

--- a/pubky-sdk/README.md
+++ b/pubky-sdk/README.md
@@ -147,6 +147,9 @@ Path rules:
 
 - Session storage uses **absolute** paths like `"/pub/app/file.txt"`.
 - Public storage uses **addressed** form `pubky<user>/pub/app/file.txt` (preferred) or `pubky://<user>/...`.
+- A storage path cannot be both an exact file and an implicit folder prefix. For example: 
+  - if `/pub/app/foo` exists, writing `/pub/app/foo/bar.json` returns `409 Conflict`. 
+  - if descendants under `/pub/app/foo/` exist, writing `/pub/app/foo` returns `409 Conflict`.
 
 **Convention:** put your app’s public data under a domain-like folder in `/pub`, e.g. `/pub/my-new-app/`.
 

--- a/pubky-sdk/bindings/js/pkg/tests/storage.ts
+++ b/pubky-sdk/bindings/js/pkg/tests/storage.ts
@@ -326,7 +326,7 @@ test("list shallow under /pub/", async (t) => {
     put("/pub/example.com/c.txt" as Path),
     put("/pub/example.com/d.txt" as Path),
     put("/pub/example.con/d.txt" as Path),
-    put("/pub/example.con" as Path),
+    put("/pub/example.con-file" as Path),
     put("/pub/file" as Path),
     put("/pub/file2" as Path),
     put("/pub/z.com/a.txt" as Path),
@@ -347,7 +347,7 @@ test("list shallow under /pub/", async (t) => {
       [
         `pubky://${pubky}/pub/a.com/`,
         `pubky://${pubky}/pub/example.com/`,
-        `pubky://${pubky}/pub/example.con`,
+        `pubky://${pubky}/pub/example.con-file`,
         `pubky://${pubky}/pub/example.con/`,
         `pubky://${pubky}/pub/file`,
         `pubky://${pubky}/pub/file2`,
@@ -364,7 +364,7 @@ test("list shallow under /pub/", async (t) => {
       [
         `pubky://${pubky}/pub/a.com/`,
         `pubky://${pubky}/pub/example.com/`,
-        `pubky://${pubky}/pub/example.con`,
+        `pubky://${pubky}/pub/example.con-file`,
       ],
       "shallow forward list with limit",
     );
@@ -372,7 +372,7 @@ test("list shallow under /pub/", async (t) => {
   {
     const list = await session.storage.list(
       dirPath,
-      `${pubky}/pub/example.con`,
+      `${pubky}/pub/example.con-file`,
       false,
       undefined,
       true,
@@ -404,7 +404,7 @@ test("list shallow under /pub/", async (t) => {
         `pubky://${pubky}/pub/file2`,
         `pubky://${pubky}/pub/file`,
         `pubky://${pubky}/pub/example.con/`,
-        `pubky://${pubky}/pub/example.con`,
+        `pubky://${pubky}/pub/example.con-file`,
         `pubky://${pubky}/pub/example.com/`,
         `pubky://${pubky}/pub/a.com/`,
       ],
@@ -419,7 +419,7 @@ test("list shallow under /pub/", async (t) => {
       [
         `pubky://${pubky}/pub/file`,
         `pubky://${pubky}/pub/example.con/`,
-        `pubky://${pubky}/pub/example.con`,
+        `pubky://${pubky}/pub/example.con-file`,
       ],
       "shallow reverse list with limit and cursor",
     );


### PR DESCRIPTION
## Summary

Closes #419.

This PR prevents new app file/folder path collisions in homeserver storage. Writes now fail with `409 Conflict` when a path would become both an exact file and an implicit folder prefix.

Examples:

- If `/pub/app/foo` exists, writing `/pub/app/foo/bar.json` returns `409 Conflict`.
- If `/pub/app/foo/bar.json` exists, writing `/pub/app/foo` returns `409 Conflict`.
- Exact overwrites remain allowed.

## Changes

- Added a `PathCollisionLayer` to the app-facing OpenDAL storage stack.
- Kept `admin_operator` unchanged so admin WebDAV/delete paths can still repair legacy data.
- Added `EntryRepository::has_file_folder_collision` for same-user collision detection.

## Notes

This does not migrate or block existing deployed collisions. The guard only prevents new app-facing collisions.

Admin maintenance paths can still access/delete legacy data. Deleting an exact file path does not delete descendants that may exist from legacy/admin-created collisions.