### PR TITLE
docs: fix rustdoc links

### DIFF
--- a/pubky-homeserver/src/data_directory/mock_data_dir.rs
+++ b/pubky-homeserver/src/data_directory/mock_data_dir.rs
@@ -34,8 +34,9 @@ impl MockDataDir {
 
     /// Creates a mock data directory with a config and keypair appropriate for testing.
     ///
-    /// Uses [`ConfigToml::default_test_config()`] which enables the admin server.
-    /// For lightweight tests, use [`MockDataDir::new()`] with [`ConfigToml::minimal_test_config()`].
+    /// Uses [`super::ConfigToml::default_test_config()`] which enables the admin server.
+    /// For lightweight tests, use [`MockDataDir::new()`] with
+    /// [`super::ConfigToml::minimal_test_config()`].
     #[cfg(any(test, feature = "testing"))]
     pub fn test() -> Self {
         let config = super::ConfigToml::default_test_config();

--- a/pubky-homeserver/src/persistence/sql/connection_string.rs
+++ b/pubky-homeserver/src/persistence/sql/connection_string.rs
@@ -3,7 +3,7 @@ use std::{fmt::Display, str::FromStr};
 use serde::{Deserialize, Serialize};
 
 /// A connection string for a  postgres database.
-/// See https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS
+/// See <https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS>
 #[derive(Debug, Clone, PartialEq)]
 pub struct ConnectionString(url::Url);
 

--- a/pubky-homeserver/src/shared/toml_merge.rs
+++ b/pubky-homeserver/src/shared/toml_merge.rs
@@ -1,5 +1,5 @@
 //!
-//! Code from unmerge PR https://github.com/jdrouet/serde-toml-merge/pull/39
+//! Code from unmerge PR <https://github.com/jdrouet/serde-toml-merge/pull/39>
 //! We can't publish crates with a git dependency, so we copy the code here.
 //!
 

--- a/pubky-homeserver/src/shared/webdav/mod.rs
+++ b/pubky-homeserver/src/shared/webdav/mod.rs
@@ -23,7 +23,7 @@
 ///
 /// ## Get rid of `/pub` requirement
 /// This needs more research especially in consideration with Cryptrees. I see a future where "permissions" are set on an individual folder level and not forced on top level folders. TBD though.
-/// via: https://github.com/pubky/pubky-core/pull/145#discussion_r2149297326
+/// via: <https://github.com/pubky/pubky-core/pull/145#discussion_r2149297326>
 ///
 mod entry_path;
 mod entry_path_pub;

--- a/pubky-sdk/src/actors/auth/cookie/legacy_api.rs
+++ b/pubky-sdk/src/actors/auth/cookie/legacy_api.rs
@@ -27,7 +27,7 @@ impl PubkySession {
 
     /// Restore a session from an `export()` string.
     ///
-    /// Delegates to [`super::secret::import_session`].
+    /// Delegates to `super::secret::import_session`.
     ///
     /// # Errors
     /// - Returns [`crate::errors::RequestError::Validation`] if the export string is malformed.
@@ -38,7 +38,7 @@ impl PubkySession {
 
     /// Rehydrate a session from a compact secret token `<pubkey>:<cookie_secret>`.
     ///
-    /// Delegates to [`super::secret::import_session_secret`].
+    /// Delegates to `super::secret::import_session_secret`.
     ///
     /// # Errors
     /// - Returns [`crate::errors::RequestError::Validation`] if the token is malformed.
@@ -49,7 +49,7 @@ impl PubkySession {
 
     /// Restore a session from a secret token stored in a file.
     ///
-    /// Delegates to [`super::secret::session_from_secret_file`].
+    /// Delegates to `super::secret::session_from_secret_file`.
     ///
     /// # Errors
     /// - Returns [`crate::errors::RequestError::Validation`] when the file extension is not `.sess`.

--- a/pubky-sdk/src/actors/auth/relay/http_relay_inbox_channel.rs
+++ b/pubky-sdk/src/actors/auth/relay/http_relay_inbox_channel.rs
@@ -19,11 +19,10 @@ enum PollError {
 
 /// An HTTP relay inbox channel for store-and-forward messaging.
 ///
-/// Unlike [`super::http_relay_link_channel::HttpRelayLinkChannel`] (synchronous
-/// producer/consumer pairing), the inbox channel persists messages server-side
-/// for up to 5 minutes. The consumer retrieves via long-poll GET, acknowledges
-/// via DELETE, and the producer can verify delivery via the `/ack` and `/await`
-/// sub-endpoints.
+/// Unlike `HttpRelayLinkChannel` (synchronous producer/consumer pairing), the
+/// inbox channel persists messages server-side for up to 5 minutes. The consumer
+/// retrieves via long-poll GET, acknowledges via DELETE, and the producer can
+/// verify delivery via the `/ack` and `/await` sub-endpoints.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HttpRelayInboxChannel {
     /// The base URL of the relay inbox endpoint.

--- a/pubky-sdk/src/actors/session/core.rs
+++ b/pubky-sdk/src/actors/session/core.rs
@@ -27,9 +27,9 @@ use crate::{PubkyHttpClient, Result, SessionStorage, cross_log};
 /// [`Self::as_cookie`].
 ///
 /// Credential-specific factory functions live alongside each auth flow:
-/// - Cookie: [`crate::actors::auth::cookie`] — `CookieCredential::from_auth_token`
+/// - Cookie: `crate::actors::auth::cookie` — `CookieCredential::from_auth_token`
 ///   and the `secret` module for rehydration helpers.
-/// - Grant: [`crate::actors::auth::grant::grant_exchange`] —
+/// - Grant: `crate::actors::auth::grant::grant_exchange` —
 ///   `credential_from_grant_exchange`.
 ///
 /// Thin delegations on `PubkySession` (`export`, `import`, `import_secret`,
@@ -46,8 +46,8 @@ pub struct PubkySession {
 
 impl PubkySession {
     /// Build a session from a fully-formed credential. Used by the grant-mode
-    /// constructors in [`crate::actors::auth::grant::grant_exchange`] and the
-    /// cookie constructors in [`crate::actors::auth::cookie`].
+    /// constructors in `crate::actors::auth::grant::grant_exchange` and the
+    /// cookie constructors in `crate::actors::auth::cookie`.
     pub(crate) fn from_credential(
         client: PubkyHttpClient,
         credential: Arc<dyn SessionCredential>,

--- a/pubky-testnet/src/ephemeral_testnet.rs
+++ b/pubky-testnet/src/ephemeral_testnet.rs
@@ -28,7 +28,7 @@ use crate::docker_postgres::DockerPostgres;
 /// ```
 ///
 /// # Configuration Defaults
-/// - [`EphemeralTestnet::builder().build()`] uses [`ConfigToml::minimal_test_config()`] (admin/metrics **disabled**)
+/// - `EphemeralTestnet::builder().build()` uses [`ConfigToml::minimal_test_config()`] (admin/metrics **disabled**)
 /// - Deprecated [`EphemeralTestnet::start()`] uses [`ConfigToml::default_test_config()`] (admin **enabled**)
 pub struct EphemeralTestnet {
     /// Inner flexible testnet.

--- a/pubky-testnet/src/testnet.rs
+++ b/pubky-testnet/src/testnet.rs
@@ -153,7 +153,7 @@ impl Testnet {
 
     /// Run a new Pkarr relay.
     ///
-    /// You can access the list of relays at [Self::pkarr_relays].
+    /// You can access the list of relays at `Self::pkarr_relays`.
     pub async fn create_pkarr_relay(&mut self) -> Result<Url> {
         let dir = tempfile::tempdir()?;
         let mut builder = pkarr_relay::Relay::builder();


### PR DESCRIPTION
Replace broken/private intra-doc links with resolvable links or code
formatting, and wrap bare URLs so `cargo doc` runs cleanly.
