### PR TITLE
feat: allow writes to `/priv` folder

### DIFF
--- a/e2e/src/tests/storage/authorization.rs
+++ b/e2e/src/tests/storage/authorization.rs
@@ -69,3 +69,32 @@ async fn unauthorized_put_delete() {
         .unwrap();
     assert_eq!(body, bytes::Bytes::from(vec![0, 1, 2, 3, 4]));
 }
+
+#[tokio::test]
+#[pubky_testnet::test]
+async fn priv_writes_are_accepted() {
+    // `/priv/` writes are authorized exactly like `/pub/` writes
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+
+    let owner = pubky.signer(Keypair::random());
+    let owner_session = owner
+        .signup_cookie(&server.public_key(), None)
+        .await
+        .unwrap();
+
+    let path = "/priv/foo.txt";
+
+    // Owner writes to /priv successfully
+    let resp = owner_session
+        .storage()
+        .put(path, vec![0, 1, 2, 3, 4])
+        .await
+        .unwrap();
+    assert!(resp.status().is_success());
+
+    // Owner deletes the /priv file successfully.
+    let resp = owner_session.storage().delete(path).await.unwrap();
+    assert!(resp.status().is_success());
+}

--- a/pubky-homeserver/src/client_server/auth/authorization.rs
+++ b/pubky-homeserver/src/client_server/auth/authorization.rs
@@ -18,16 +18,22 @@ use crate::client_server::middleware::pubky_host::PubkyHost;
 use crate::shared::webdav::WebDavPath;
 use crate::shared::HttpError;
 
+/// Storage roots a write may target.
+/// `/pub/` is public readable
+/// `/priv/` is private storage
+const WRITABLE_ROOTS: [&str; 2] = ["/pub/", "/priv/"];
+
 /// Authorize a write to `path` for `session` on tenant `pubky`.
 ///
-/// Returns `Ok(())` when the path is under `/pub/`, the session targets the
-/// same tenant, and the session holds a capability whose scope covers `path`
-/// with [`Action::Write`]. Returns a 403 `HttpError` otherwise.
+/// Returns `Ok(())` when the path is under one of [`WRITABLE_ROOTS`], the
+/// session targets the same tenant, and the session holds a capability whose
+/// scope covers `path` with [`Action::Write`]. Returns a 403 `HttpError`
+/// otherwise.
 ///
