### PR TITLE
chore(deps): remove unused crate dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,15 +1598,11 @@ dependencies = [
  "bytes",
  "eventsource-stream",
  "futures",
- "pkarr",
- "pubky-common",
  "pubky-testnet",
  "rand 0.10.1",
  "serde",
  "serde_json",
  "tokio",
- "tracing-subscriber",
- "url",
 ]
 
 [[package]]
@@ -1815,7 +1811,6 @@ checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
 dependencies = [
  "futures-core",
  "futures-sink",
- "nanorand",
  "spin 0.9.8",
 ]
 
@@ -3221,15 +3216,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.17",
-]
-
-[[package]]
 name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4069,14 +4055,10 @@ name = "pubky-common"
 version = "0.9.0"
 dependencies = [
  "argon2",
- "base32",
  "base64 0.22.1",
  "blake3",
  "crypto_secretbox",
  "ed25519-dalek",
- "getrandom 0.3.4",
- "js-sys",
- "once_cell",
  "pkarr",
  "postcard",
  "pubky-timestamp",
@@ -4129,7 +4111,6 @@ dependencies = [
  "dirs",
  "dyn-clone",
  "fast-glob",
- "flume 0.11.1",
  "futures-lite",
  "futures-util",
  "governor",
@@ -4157,7 +4138,6 @@ dependencies = [
  "serde_valid",
  "sha2 0.10.9",
  "sqlx",
- "temp-env",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -4178,11 +4158,8 @@ version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",
- "dirs",
  "http-relay",
  "libc",
- "mainline",
- "once_cell",
  "pkarr",
  "pkarr-relay",
  "pubky",
@@ -5762,16 +5739,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "temp-env"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96374855068f47402c3121c6eed88d29cb1de8f3ab27090e273e420bdabcf050"
-dependencies = [
- "futures",
- "parking_lot",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,15 +46,12 @@ base32 = "0.5"
 base64 = "0.22"
 bytes = "1"
 clap = "4"
-dirs = "6"
 eventsource-stream = "0.2"
 futures-util = "0.3"
 http-relay = "0.7"
 httpdate = "1"
 js-sys = "0.3"
 log = "0.4"
-mainline = { version = "6" }
-once_cell = "1"
 pkarr = { version = "6", default-features = false }
 pkarr-relay = { version = "0.12" }
 pubky = { path = "pubky-sdk", version = "0.9", default-features = false }

--- a/e2e/Cargo.toml
+++ b/e2e/Cargo.toml
@@ -9,19 +9,13 @@ homepage.workspace = true
 repository.workspace = true
 publish = false
 
-[dependencies]
+[dev-dependencies]
 base64.workspace = true
 bytes.workspace = true
-pkarr = { workspace = true }
-pubky-common.workspace = true
+eventsource-stream.workspace = true
+futures = "0.3"
 pubky-testnet.workspace = true
 rand = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true
 tokio = { workspace = true, features = ["full", "test-util"] }
-tracing-subscriber.workspace = true
-url.workspace = true
-
-[dev-dependencies]
-eventsource-stream.workspace = true
-futures = "0.3"

--- a/e2e/src/lib.rs
+++ b/e2e/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(unused_crate_dependencies)]
 // E2E tests
 #[cfg(test)]
 mod tests;

--- a/pubky-common/Cargo.toml
+++ b/pubky-common/Cargo.toml
@@ -12,10 +12,8 @@ keywords = ["pkarr", "pubky", "auth", "pubkey"]
 categories = ["web-programming", "authentication", "cryptography"]
 
 [dependencies]
-base32.workspace = true
 blake3 = "1"
 ed25519-dalek = { version = "3.0.0-pre.1", features = ["serde"] }
-once_cell.workspace = true
 rand.workspace = true
 thiserror.workspace = true
 postcard = { version = "1", features = ["alloc"] }
@@ -27,7 +25,3 @@ pkarr = { workspace = true, features = ["keys"] }
 url.workspace = true
 serde_json.workspace = true
 base64.workspace = true
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.3", features = ["wasm_js"] }
-js-sys.workspace = true

--- a/pubky-common/src/lib.rs
+++ b/pubky-common/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 //!
 
+#![warn(unused_crate_dependencies)]
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![cfg_attr(any(), deny(clippy::unwrap_used))]

--- a/pubky-homeserver/Cargo.toml
+++ b/pubky-homeserver/Cargo.toml
@@ -28,10 +28,8 @@ base32.workspace = true
 base64.workspace = true
 bytes.workspace = true
 clap = { workspace = true, features = ["derive"] }
-flume = "0.11"
 futures-lite = "2"
 futures-util.workspace = true
-hex = "0.4"
 httpdate.workspace = true
 pkarr = { workspace = true, features = ["default", "dht", "tls"] }
 pubky-common.workspace = true
@@ -47,9 +45,8 @@ url = { workspace = true, features = ["serde"] }
 axum-server = { workspace = true, features = ["tls-rustls-no-provider"] }
 tower = "0.5"
 thiserror.workspace = true
-dirs.workspace = true
+dirs = "6"
 hostname-validator = "1"
-axum-test = "17"
 tempfile.workspace = true
 dyn-clone = "1"
 reqwest = { workspace = true, features = [
@@ -81,7 +78,6 @@ sqlx = { version = "0.8", features = [
 ] }
 dashmap = "6"
 async-trait.workspace = true
-async-dropper = { version = "0.3", features = ["tokio", "simple"] }
 async-stream = "0.3"
 uuid = { version = "1", features = ["v4"] }
 pubky_test_utils.workspace = true
@@ -95,8 +91,9 @@ sha2 = "0.10"
 rand.workspace = true
 
 [dev-dependencies]
-# The async_closure feature is not available in early 0.3.x releases.
-temp-env = { version = "0.3.6", features = ["async_closure"] }
+async-dropper = { version = "0.3", features = ["tokio", "simple"] }
+axum-test = "17"
+hex = "0.4"
 
 [features]
 default = ["storage-gcs"]

--- a/pubky-sdk/src/lib.rs
+++ b/pubky-sdk/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![warn(unused_crate_dependencies)]
 #![deny(missing_docs)]
 #![deny(rustdoc::broken_intra_doc_links)]
 #![allow(
@@ -95,3 +96,6 @@ pub use pubky_common::{
     session::CookieSessionRecord,
 };
 pub use reqwest::{Method, StatusCode};
+
+#[cfg(test)]
+use pubky_testnet as _; // Used in docstring tests.

--- a/pubky-sdk/src/macros.rs
+++ b/pubky-sdk/src/macros.rs
@@ -26,3 +26,6 @@ macro_rules! cross_log {
         println!("[{}] {}", stringify!($level), format_args!($($arg)*));
     };
 }
+
+#[cfg(not(target_arch = "wasm32"))]
+use tracing as _; // Not used in test code.

--- a/pubky-testnet/Cargo.toml
+++ b/pubky-testnet/Cargo.toml
@@ -16,12 +16,9 @@ categories = ["web-programming", "authentication", "cryptography"]
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
-dirs.workspace = true
 # External http-relay: server + link-compat, no persist/cli (in-memory storage for tests)
 http-relay = { workspace = true, features = ["server", "link-compat"] }
 libc = { version = "0.2", optional = true }
-mainline = { workspace = true }
-once_cell.workspace = true
 pkarr = { workspace = true }
 pkarr-relay = { workspace = true }
 pubky = { workspace = true, features = ["json"] }


### PR DESCRIPTION
Enable unused crate dependency warnings for crates where the lint is
useful, then remove dependencies that are no longer referenced directly.

Move test-only dependencies out of normal dependency sets where possible.
