### PR TITLE
fix(sdk): use bundled webpki roots for ICANN TLS instead of platform verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3715,9 +3715,9 @@ dependencies = [
 
 [[package]]
 name = "pkarr"
-version = "6.0.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "997d5cbd9be48de01468085ecb82e951b82a04496cd76b1b3a1ea20b2fa84107"
+checksum = "51c6a54ffd41eaecab1c5736251f48f229638430939fcf1e02a22ddc632471be"
 dependencies = [
  "async-compat",
  "base32",
@@ -4003,7 +4003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ opt-level = 'z'
 # Setting "default-features = false" because cargo doesn't allow member crates to override the root "default-features" flag, which if not set, is implied to be true.
 # Member crates that need "default-features = false" should leave it out of their dependency specification, as it's inherited from here.
 # Member crates that need "default-features = true" should add a "default" feature to the features list, which is equivalent.
-pkarr = { version = "6", default-features = false }
+pkarr = { version = "6.0.1", default-features = false }
 mainline = { version = "6.1.1" }
 pkarr-relay = { version = "0.12" }
 log = "0.4.29"

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -2,12 +2,12 @@
 name = "e2e"
 edition.workspace = true
 rust-version.workspace = true
-version = "0.9.0"
+version = "0.9.1"
 publish = false
 
 [dependencies]
-pubky-testnet = { path = "../pubky-testnet" , version = "0.9.0" }
-pubky-common = { path = "../pubky-common" , version = "0.9.0" }
+pubky-testnet = { path = "../pubky-testnet" , version = "0.9.1" }
+pubky-common = { path = "../pubky-common" , version = "0.9.1" }
 tokio = { workspace = true, features = ["full", "test-util"] }
 tracing-subscriber.workspace = true
 pkarr = { workspace = true }

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky-core-examples"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 publish = false
@@ -52,9 +52,9 @@ futures-util = "0.3.31"
 anyhow.workspace = true
 base64 = "0.22.1"
 clap = { version = "4.6.0", features = ["derive"] }
-pubky = { path = "../../pubky-sdk" , version = "0.9.0" }
-pubky-testnet = { path = "../../pubky-testnet" , version = "0.9.0" }
-pubky-common = { path = "../../pubky-common" , version = "0.9.0" }
+pubky = { path = "../../pubky-sdk" , version = "0.9.1" }
+pubky-testnet = { path = "../../pubky-testnet" , version = "0.9.1" }
+pubky-common = { path = "../../pubky-common" , version = "0.9.1" }
 reqwest.workspace = true
 rpassword = "7.4.0"
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/pubky-common/Cargo.toml
+++ b/pubky-common/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubky-common"
 description = "Types and struct in common between Pubky client and homeserver"
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/pubky-homeserver/Cargo.toml
+++ b/pubky-homeserver/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubky-homeserver"
 description = "Pubky core's homeserver."
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -33,7 +33,7 @@ futures-util = "0.3.31"
 hex = "0.4.3"
 httpdate = "1.0.3"
 pkarr = { workspace = true, features = ["default", "dht", "tls"] }
-pubky-common = { path = "../pubky-common" , version = "0.9.0" }
+pubky-common = { path = "../pubky-common" , version = "0.9.1" }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1"
 tokio = { workspace = true, features = ["full"] }

--- a/pubky-sdk/Cargo.toml
+++ b/pubky-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubky"
 description = "Pubky SDK"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 rust-version.workspace = true
 authors = [
@@ -29,7 +29,7 @@ default = []
 json = ["dep:serde", "reqwest/json"]
 
 [dependencies]
-pubky-common = { path = "../pubky-common" , version = "0.9.0" }
+pubky-common = { path = "../pubky-common" , version = "0.9.1" }
 thiserror.workspace = true
 eventsource-stream = "0.2.3"
 url.workspace = true
@@ -59,7 +59,7 @@ wasm-bindgen-futures = "0.4.50"
 futures-lite = { version = "2.6.0", default-features = false }
 
 [dev-dependencies]
-pubky-testnet = { path = "../pubky-testnet" , version = "0.9.0" } # used in docstring tests
+pubky-testnet = { path = "../pubky-testnet" , version = "0.9.1" } # used in docstring tests
 httpmock = "0.7"
 http-relay = { workspace = true, features = ["server", "link-compat"] }
 

--- a/pubky-sdk/Cargo.toml
+++ b/pubky-sdk/Cargo.toml
@@ -49,6 +49,8 @@ reqwest = { workspace = true, features = [
     "json",
     "stream",
 ] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"] }
+webpki-roots = "0.26"
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
 

--- a/pubky-sdk/bindings/js/Cargo.toml
+++ b/pubky-sdk/bindings/js/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pubky-wasm"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 rust-version.workspace = true
 description = "Pubky-Core Client WASM bindings"
@@ -41,8 +41,8 @@ serde-wasm-bindgen = "0.6"
 tsify = "0.5.5"
 pubky = { path = "../../../pubky-sdk", default-features = false, features = [
     "json",
-] , version = "0.9.0" }
-pubky-common = { path = "../../../pubky-common" , version = "0.9.0" }
+] , version = "0.9.1" }
+pubky-common = { path = "../../../pubky-common" , version = "0.9.1" }
 pkarr = { workspace = true, default-features = false }
 web-sys = { version = "0.3.77", default-features = false, features = [
     "Request",

--- a/pubky-sdk/bindings/js/pkg/package-lock.json
+++ b/pubky-sdk/bindings/js/pkg/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@synonymdev/pubky",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@synonymdev/pubky",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "fetch-cookie": "^3.0.1"

--- a/pubky-sdk/bindings/js/pkg/package.json
+++ b/pubky-sdk/bindings/js/pkg/package.json
@@ -2,7 +2,7 @@
   "name": "@synonymdev/pubky",
   "type": "module",
   "description": "Pubky client",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/pubky-sdk/src/client/core.rs
+++ b/pubky-sdk/src/client/core.rs
@@ -216,8 +216,28 @@ impl PubkyHttpClientBuilder {
         #[cfg(target_arch = "wasm32")]
         let http_builder = reqwest::Client::builder().user_agent(user_agent.as_ref());
 
+        // ICANN domains use standard X.509 TLS. Pin bundled webpki roots with an explicit
+        // `ring` crypto provider instead of letting reqwest fall back to rustls-platform-verifier:
+        // the platform verifier panics on targets where it isn't initialised (e.g. Android/iOS
+        // without the native component), and relying on a process-default crypto provider is
+        // ambiguous when both `ring` and `aws-lc-rs` are in the dependency tree.
         #[cfg(not(target_arch = "wasm32"))]
-        let mut icann_http_builder = reqwest::Client::builder().user_agent(user_agent.as_ref());
+        let icann_tls_config = {
+            let mut roots = rustls::RootCertStore::empty();
+            roots.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+            rustls::ClientConfig::builder_with_provider(std::sync::Arc::new(
+                rustls::crypto::ring::default_provider(),
+            ))
+            .with_safe_default_protocol_versions()
+            .expect("ring provider supports the default protocol versions")
+            .with_root_certificates(roots)
+            .with_no_client_auth()
+        };
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let mut icann_http_builder = reqwest::Client::builder()
+            .user_agent(user_agent.as_ref())
+            .use_preconfigured_tls(icann_tls_config);
 
         // TODO: change this after Reqwest publish a release with timeout in wasm
         #[cfg(not(target_arch = "wasm32"))]

--- a/pubky-testnet/Cargo.toml
+++ b/pubky-testnet/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pubky-testnet"
 description = "A local test network for Pubky Core development."
-version = "0.9.0"
+version = "0.9.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -20,11 +20,11 @@ tokio = { workspace = true, features = ["full"] }
 tracing-subscriber.workspace = true
 url.workspace = true
 
-pubky = { path = "../pubky-sdk", features = ["json"] , version = "0.9.0" }
-pubky-common = { path = "../pubky-common" , version = "0.9.0" }
+pubky = { path = "../pubky-sdk", features = ["json"] , version = "0.9.1" }
+pubky-common = { path = "../pubky-common" , version = "0.9.1" }
 pubky-homeserver = { path = "../pubky-homeserver", default-features = false, features = [
     "testing",
-] , version = "0.9.0" }
+] , version = "0.9.1" }
 pubky_test_utils = { path = "../test_utils/pubky_test", version = "0.1.0" }
 # External http-relay: server + link-compat, no persist/cli (in-memory storage for tests)
 http-relay = { workspace = true, features = ["server", "link-compat"] }


### PR DESCRIPTION
## Problem

`PubkyHttpClient` builds its `icann_http` client with `reqwest::Client::builder()` and no explicit TLS config, so reqwest defaults to **rustls-platform-verifier**. On targets where that verifier isn't initialized — notably Android and iOS without the native verifier component — the *first* standard-TLS request panics:

```
panicked at rustls-platform-verifier-0.7.0/src/android.rs:90:
Expect rustls-platform-verifier to be initialized
```

Because the panic happens inside the background auth-relay polling task, the task is torn down, its channel sender drops, and the awaiting caller receives `AuthError::RequestExpired`. The visible symptom: **Pubky Ring sign-in never completes on mobile** — Ring approves successfully, but the requesting app errors out ~500 ms after `start_auth_flow` with "the provided auth request has expired or was cancelled", before approval even happens.

This was diagnosed end-to-end against a real device/emulator: Ring reaches the relay (it uses the OS HTTP stack), but the SDK's `icann_http` request to `httprelay.pubky.app` panics in the platform verifier.

## Fix

Build `icann_http` with bundled **webpki roots** and an explicit **ring** `CryptoProvider`, via `use_preconfigured_tls`. This:

- works on every platform with no native verifier component and no process-default crypto provider (which is itself ambiguous when both `ring` and `aws-lc-rs` are in the tree);
- only affects ICANN-host TLS — pubky-host TLS still goes through pkarr's RawPublicKey verifier (`ClientBuilder::from(pkarr)`), unchanged.

Adds `rustls` (ring) and `webpki-roots` to the non-wasm deps.

## Test

- Builds clean; the SDK compiles into a UniFFI Android library.
- Verified on an Android emulator: with this change, `httprelay.pubky.app` TLS succeeds, the relay poller stays alive, and a full Pubky Ring sign-in completes (token decrypted → session exchange → hydrated session). Without it, the verifier panic reproduces 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
