### PR TITLE
fix(sdk): disable TLS revocation hard-fail on ICANN HTTP client (false Revoked errors on Android)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4054,6 +4054,7 @@ dependencies = [
  "pubky-common",
  "pubky-testnet",
  "reqwest 0.13.4",
+ "rustls",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -4062,6 +4063,7 @@ dependencies = [
  "url",
  "wasm-bindgen-futures",
  "web-time",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]

--- a/pubky-sdk/Cargo.toml
+++ b/pubky-sdk/Cargo.toml
@@ -53,6 +53,10 @@ reqwest = { workspace = true, features = [
 ] }
 tokio = { workspace = true, features = ["full"] }
 tracing.workspace = true
+# Used to build a revocation-free rustls config for the ICANN HTTP client (see
+# client/core.rs). Versions unify with what reqwest's rustls feature already pulls in.
+rustls = "0.23"
+webpki-roots = "1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 reqwest = { workspace = true, features = ["json", "stream"] }

--- a/pubky-sdk/src/client/core.rs
+++ b/pubky-sdk/src/client/core.rs
@@ -216,8 +216,12 @@ impl PubkyHttpClientBuilder {
         #[cfg(target_arch = "wasm32")]
         let http_builder = reqwest::Client::builder().user_agent(user_agent.as_ref());
 
+        // The ICANN client validates TLS against the webpki/Mozilla root bundle WITHOUT
+        // certificate revocation checking (see `icann_tls_config`).
         #[cfg(not(target_arch = "wasm32"))]
-        let mut icann_http_builder = reqwest::Client::builder().user_agent(user_agent.as_ref());
+        let mut icann_http_builder = reqwest::Client::builder()
+            .user_agent(user_agent.as_ref())
+            .use_preconfigured_tls(icann_tls_config());
 
         // TODO: change this after Reqwest publish a release with timeout in wasm
         #[cfg(not(target_arch = "wasm32"))]
@@ -240,6 +244,31 @@ impl PubkyHttpClientBuilder {
             testnet_host: self.testnet_host.clone(),
         })
     }
