### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
   </h3>
 </div>
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/pubky/pubky-core)
 [![GitHub Release](https://img.shields.io/github/v/release/pubky/pkdns)](https://github.com/pubky/pubky-core/releases/latest/)
 [![Crates.io Version](https://img.shields.io/crates/v/pubky)](https://crates.io/crates/pubky)
 [![Telegram Chat Group](https://img.shields.io/badge/Chat-Telegram-violet)](https://t.me/pubkycore)

--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@
   </h3>
 </div>
 
-[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/pubky/pubky-core)
 [![GitHub Release](https://img.shields.io/github/v/release/pubky/pkdns)](https://github.com/pubky/pubky-core/releases/latest/)
 [![Crates.io Version](https://img.shields.io/crates/v/pubky)](https://crates.io/crates/pubky)
 [![Telegram Chat Group](https://img.shields.io/badge/Chat-Telegram-violet)](https://t.me/pubkycore)
 [![GitHub License](https://img.shields.io/github/license/pubky/pubky-core)](https://github.com/pubky/pubky-core/blob/main/LICENSE)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/pubky/pubky-core)
 
 > The Web, long centralized, must decentralize; Long decentralized, must centralize.
 


### PR DESCRIPTION
This PR adds a badge to the README, which is a link to https://deepwiki.com/pubky/pubky-core

This has two benefits:
- gives us quick link to the DeepWiki page for Core (where anyone can ask AI questions about the repo)
- having the badge in the README signals to DeepWiki to regularly re-index the repo

See similar PR in Nexus: https://github.com/pubky/pubky-nexus/pull/909 . This causes the Nexus repo to be re-indexed every week. DeepWiki last indexed the Core repo ~1y ago ( https://deepwiki.com/pubky/pubky-core )