### PR TITLE
feat(homeserver): filter private events from `/events` endpoint

### DIFF
--- a/pubky-homeserver/src/admin_server/routes/delete_entry.rs
+++ b/pubky-homeserver/src/admin_server/routes/delete_entry.rs
@@ -20,7 +20,7 @@ mod tests {
     use super::super::super::app_state::AppState;
     use super::*;
     use crate::persistence::files::{
-        events::{EventRepository, EventType},
+        events::{EventRepository, EventType, EventVisibility},
         FileService,
     };
     use crate::persistence::sql::entry::EntryRepository;
@@ -81,9 +81,14 @@ mod tests {
             .get(&entry_path)
             .await
             .expect_err("Blob should be deleted from storage");
-        let events = EventRepository::get_by_cursor(None, Some(10), &mut db.pool().into())
-            .await
-            .unwrap();
+        let events = EventRepository::get_by_cursor(
+            None,
+            Some(10),
+            EventVisibility::All,
+            &mut db.pool().into(),
+        )
+        .await
+        .unwrap();
 
         assert_eq!(
             events.len(),

--- a/pubky-homeserver/src/client_server/auth/authorization.rs
+++ b/pubky-homeserver/src/client_server/auth/authorization.rs
@@ -20,13 +20,9 @@ use pubky_common::capabilities::Action;
 
 use crate::client_server::auth::AuthSession;
 use crate::client_server::middleware::pubky_host::PubkyHost;
+use crate::constants::{PRIVATE_ROOT, PUBLIC_ROOT};
 use crate::shared::webdav::WebDavPath;
 use crate::shared::HttpError;
-
-/// `/pub/` is public-readable storage, anonymous reads are allowed.
-const PUBLIC_ROOT: &str = "/pub/";
-/// `/priv/` is private storage, reads and writes require auth.
-const PRIVATE_ROOT: &str = "/priv/";
 
 /// Storage roots a write may target.
 const STORAGE_ROOTS: [&str; 2] = [PUBLIC_ROOT, PRIVATE_ROOT];

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -238,6 +238,10 @@ fn event_to_sse_data(entity: &EventEntity) -> String {
 
 /// Legacy text-based endpoint for fetching historical events.
 ///
+/// This feed is public and unauthenticated: it returns events under
+/// `/pub/...` exclusively and never exposes private (`/priv/...`) paths, even to
+/// an authenticated caller.
+///
 /// ## Query Parameters
 /// - `cursor` (optional): Starting cursor position. Default: "0" (beginning)
 /// - `limit` (optional): Maximum number of events to return
@@ -271,7 +275,7 @@ pub async fn feed(
     let query_start = Instant::now();
     let events = state
         .events_service
-        .get_by_cursor(Some(cursor), params.limit, &mut state.sql_db.pool().into())
+        .get_public_by_cursor(Some(cursor), params.limit, &mut state.sql_db.pool().into())
         .await?;
     state
         .metrics

--- a/pubky-homeserver/src/constants.rs
+++ b/pubky-homeserver/src/constants.rs
@@ -1,3 +1,9 @@
 // The default limit of a list api if no `limit` query parameter is provided.
 pub const DEFAULT_LIST_LIMIT: u16 = 100;
 pub const DEFAULT_MAX_LIST_LIMIT: u16 = 1000;
+
+/// Storage root for public, world-readable data (`/pub/...`).
+pub const PUBLIC_ROOT: &str = "/pub/";
+
+/// Storage root for private data (`/priv/...`), reads and writes require auth.
+pub const PRIVATE_ROOT: &str = "/priv/";

--- a/pubky-homeserver/src/persistence/files/events/events_layer.rs
+++ b/pubky-homeserver/src/persistence/files/events/events_layer.rs
@@ -278,7 +278,7 @@ mod tests {
     use crate::{
         persistence::{
             files::{
-                events::{EventRepository, EventType, EventsService},
+                events::{EventRepository, EventType, EventVisibility, EventsService},
                 opendal::opendal_test_operators::OpendalTestOperators,
             },
             sql::user::UserRepository,
@@ -309,9 +309,14 @@ mod tests {
                 .expect("Should succeed because the path starts with a pubkey");
 
             // Make sure the event is written to the database correctly
-            let events = EventRepository::get_by_cursor(None, Some(9999), &mut db.pool().into())
-                .await
-                .expect("Should succeed");
+            let events = EventRepository::get_by_cursor(
+                None,
+                Some(9999),
+                EventVisibility::All,
+                &mut db.pool().into(),
+            )
+            .await
+            .expect("Should succeed");
             assert_eq!(events.len(), 1);
             let first_event = events.first().expect("Should succeed");
             assert_eq!(first_event.path, entry_path);
@@ -324,9 +329,14 @@ mod tests {
                 .expect("Should succeed because the path starts with a pubkey");
 
             // Make sure the event is written to the database correctly
-            let events = EventRepository::get_by_cursor(None, Some(9999), &mut db.pool().into())
-                .await
-                .expect("Should succeed");
+            let events = EventRepository::get_by_cursor(
+                None,
+                Some(9999),
+                EventVisibility::All,
+                &mut db.pool().into(),
+            )
+            .await
+            .expect("Should succeed");
             assert_eq!(events.len(), 2);
             let second_event = events.get(1).expect("Should succeed");
             assert_eq!(second_event.path, entry_path);
@@ -339,9 +349,14 @@ mod tests {
                 .expect("Should succeed");
 
             // Make sure the event is written to the database correctly
-            let events = EventRepository::get_by_cursor(None, Some(9999), &mut db.pool().into())
-                .await
-                .expect("Should succeed");
+            let events = EventRepository::get_by_cursor(
+                None,
+                Some(9999),
+                EventVisibility::All,
+                &mut db.pool().into(),
+            )
+            .await
+            .expect("Should succeed");
             assert_eq!(events.len(), 3);
             let third_event = events.get(2).expect("Should succeed");
             assert_eq!(third_event.path, entry_path);

--- a/pubky-homeserver/src/persistence/files/events/events_repository.rs
+++ b/pubky-homeserver/src/persistence/files/events/events_repository.rs
@@ -9,7 +9,7 @@ use sqlx::{
 };
 
 use crate::{
-    constants::{DEFAULT_LIST_LIMIT, DEFAULT_MAX_LIST_LIMIT},
+    constants::{DEFAULT_LIST_LIMIT, DEFAULT_MAX_LIST_LIMIT, PUBLIC_ROOT},
     persistence::{
         files::events::EventEntity,
         sql::{
@@ -21,6 +21,15 @@ use crate::{
 };
 
 pub const EVENT_TABLE: &str = "events";
+
+/// Selects which events a cursor query returns, by storage-root visibility.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EventVisibility {
+    /// Only public (`/pub/...`) events.
+    Public,
+    /// All events, includes `/priv/...` events.
+    All,
+}
 
 /// Repository that handles all the queries regarding the EventEntity.
 pub struct EventRepository;
@@ -257,17 +266,19 @@ impl EventRepository {
 
     /// Get a list of events by the cursor.
     /// The limit is the maximum number of events to return.
+    /// `visibility` selects which storage roots are returned (see [`EventVisibility`]).
     /// The executor can either be db.pool() or a transaction.
     pub async fn get_by_cursor<'a>(
         cursor: Option<EventCursor>,
         limit: Option<u16>,
+        visibility: EventVisibility,
         executor: &mut UnifiedExecutor<'a>,
     ) -> Result<Vec<EventEntity>, sqlx::Error> {
         let cursor = cursor.unwrap_or(EventCursor::new(0));
         let limit = limit.unwrap_or(DEFAULT_LIST_LIMIT);
         let limit = limit.min(DEFAULT_MAX_LIST_LIMIT);
 
-        let statement = Query::select()
+        let mut statement = Query::select()
             .columns([
                 (EVENT_TABLE, EventIden::Id),
                 (EVENT_TABLE, EventIden::User),
@@ -286,6 +297,16 @@ impl EventRepository {
             .order_by((EVENT_TABLE, EventIden::Id), Order::Asc)
             .limit(limit as u64)
             .to_owned();
+
+        // `All` adds no predicate; `Public` restricts to the public root.
+        if let EventVisibility::Public = visibility {
+            statement = statement
+                .and_where(
+                    Expr::col((EVENT_TABLE, EventIden::Path)).like(format!("{PUBLIC_ROOT}%")),
+                )
+                .to_owned();
+        }
+
         let (query, values) = statement.build_sqlx(PostgresQueryBuilder);
         let con = executor.get_con().await?;
         let events: Vec<EventEntity> = sqlx::query_as_with(&query, values).fetch_all(con).await?;
@@ -345,6 +366,7 @@ mod tests {
         let events = EventRepository::get_by_cursor(
             Some(EventCursor::new(5)),
             Some(4),
+            EventVisibility::All,
             &mut db.pool().into(),
         )
         .await
@@ -357,6 +379,83 @@ mod tests {
             EntryPath::new(user_pubkey, WebDavPath::new("/test").unwrap())
         );
         assert!(matches!(events[0].event_type, EventType::Put { .. }));
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_get_by_cursor_public_visibility_excludes_private() {
+        let db = SqlDb::test().await;
+        let user_pubkey = Keypair::random().public_key();
+        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
+            .await
+            .unwrap();
+
+        // Interleave public, private, and look-alike roots that must NOT match
+        // the `/pub/` prefix (`/public/...` and `/pub` without a trailing slash).
+        let paths = [
+            "/pub/a",       // 1: public
+            "/priv/x",      // 2: private  -> excluded
+            "/pub/b",       // 3: public
+            "/public/evil", // 4: not the public root -> excluded
+            "/priv/y",      // 5: private  -> excluded
+            "/pub/c",       // 6: public
+            "/pub",         // 7: bare root, not under `/pub/` -> excluded
+        ];
+        for p in paths {
+            let path = EntryPath::new(user_pubkey.clone(), WebDavPath::new(p).unwrap());
+            EventRepository::create(
+                user.id,
+                EventType::Put {
+                    content_hash: Hash::from_bytes([0; 32]),
+                },
+                &path,
+                &mut db.pool().into(),
+            )
+            .await
+            .unwrap();
+        }
+
+        // Public-only view: only the three `/pub/<scope>/...` events.
+        let public = EventRepository::get_by_cursor(
+            None,
+            None,
+            EventVisibility::Public,
+            &mut db.pool().into(),
+        )
+        .await
+        .unwrap();
+        let public_paths: Vec<&str> = public.iter().map(|e| e.path.path().as_str()).collect();
+        assert_eq!(public_paths, vec!["/pub/a", "/pub/b", "/pub/c"]);
+
+        // The internal all-events view is unchanged (regression guard for the
+        // broadcaster / quota / admin callers).
+        let all =
+            EventRepository::get_by_cursor(None, None, EventVisibility::All, &mut db.pool().into())
+                .await
+                .unwrap();
+        assert_eq!(all.len(), 7);
+
+        // Pagination stays correct across filtered-out private events: a limit of
+        // 2 returns a full page (ids 1 and 3) and the next cursor resumes after it.
+        let page = EventRepository::get_by_cursor(
+            None,
+            Some(2),
+            EventVisibility::Public,
+            &mut db.pool().into(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(page.iter().map(|e| e.id).collect::<Vec<_>>(), vec![1, 3]);
+        let next = page.last().unwrap().cursor();
+        let page = EventRepository::get_by_cursor(
+            Some(next),
+            Some(2),
+            EventVisibility::Public,
+            &mut db.pool().into(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(page.iter().map(|e| e.id).collect::<Vec<_>>(), vec![6]);
     }
 
     #[tokio::test]
@@ -458,10 +557,14 @@ mod tests {
                 .await
                 .unwrap();
 
-            let events_after =
-                EventRepository::get_by_cursor(Some(cursor_id), None, &mut db.pool().into())
-                    .await
-                    .unwrap();
+            let events_after = EventRepository::get_by_cursor(
+                Some(cursor_id),
+                None,
+                EventVisibility::All,
+                &mut db.pool().into(),
+            )
+            .await
+            .unwrap();
 
             // Should get events after the cursor (events[3] and events[4])
             assert_eq!(

--- a/pubky-homeserver/src/persistence/files/events/events_service.rs
+++ b/pubky-homeserver/src/persistence/files/events/events_service.rs
@@ -1,5 +1,5 @@
 use crate::persistence::{
-    files::events::{EventCursor, EventEntity, EventRepository, EventType},
+    files::events::{EventCursor, EventEntity, EventRepository, EventType, EventVisibility},
     sql::UnifiedExecutor,
 };
 use crate::shared::webdav::EntryPath;
@@ -107,19 +107,19 @@ impl EventsService {
         EventRepository::parse_cursor(cursor, executor).await
     }
 
-    /// Get a list of events starting from a cursor position.
-    /// This is used by the `/events/` endpoint.
+    /// Get a list of public (`/pub/...`) events starting from a cursor position.
+    /// Private events are served only through the authenticated event stream.
     ///
     /// ## Parameters
     /// - `cursor`: Starting position (None = from beginning)
     /// - `limit`: Maximum number of events to return (None = default limit)
-    pub async fn get_by_cursor<'a>(
+    pub async fn get_public_by_cursor<'a>(
         &self,
         cursor: Option<EventCursor>,
         limit: Option<u16>,
         executor: &mut UnifiedExecutor<'a>,
     ) -> Result<Vec<EventEntity>, sqlx::Error> {
-        EventRepository::get_by_cursor(cursor, limit, executor).await
+        EventRepository::get_by_cursor(cursor, limit, EventVisibility::Public, executor).await
     }
 
     /// Get events for multiple users with individual cursor positions.
@@ -189,7 +189,7 @@ mod tests {
 
     #[tokio::test]
     #[pubky_test_utils::test]
-    async fn test_events_service_get_by_cursor() {
+    async fn test_events_service_get_public_by_cursor() {
         let db = SqlDb::test().await;
         let events_service = EventsService::new(100);
 
@@ -198,12 +198,11 @@ mod tests {
             .await
             .unwrap();
 
-        // Create multiple events
-        for i in 0..5 {
-            let path = EntryPath::new(
-                user_pubkey.clone(),
-                WebDavPath::new(&format!("/test{}.txt", i)).unwrap(),
-            );
+        // Interleave public and private events: ids 1=/pub/a, 2=/priv/x,
+        // 3=/pub/b, 4=/priv/y, 5=/pub/c.
+        let paths = ["/pub/a", "/priv/x", "/pub/b", "/priv/y", "/pub/c"];
+        for p in paths {
+            let path = EntryPath::new(user_pubkey.clone(), WebDavPath::new(p).unwrap());
             events_service
                 .create_event(
                     user.id,
@@ -217,15 +216,30 @@ mod tests {
                 .unwrap();
         }
 
-        // Get events from cursor
+        // From the beginning, only public events come back, in id order.
         let events = events_service
-            .get_by_cursor(Some(EventCursor::new(2)), Some(3), &mut db.pool().into())
+            .get_public_by_cursor(None, None, &mut db.pool().into())
             .await
             .unwrap();
+        let returned: Vec<&str> = events.iter().map(|e| e.path.path().as_str()).collect();
+        assert_eq!(returned, vec!["/pub/a", "/pub/b", "/pub/c"]);
 
-        assert_eq!(events.len(), 3);
-        assert_eq!(events[0].id, 3);
-        assert_eq!(events[1].id, 4);
-        assert_eq!(events[2].id, 5);
+        // A limited page returns a FULL page of public events despite the
+        // interleaved private ones, and the next cursor resumes correctly.
+        let page = events_service
+            .get_public_by_cursor(None, Some(2), &mut db.pool().into())
+            .await
+            .unwrap();
+        assert_eq!(page.len(), 2);
+        assert_eq!(page[0].id, 1); // /pub/a
+        assert_eq!(page[1].id, 3); // /pub/b (skips /priv/x at id 2)
+
+        let next_cursor = page.last().unwrap().cursor();
+        let page = events_service
+            .get_public_by_cursor(Some(next_cursor), Some(2), &mut db.pool().into())
+            .await
+            .unwrap();
+        assert_eq!(page.len(), 1);
+        assert_eq!(page[0].id, 5); // /pub/c (skips /priv/y at id 4)
     }
 }

--- a/pubky-homeserver/src/persistence/files/events/mod.rs
+++ b/pubky-homeserver/src/persistence/files/events/mod.rs
@@ -13,7 +13,7 @@ mod events_service;
 
 pub use events_entity::EventEntity;
 pub use events_layer::EventsLayer;
-pub use events_repository::{EventIden, EventRepository};
+pub use events_repository::{EventIden, EventRepository, EventVisibility};
 pub(crate) use events_service::PG_NOTIFY_CHANNEL;
 pub use events_service::{EventsService, MAX_EVENT_STREAM_USERS};
 

--- a/pubky-homeserver/src/persistence/files/user_quota_layer.rs
+++ b/pubky-homeserver/src/persistence/files/user_quota_layer.rs
@@ -528,7 +528,9 @@ mod tests {
     #[pubky_test_utils::test]
     async fn test_quota_rechead() {
         use crate::persistence::files::entry::entry_layer::EntryLayer;
-        use crate::persistence::files::events::{EventRepository, EventsLayer, EventsService};
+        use crate::persistence::files::events::{
+            EventRepository, EventVisibility, EventsLayer, EventsService,
+        };
         use crate::persistence::sql::entry::EntryRepository;
         use crate::shared::webdav::{EntryPath, WebDavPath};
 
@@ -574,6 +576,7 @@ mod tests {
         let events = crate::persistence::files::events::EventRepository::get_by_cursor(
             None,
             Some(9999),
+            EventVisibility::All,
             &mut db.pool().into(),
         )
         .await
@@ -603,9 +606,14 @@ mod tests {
         assert_eq!(entry.content_length as usize, max_content);
 
         // Verify that event WAS created when write succeeded
-        let events = EventRepository::get_by_cursor(None, Some(9999), &mut db.pool().into())
-            .await
-            .expect("Should succeed");
+        let events = EventRepository::get_by_cursor(
+            None,
+            Some(9999),
+            EventVisibility::All,
+            &mut db.pool().into(),
+        )
+        .await
+        .expect("Should succeed");
         assert_eq!(
             events.len(),
             1,

--- a/pubky-homeserver/src/persistence/sql/pg_event_listener.rs
+++ b/pubky-homeserver/src/persistence/sql/pg_event_listener.rs
@@ -24,7 +24,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::constants::DEFAULT_MAX_LIST_LIMIT;
 use crate::persistence::files::events::{
-    EventCursor, EventRepository, EventsService, PG_NOTIFY_CHANNEL,
+    EventCursor, EventRepository, EventVisibility, EventsService, PG_NOTIFY_CHANNEL,
 };
 use crate::persistence::sql::UnifiedExecutor;
 
@@ -184,6 +184,7 @@ impl PgEventListener {
             let events = EventRepository::get_by_cursor(
                 Some(cursor),
                 Some(Self::BATCH_SIZE),
+                EventVisibility::All,
                 &mut UnifiedExecutor::from(pool),
             )
             .await?;


### PR DESCRIPTION
## Summary

Closes [#436](https://github.com/pubky/pubky-core/issues/436)

`GET /events/` is a global, unauthenticated feed that returned all events by cursor with no path or auth filter. Now that `/priv/` writes emit events into the same table ([#432](https://github.com/pubky/pubky-core/issues/432)), this endpoint would dump private paths (`PUT pubky://user/priv/...`) to any anonymous caller.

This PR makes the legacy feed public only: it returns `/pub/...` events exclusively and never exposes `/priv/...`, even to an authenticated caller — matching the Private Storage spec ("/events/ must become public-only"; private events are served only via the authenticated `/event-stream` endpoint).

### Acceptance criteria
- [x] After a `PUT /priv/app/x`, `GET /events/` (anonymous) does **not** include that path at any
      cursor position.
- [x] `GET /events/` still returns all `/pub/...` events with correct cursor continuation.
- [x] Cursor/limit pagination remains correct when private events are interleaved and filtered out
      (no short pages that skip the limit, no infinite loops).