+}
+
+/// rustls config for the ICANN HTTP client: validate against the webpki/Mozilla root
+/// bundle WITHOUT certificate revocation checking.
+///
+/// reqwest's default rustls config uses rustls-platform-verifier, which on Android
+/// performs hard-fail revocation checking. With Let's Encrypt's newer sharded-CRL
+/// hierarchy this falsely rejects valid certificates on some devices ("invalid peer
+/// certificate: Revoked"), breaking the relay and ICANN homeserver fallback even though
+/// the cert is not actually revoked. Browsers soft-fail revocation; this matches that
+/// behavior. Only the ICANN client is affected — the homeserver raw-public-key client
+/// (`http`) keeps its pkarr-derived TLS unchanged.
+#[cfg(not(target_arch = "wasm32"))]
+fn icann_tls_config() -> rustls::ClientConfig {
+    let mut root_store = rustls::RootCertStore::empty();
+    root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
+    let mut tls_config = rustls::ClientConfig::builder_with_provider(std::sync::Arc::new(
+        rustls::crypto::aws_lc_rs::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .expect("aws-lc-rs provides safe default protocol versions")
+    .with_root_certificates(root_store)
+    .with_no_client_auth();
+    tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    tls_config
 }
 
 /// Transport client for Pubky homeserver APIs and generic HTTP, with PKARR-aware

--- a/pubky-sdk/src/client/core.rs
+++ b/pubky-sdk/src/client/core.rs
@@ -267,7 +267,7 @@ fn icann_tls_config() -> rustls::ClientConfig {
     .expect("aws-lc-rs provides safe default protocol versions")
     .with_root_certificates(root_store)
     .with_no_client_auth();
-    tls_config.alpn_protocols = vec![b"h2".to_vec(), b"http/1.1".to_vec()];
+    tls_config.alpn_protocols = vec![b"http/1.1".to_vec()];
     tls_config
 }
 

--- a/pubky-sdk/src/client/core.rs
+++ b/pubky-sdk/src/client/core.rs
@@ -221,7 +221,7 @@ impl PubkyHttpClientBuilder {
         #[cfg(not(target_arch = "wasm32"))]
         let mut icann_http_builder = reqwest::Client::builder()
             .user_agent(user_agent.as_ref())
-            .use_preconfigured_tls(icann_tls_config());
+            .tls_backend_preconfigured(icann_tls_config());
 
         // TODO: change this after Reqwest publish a release with timeout in wasm
         #[cfg(not(target_arch = "wasm32"))]

--- a/pubky-sdk/src/client/core.rs
+++ b/pubky-sdk/src/client/core.rs
@@ -216,12 +216,10 @@ impl PubkyHttpClientBuilder {
         #[cfg(target_arch = "wasm32")]
         let http_builder = reqwest::Client::builder().user_agent(user_agent.as_ref());
 
-        // The ICANN client validates TLS against the webpki/Mozilla root bundle WITHOUT
-        // certificate revocation checking (see `icann_tls_config`).
         #[cfg(not(target_arch = "wasm32"))]
         let mut icann_http_builder = reqwest::Client::builder()
             .user_agent(user_agent.as_ref())
-            .tls_backend_preconfigured(icann_tls_config());
+            .tls_backend_preconfigured(icann_tls_config_without_revocation_check());
 
         // TODO: change this after Reqwest publish a release with timeout in wasm
         #[cfg(not(target_arch = "wasm32"))]
@@ -246,18 +244,15 @@ impl PubkyHttpClientBuilder {
     }
 }
 
-/// rustls config for the ICANN HTTP client: validate against the webpki/Mozilla root
-/// bundle WITHOUT certificate revocation checking.
+/// TLS config for the ICANN HTTP client: webpki/Mozilla roots, certificate revocation
+/// checking disabled.
 ///
-/// reqwest's default rustls config uses rustls-platform-verifier, which on Android
-/// performs hard-fail revocation checking. With Let's Encrypt's newer sharded-CRL
-/// hierarchy this falsely rejects valid certificates on some devices ("invalid peer
-/// certificate: Revoked"), breaking the relay and ICANN homeserver fallback even though
-/// the cert is not actually revoked. Browsers soft-fail revocation; this matches that
-/// behavior. Only the ICANN client is affected — the homeserver raw-public-key client
-/// (`http`) keeps its pkarr-derived TLS unchanged.
+/// Revocation is disabled because reqwest's default verifier (rustls-platform-verifier)
+/// hard-fails revocation on Android, where Let's Encrypt's sharded-CRL hierarchy makes it
+/// falsely reject valid certificates ("invalid peer certificate: Revoked"). Only the ICANN
+/// client uses this; the homeserver raw-public-key client keeps its pkarr-derived TLS.
 #[cfg(not(target_arch = "wasm32"))]
-fn icann_tls_config() -> rustls::ClientConfig {
+fn icann_tls_config_without_revocation_check() -> rustls::ClientConfig {
     let mut root_store = rustls::RootCertStore::empty();
     root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     let mut tls_config = rustls::ClientConfig::builder_with_provider(std::sync::Arc::new(


### PR DESCRIPTION
## Summary

`PubkyHttpClient`'s `icann_http` client relies on reqwest 0.13's default rustls verifier (`rustls-platform-verifier`). On Android that verifier performs **hard-fail** certificate revocation checking. With Let's Encrypt's newer sharded-CRL hierarchy this falsely rejects valid certificates on some Android devices with:

```
invalid peer certificate: Revoked
```

The certificate is **not** actually revoked. This breaks the auth relay and the ICANN homeserver fallback on affected devices even though the endpoint is healthy. Browsers soft-fail revocation; the strict hard-fail here is stricter than the web PKI ecosystem in practice.

## Fix

Preconfigure the `icann_http` client with an explicit rustls config that validates against the webpki/Mozilla root bundle and does **not** perform revocation checking (matching browser soft-fail behavior). Only the ICANN client is affected — the homeserver raw-public-key client (`http`) keeps its pkarr-derived TLS unchanged.

- `pubky-sdk/src/client/core.rs` — `PubkyHttpClientBuilder::build()`, native (non-wasm) only.
- `pubky-sdk/Cargo.toml` — adds `rustls = "0.23"` and `webpki-roots = "1"` (both already in the tree via reqwest's rustls feature, so no new major versions are introduced).

WASM is unaffected (it uses the browser fetch stack, not rustls).

## Testing

- `cargo check -p pubky` passes.
- Verified downstream (pubky-core-ffi → react-native-pubky on Android): with this change the relay / ICANN homeserver fallback completes instead of failing with `Revoked`.

## Notes / related

- A complete Android fix should also cover **pkarr's relay client**, which is a separate reqwest client with the same default-verifier behavior (`pkarr/src/client/relays.rs` — `RelaysClient::new` builds a plain `Client::builder().build()`). Tracked in a separate PR against pkarr.
- Bonus observation: surfacing the full error `source()` chain in SDK errors would have made this much faster to diagnose (the reqwest `Display` only shows "error sending request…"; the `Revoked` cause is in the source chain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)