-/// The `/pub/` requirement is enforced here (not at the path extractor) so
-/// that violations produce a 403 with a meaningful message — the SDK contract
-/// expects `"Writing to directories other than '/pub/' is forbidden"` rather
-/// than axum's default 400 for a deserialization failure.
+/// The writable root requirement is enforced here (not at the path extractor)
+/// so that violations produce a 403 with a meaningful message — the SDK
+/// contract expects `"Writing to directories other than '/pub/' and '/priv/'
+/// is forbidden"` rather than axum's default 400 for a deserialization failure.
 pub fn has_write_permission(
     session: &AuthSession,
     pubky: &PubkyHost,
@@ -35,9 +41,9 @@ pub fn has_write_permission(
 ) -> Result<(), HttpError> {
     let path_str = path.as_str();
 
-    if !path_str.starts_with("/pub/") {
+    if !WRITABLE_ROOTS.iter().any(|root| path_str.starts_with(root)) {
         return Err(HttpError::forbidden_with_message(
-            "Writing to directories other than '/pub/' is forbidden",
+            "Writing to directories other than '/pub/' and '/priv/' is forbidden",
         ));
     }
 
@@ -183,14 +189,35 @@ mod tests {
     }
 
     #[test]
-    fn write_outside_pub_is_rejected() {
-        // SDK contract: writes to non-`/pub/` paths must return 403 with a
-        // message containing `"Writing to directories other than '/pub/'"`
-        // (asserted by `pubky-sdk/bindings/js/pkg/tests/storage.ts` →
-        // "forbidden: writing outside /pub returns 403"). The HTTP shape is
+    fn write_outside_writable_roots_is_rejected() {
+        // SDK contract: writes to roots other than `/pub/` and `/priv/` must
+        // return 403 with a message containing `"Writing to directories other
+        // than '/pub/' and '/priv/'"`. The HTTP shape is
         // covered end-to-end by that SDK test; here we just verify the
         // predicate rejects the path before any tenant/capability check.
         let (session, pubky) = session_with_caps(root_caps());
-        assert!(has_write_permission(&session, &pubky, &web_path("/priv/example.com/x")).is_err());
+        assert!(has_write_permission(&session, &pubky, &web_path("/foo/example.com/x")).is_err());
+    }
+
+    #[test]
+    fn root_capability_grants_access_to_any_priv_path() {
+        let (session, pubky) = session_with_caps(root_caps());
+        assert!(has_write_permission(&session, &pubky, &web_path("/priv/anything")).is_ok());
+    }
+
+    #[test]
+    fn priv_path_with_covering_cap_is_allowed() {
+        // A write cap scoped to `/priv/app/` authorizes writes beneath it,
+        // exactly as it does under `/pub/`.
+        let (session, pubky) = session_with_caps(scoped_caps("/priv/app/"));
+        assert!(has_write_permission(&session, &pubky, &web_path("/priv/app/x")).is_ok());
+    }
+
+    #[test]
+    fn priv_path_with_only_pub_caps_is_denied() {
+        // A `/pub/`-scoped cap does not cover a `/priv/` write. Uses a scoped
+        // cap rather than root, since a root `/` cap would cover `/priv/` too.
+        let (session, pubky) = session_with_caps(scoped_caps("/pub/app/"));
+        assert!(has_write_permission(&session, &pubky, &web_path("/priv/app/x")).is_err());
     }
 }

--- a/pubky-sdk/bindings/js/pkg/tests/storage.ts
+++ b/pubky-sdk/bindings/js/pkg/tests/storage.ts
@@ -163,7 +163,7 @@ test("session: putBytes/getBytes/delete, public: getBytes", async (t) => {
   t.end();
 });
 
-test("forbidden: writing outside /pub returns 403", async (t) => {
+test("forbidden: writing outside /pub and /priv returns 403", async (t) => {
   const sdk = Pubky.testnet();
 
   const signer = sdk.signer(Keypair.random());
@@ -171,21 +171,43 @@ test("forbidden: writing outside /pub returns 403", async (t) => {
   await signer.signup(HOMESERVER_PUBLICKEY, signupToken);
   const session = await signer.signin("storage.test");
 
-  const forbiddenPath = "/priv/example.com/arbitrary";
+  const forbiddenPath = "/foo/example.com/arbitrary";
   try {
     await session.storage.putText(forbiddenPath as unknown as Path, "Hello");
-    t.fail("putText to /priv should fail with 403");
+    t.fail("putText to /foo should fail with 403");
   } catch (error) {
     assertPubkyError(t, error);
     t.equal(error.name, "RequestError", "mapped error name");
     t.equal(getStatusCode(error), 403, "status code 403");
     t.ok(
       String(error.message || "").includes(
-        "Writing to directories other than '/pub/'",
+        "Writing to directories other than '/pub/' and '/priv/'",
       ),
-      "error message mentions /pub restriction",
+      "error message mentions /pub and /priv restriction",
     );
   }
+
+  t.end();
+});
+
+test("session: putText/delete under /priv (write-only; reads not yet enabled)", async (t) => {
+  const sdk = Pubky.testnet();
+
+  const signer = sdk.signer(Keypair.random());
+  const signupToken = await createSignupToken();
+  await signer.signup(HOMESERVER_PUBLICKEY, signupToken);
+  // signin grants a root-capability session, which covers /priv/ writes.
+  const session = await signer.signin("storage.test");
+
+  const path: Path = "/priv/example.com/secret.txt";
+
+  // Write under /priv succeeds
+  await session.storage.putText(path, "top secret");
+  t.pass("putText under /priv succeeded");
+
+  // Deleting under /priv also goes through the write authorizer.
+  await session.storage.delete(path);
+  t.pass("delete under /priv succeeded");
 
   t.end();
 });

--- a/pubky-sdk/bindings/js/src/actors/storage/session.rs
+++ b/pubky-sdk/bindings/js/src/actors/storage/session.rs
@@ -8,8 +8,7 @@ use super::stats::ResourceStats;
 use crate::js_error::JsResult;
 
 #[wasm_bindgen(typescript_custom_section)]
-const TS_PATH: &'static str =
-    r#"export type Path = `/pub/${string}` | `/priv/${string}`;"#;
+const TS_PATH: &'static str = r#"export type Path = `/pub/${string}` | `/priv/${string}`;"#;
 
 /// Read/write storage scoped to **your** session (absolute paths: `/pub/...` or `/priv/...`).
 #[wasm_bindgen]

--- a/pubky-sdk/bindings/js/src/actors/storage/session.rs
+++ b/pubky-sdk/bindings/js/src/actors/storage/session.rs
@@ -8,9 +8,10 @@ use super::stats::ResourceStats;
 use crate::js_error::JsResult;
 
 #[wasm_bindgen(typescript_custom_section)]
-const TS_PATH: &'static str = r#"export type Path = `/pub/${string}`;"#;
+const TS_PATH: &'static str =
+    r#"export type Path = `/pub/${string}` | `/priv/${string}`;"#;
 
-/// Read/write storage scoped to **your** session (absolute paths: `/pub/...`).
+/// Read/write storage scoped to **your** session (absolute paths: `/pub/...` or `/priv/...`).
 #[wasm_bindgen]
 pub struct SessionStorage(pub(crate) pubky::SessionStorage);
 


### PR DESCRIPTION
Closes #432.

## Summary

Writes were hardcoded to `/pub/` in two places. This relaxes both so `PUT`/`DELETE`
are allowed under `/priv/<scope>/...` as well as `/pub/<scope>/...`, while keeping
capability enforcement unchanged (a write cap must still cover the target path).
Any other root (e.g. `/foo/...`) is still rejected with `403`.

## Out of scope (intentionally)

- **`/priv/` reads** stay `/pub/`-only (the read path uses a separate `/pub/`-requiring
  extractor). You can write to `/priv/` but not read it back yet — that's a later epic step.
- **Event privacy:** `/priv/` writes still emit events through the same pipeline as `/pub/`,
  so a private write's path/timestamp can surface via the public event feed. To be fixed in #438 

## Acceptance criteria

- [x] `PUT /priv/app/x` with a cap covering `/priv/app/` → `201`
- [x] `PUT /priv/app/x` with only `/pub/...` caps → `403`
- [x] `PUT /foo/x` (neither root) → `403`, message updated to mention both roots
- [x] Existing `/pub/` write tests still pass (`authorization.rs` test module updated)