### PR TITLE
build(homeserver): set default run binary to pubky-homeserver

### DIFF
--- a/pubky-homeserver/Cargo.toml
+++ b/pubky-homeserver/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "pubky-homeserver"
 description = "Pubky core's homeserver."
+default-run = "pubky-homeserver"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
Configure Cargo to run the pubky-homeserver binary by default when
invoking `cargo run`.
