### PR TITLE
feat(sdk)!: Renamed startAuthFlow to startCookieAuthFlow + Cookie migration guide

### DIFF
--- a/docs/migration-v0.10.md
+++ b/docs/migration-v0.10.md
@@ -21,6 +21,9 @@ For cookie-auth applications:
 - JS: replace `resumeAuthFlow` with `resumeCookieAuthFlow`.
 - Rust: replace `start_auth_flow` with `start_cookie_auth_flow`.
 - Rust: replace `resume_auth_flow` with `resume_cookie_auth_flow`.
+- Rust: replace `session.export_secret()` with `session.as_cookie().and_then(|cookie| cookie.export_secret())`.
+- Rust: if your code uses cookie metadata fields from `session.info()`, use `session.as_cookie().unwrap().session_info()`.
+- Rust: prefer `session.as_cookie().unwrap().write_secret_file(...)` over deprecated `session.write_secret_file(...)`.
 
 ## JavaScript SDK
 
@@ -267,12 +270,16 @@ Restore cookie secret tokens with `Pubky::restore_session` or the existing `Pubk
 let restored = pubky.restore_session(&secret).await?;
 ```
 
-Writing `.sess` files also moves behind the cookie view.
+In `v0.9.x`, native Rust apps could write `.sess` files directly from `PubkySession`.
 
 ```rust
 // v0.9.x
 session.write_secret_file("alice.sess")?;
+```
 
+In v0.10, `write_secret_file` still exists as a deprecated compatibility method. Prefer the cookie view so the cookie-only operation is explicit.
+
+```rust
 // v0.10 cookie-compatible
 session
     .as_cookie()
@@ -290,16 +297,26 @@ The direct legacy methods `session.export()`, `session.write_secret_file(...)`, 
 
 ### Session Info
 
-In `v0.9.x`, `session.info()` returned the common cookie session record type. In v0.10, `session.info()` returns minimal auth-agnostic metadata.
+In `v0.9.x`, `session.info()` returned the common cookie session record type, so cookie metadata fields were available directly.
 
 ```rust
+// v0.9.x
+let created_at = session.info().created_at();
+let bytes = session.info().serialize();
+```
+
+In v0.10, `session.info()` returns minimal auth-agnostic metadata.
+
+```rust
+// v0.10 auth-agnostic
 let public_key = session.info().public_key();
 let capabilities = session.info().capabilities();
 ```
 
-If your app needs cookie-specific fields such as `created_at()` or the old binary serialization format, use the cookie view.
+To keep using cookie-specific fields such as `created_at()` or the old binary serialization format, use the cookie view.
 
 ```rust
+// v0.10 cookie-compatible
 let cookie_record = session
     .as_cookie()
     .expect("expected a cookie-backed session")

--- a/docs/migration-v0.10.md
+++ b/docs/migration-v0.10.md
@@ -24,6 +24,7 @@ For cookie-auth applications:
 - Rust: replace `session.export_secret()` with `session.as_cookie().and_then(|cookie| cookie.export_secret())`.
 - Rust: if your code uses cookie metadata fields from `session.info()`, use `session.as_cookie().unwrap().session_info()`.
 - Rust: prefer `session.as_cookie().unwrap().write_secret_file(...)` over deprecated `session.write_secret_file(...)`.
+- General: v0.10 tightens capability path matching. A trailing slash is significant.
 
 ## JavaScript SDK
 

--- a/docs/migration-v0.10.md
+++ b/docs/migration-v0.10.md
@@ -1,0 +1,386 @@
+# Migrating to v0.10
+
+This guide is for applications upgrading from `v0.9.x` that already use cookie-based SDK authentication and want that behavior to keep working.
+
+Cookie auth still exists in v0.10, but the SDK now names the cookie-compatible APIs explicitly. The main migration is to replace the old generic signer methods with the new `*Cookie` methods where your app expects a cookie-backed session.
+
+Some cookie-specific APIs are documented or marked as deprecated because cookie auth is now the compatibility path. That is expected for this migration.
+
+## Summary
+
+For cookie-auth applications:
+
+- JS: replace `signer.signup(...)` with `signer.signupCookie(...)` when you need the returned `Session`.
+- JS: replace `signer.signin()` with `signer.signinCookie()`.
+- JS: replace `signer.signinBlocking()` with `signer.signinCookieBlocking()`.
+- Rust: replace `signer.signup(...)` with `signer.signup_cookie(...)` when you need the returned `PubkySession`.
+- Rust: replace `signer.signin()` with `signer.signin_cookie()`.
+- Rust: replace `signer.signin_blocking()` with `signer.signin_cookie_blocking()`.
+- Rust: replace explicit `PubkyAuthFlow` references with `PubkyCookieAuthFlow`.
+- JS: replace `startAuthFlow` with `startCookieAuthFlow`.
+- JS: replace `resumeAuthFlow` with `resumeCookieAuthFlow`.
+- Rust: replace `start_auth_flow` with `start_cookie_auth_flow`.
+- Rust: replace `resume_auth_flow` with `resume_cookie_auth_flow`.
+
+## JavaScript SDK
+
+### Direct Signup
+
+In `v0.9.x`, `signup` created the account and returned a cookie-backed session.
+
+```js
+// v0.9.x
+const session = await signer.signup(homeserver, signupToken);
+```
+
+In v0.10, `signup` no longer returns a session, it only signs up. To keep the old cookie behavior, use `signupCookie`.
+
+```js
+// v0.10 cookie-compatible
+const session = await signer.signupCookie(homeserver, signupToken);
+```
+
+If the signup token is optional in your code, keep passing `null` or `undefined` as before.
+
+```js
+const session = await signer.signupCookie(homeserver, null);
+```
+
+### Direct Signin
+
+In `v0.9.x`, `signin` returned a cookie-backed session and did not take arguments.
+
+```js
+// v0.9.x
+const session = await signer.signin();
+```
+
+In v0.10, use `signinCookie` to keep cookie auth.
+
+```js
+// v0.10 cookie-compatible
+const session = await signer.signinCookie();
+```
+
+For blocking signin:
+
+```js
+// v0.9.x
+const session = await signer.signinBlocking();
+
+// v0.10 cookie-compatible
+const session = await signer.signinCookieBlocking();
+```
+
+### Auth Flow / QR Login
+
+If your existing JS app uses `startAuthFlow`, rename it to `startCookieAuthFlow`.
+
+```js
+const flow = pubky.startCookieAuthFlow(
+  "/pub/my-cool-app/:rw",
+  AuthFlowKind.signin(),
+  relay,
+);
+
+renderQr(flow.authorizationUrl);
+const session = await flow.awaitApproval();
+```
+
+This remains the cookie auth flow. Do not switch this code to `startGrantAuthFlow` unless you are intentionally changing auth models.
+
+If your app resumes a pending cookie auth flow, rename `resumeAuthFlow` to `resumeCookieAuthFlow`.
+
+```js
+const flow = pubky.resumeCookieAuthFlow(savedAuthorizationUrl);
+```
+
+### Session Persistence
+
+For browser cookie sessions, `session.export()` still works for the legacy metadata snapshot. The browser must still have the HTTP-only session cookie.
+
+```js
+const exported = session.export();
+
+const restored = await pubky.restoreSession(exported);
+```
+
+You can also use the explicit cookie view:
+
+```js
+const cookie = session.cookie;
+if (!cookie) {
+  throw new Error("Expected a cookie-backed session");
+}
+
+const exported = cookie.export();
+const restored = await pubky.restoreSession(exported);
+```
+
+In Node.js, the SDK can capture the cookie secret. If your application needs to persist a restartable cookie session, use `session.cookie.exportSecret()` and restore it with `pubky.restoreSession(...)`.
+
+```js
+const cookie = session.cookie;
+if (!cookie) {
+  throw new Error("Expected a cookie-backed session");
+}
+
+const secret = await cookie.exportSecret();
+const restored = await pubky.restoreSession(secret);
+```
+
+Browsers cannot export HTTP-only cookie secrets. In browser apps, keep using the metadata export plus the browser cookie jar.
+
+### JS Checklist
+
+- If your code expects `signup` to return a session, change it to `signupCookie`.
+- If your code calls `signin()` with no arguments, change it to `signinCookie()`.
+- If your code calls `signinBlocking()` with no arguments, change it to `signinCookieBlocking()`.
+- If your code uses `startAuthFlow`, change it to `startCookieAuthFlow`.
+- If your code uses `resumeAuthFlow`, change it to `resumeCookieAuthFlow`.
+- If your code persists browser sessions with `session.export()`, it can keep doing so for cookie-backed sessions.
+- If your code persists Node.js cookie secrets, prefer `session.cookie.exportSecret()`.
+
+## Rust SDK
+
+### Direct Signup
+
+In `v0.9.x`, `signup` created the account and returned a cookie-backed `PubkySession`.
+
+```rust
+// v0.9.x
+let session = signer.signup(&homeserver, None).await?;
+```
+
+In v0.10, `signup` no longer returns a session. To keep the old cookie behavior, use `signup_cookie`.
+
+```rust
+// v0.10 cookie-compatible
+let session = signer.signup_cookie(&homeserver, None).await?;
+```
+
+With a signup token:
+
+```rust
+let session = signer
+    .signup_cookie(&homeserver, Some("INVITE-123"))
+    .await?;
+```
+
+### Direct Signin
+
+In `v0.9.x`, `signin` returned a cookie-backed session and did not take arguments.
+
+```rust
+// v0.9.x
+let session = signer.signin().await?;
+```
+
+In v0.10, use `signin_cookie` to keep cookie auth.
+
+```rust
+// v0.10 cookie-compatible
+let session = signer.signin_cookie().await?;
+```
+
+For blocking signin:
+
+```rust
+// v0.9.x
+let session = signer.signin_blocking().await?;
+
+// v0.10 cookie-compatible
+let session = signer.signin_cookie_blocking().await?;
+```
+
+### Auth Flow / QR Login
+
+If your app starts auth flows through the `Pubky` facade, rename `start_auth_flow` to `start_cookie_auth_flow`.
+
+```rust
+let caps = Capabilities::builder()
+    .read_write("/pub/my-cool-app/")
+    .finish();
+
+let flow = pubky.start_cookie_auth_flow(&caps, AuthFlowKind::signin())?;
+println!("Scan to sign in: {}", flow.authorization_url());
+
+let session = flow.await_approval().await?;
+```
+
+If your code names the flow type directly, rename it from `PubkyAuthFlow` to `PubkyCookieAuthFlow`.
+
+```rust
+// v0.9.x
+use pubky::PubkyAuthFlow;
+
+// v0.10 cookie-compatible
+use pubky::PubkyCookieAuthFlow;
+```
+
+Builder usage changes the same way.
+
+```rust
+// v0.9.x
+let flow = PubkyAuthFlow::builder(&caps, AuthFlowKind::signin())
+    .relay(relay)
+    .start()?;
+
+// v0.10 cookie-compatible
+let flow = PubkyCookieAuthFlow::builder(&caps, AuthFlowKind::signin())
+    .relay(relay)
+    .start()?;
+```
+
+This remains the cookie auth flow. Do not switch this code to `start_grant_auth_flow` unless you are intentionally changing auth models.
+
+If your app resumes a pending cookie auth flow, rename `resume_auth_flow` to `resume_cookie_auth_flow`.
+
+```rust
+let flow = pubky.resume_cookie_auth_flow(saved_authorization_url)?;
+```
+
+### Session Persistence
+
+Cookie-specific session operations now live behind `session.as_cookie()`.
+
+In `v0.9.x`, native Rust apps could export a cookie secret directly from `PubkySession`.
+
+```rust
+// v0.9.x
+let secret = session.export_secret();
+```
+
+In v0.10, export the secret through the cookie view.
+
+```rust
+// v0.10 cookie-compatible
+let secret = session
+    .as_cookie()
+    .and_then(|cookie| cookie.export_secret())
+    .expect("expected an exportable cookie-backed session");
+```
+
+Restore cookie secret tokens with `Pubky::restore_session` or the existing `PubkySession::import_secret` API.
+
+```rust
+let restored = pubky.restore_session(&secret).await?;
+```
+
+Writing `.sess` files also moves behind the cookie view.
+
+```rust
+// v0.9.x
+session.write_secret_file("alice.sess")?;
+
+// v0.10 cookie-compatible
+session
+    .as_cookie()
+    .expect("expected a cookie-backed session")
+    .write_secret_file("alice.sess")?;
+```
+
+Reading `.sess` files still works through the `Pubky` facade.
+
+```rust
+let restored = pubky.session_from_file("alice.sess").await?;
+```
+
+The direct legacy methods `session.export()`, `session.write_secret_file(...)`, `PubkySession::import_secret(...)`, and `PubkySession::from_secret_file(...)` still exist for compatibility, but cookie-specific code should prefer `session.as_cookie()` so it cannot accidentally run against a non-cookie-backed session.
+
+### Session Info
+
+In `v0.9.x`, `session.info()` returned the common cookie session record type. In v0.10, `session.info()` returns minimal auth-agnostic metadata.
+
+```rust
+let public_key = session.info().public_key();
+let capabilities = session.info().capabilities();
+```
+
+If your app needs cookie-specific fields such as `created_at()` or the old binary serialization format, use the cookie view.
+
+```rust
+let cookie_record = session
+    .as_cookie()
+    .expect("expected a cookie-backed session")
+    .session_info();
+
+let created_at = cookie_record.created_at();
+let bytes = cookie_record.serialize();
+```
+
+The old common type was `pubky_common::session::SessionInfo`. The cookie-specific replacement is `pubky_common::session::CookieSessionRecord`, re-exported by the SDK as `pubky::CookieSessionRecord`.
+
+### Deep Link Parsing
+
+If your Rust app implements an authenticator and parses legacy signin or signup deep links directly, the parameter accessors changed.
+
+Use `params()` instead of the old direct methods.
+
+```rust
+let params = deep_link.params();
+
+let caps = &params.capabilities;
+let relay = &params.relay;
+let secret = &params.secret;
+```
+
+For signup deep links:
+
+```rust
+let params = signup_deep_link.params();
+
+let homeserver = &params.homeserver;
+let signup_token = params.signup_token.as_deref();
+```
+
+If your code matches on `DeepLink`, make sure it has a fallback or handles all variants. v0.10 adds extra variants, so exhaustive matches written against `v0.9.x` may fail to compile.
+
+### Rust Checklist
+
+- If your code expects `signup` to return `PubkySession`, change it to `signup_cookie`.
+- If your code calls `signin()` with no arguments, change it to `signin_cookie()`.
+- If your code calls `signin_blocking()` with no arguments, change it to `signin_cookie_blocking()`.
+- If your code imports `PubkyAuthFlow`, change it to `PubkyCookieAuthFlow`.
+- If your code uses `PubkyAuthFlow::builder`, change it to `PubkyCookieAuthFlow::builder`.
+- If your code uses `start_auth_flow`, change it to `start_cookie_auth_flow`.
+- If your code uses `resume_auth_flow`, change it to `resume_cookie_auth_flow`.
+- If your code uses `session.export_secret()`, change it to `session.as_cookie().and_then(|cookie| cookie.export_secret())`.
+- If your code uses `session.write_secret_file(...)`, change it to `session.as_cookie().unwrap().write_secret_file(...)`.
+- If your code needs cookie metadata fields, use `session.as_cookie().unwrap().session_info()`.
+
+## Capability Path Matching
+
+v0.10 tightens capability path matching. A trailing slash is significant.
+
+Directory scopes should end with `/`.
+
+```text
+/pub/app/:rw covers /pub/app/file.txt
+/pub/app:rw only covers /pub/app
+```
+
+If your app intends to grant access to everything under an app directory, use a trailing slash.
+
+```rust
+let caps = Capabilities::builder()
+    .read_write("/pub/my-cool-app/")
+    .finish();
+```
+
+```js
+const caps = "/pub/my-cool-app/:rw";
+```
+
+## What Changed But Is Not Required For Cookie Auth
+
+v0.10 introduces additional auth APIs and session views, but cookie-auth applications do not need to adopt them to keep working.
+
+For a cookie-auth migration, avoid changing working code to:
+
+- JS `startGrantAuthFlow(...)`.
+- Rust `start_grant_auth_flow(...)`.
+- Grant session management APIs.
+- Grant secret export/import APIs.
+
+Use those only when you intentionally migrate away from cookie auth.

--- a/examples/rust/3-auth_flow/3rd-party-app/src/pubky-auth-widget.js
+++ b/examples/rust/3-auth_flow/3rd-party-app/src/pubky-auth-widget.js
@@ -76,7 +76,7 @@ export class PubkyAuthWidget extends LitElement {
       this.relay || (this.testnet ? TESTNET_HTTP_RELAY : DEFAULT_HTTP_RELAY);
 
     // Start the flow with the facade’s client
-    const flow = this._sdk.startAuthFlow(this.caps, pubky.AuthFlowKind.signin(), relay);
+    const flow = this._sdk.startCookieAuthFlow(this.caps, pubky.AuthFlowKind.signin(), relay);
 
     // Capture the deep link *before* awaiting (await will consume the flow handle)
     this._authUrl = flow.authorizationUrl;

--- a/examples/rust/6-auth_flow_signup/3rd-party-app/src/pubky-auth-widget.js
+++ b/examples/rust/6-auth_flow_signup/3rd-party-app/src/pubky-auth-widget.js
@@ -79,7 +79,7 @@ export class PubkyAuthWidget extends LitElement {
 
     // Start the flow with the facade’s client
     let homeserverPublicKey = pubky.PublicKey.from(this.homeserverPublicKey);
-    const flow = this._sdk.startAuthFlow(this.caps, pubky.AuthFlowKind.signup(homeserverPublicKey, this.signupToken), relay);
+    const flow = this._sdk.startCookieAuthFlow(this.caps, pubky.AuthFlowKind.signup(homeserverPublicKey, this.signupToken), relay);
 
     // Capture the deep link *before* awaiting (await will consume the flow handle)
     this._authUrl = flow.authorizationUrl;

--- a/pubky-sdk/README.md
+++ b/pubky-sdk/README.md
@@ -51,7 +51,7 @@ assert_eq!(txt, "hello");
 
 // 5) Keyless app flow (QR/deeplink)
 let caps = Capabilities::builder().write("/pub/example.com/").finish();
-let flow = pubky.start_auth_flow(&caps, AuthFlowKind::signin())?;
+let flow = pubky.start_cookie_auth_flow(&caps, AuthFlowKind::signin())?;
 println!("Scan to sign in: {}", flow.authorization_url());
 let app_session = flow.await_approval().await?;
 
@@ -198,7 +198,7 @@ Request an authorization URL and await approval.
 
 **Typical usage:**
 
-1. Start an auth flow with `pubky.start_grant_auth_flow(&caps, ..)` (or `pubky.start_auth_flow(&caps, ..)` for the deprecated cookie variant). You can also use `PubkyGrantAuthFlow::builder()` / `PubkyCookieAuthFlow::builder()` to set a custom relay.
+1. Start an auth flow with `pubky.start_grant_auth_flow(&caps, ..)` (or `pubky.start_cookie_auth_flow(&caps, ..)` for the cookie variant). You can also use `PubkyGrantAuthFlow::builder()` / `PubkyCookieAuthFlow::builder()` to set a custom relay.
 2. Show `authorization_url()` (QR/deeplink) to the signing device (e.g., [Pubky Ring](https://github.com/pubky/pubky-ring) — [iOS](https://apps.apple.com/om/app/pubky-ring/id6739356756) / [Android](https://play.google.com/store/apps/details?id=to.pubky.ring)).
 3. Await `await_approval()` to obtain a session-bound `PubkySession`, or `await_credential()` for a raw `GrantCredential`/`CookieCredential` that you can persist, inspect, or lift into a session later via `PubkySession::from_{grant,cookie}_credential`.
 
@@ -211,7 +211,7 @@ let pubky = Pubky::new()?;
 let caps = Capabilities::builder().read_write("pub/example.com/").finish();
 
 // Start the flow using the default relay (see “Relay & reliability” below)
-let flow = pubky.start_auth_flow(&caps, AuthFlowKind::signin())?;
+let flow = pubky.start_cookie_auth_flow(&caps, AuthFlowKind::signin())?;
 println!("Scan to sign in: {}", flow.authorization_url());
 
 // On the signing device, approve with: signer.approve_auth(flow.authorization_url()).await?;

--- a/pubky-sdk/bindings/js/pkg/tests/auth.ts
+++ b/pubky-sdk/bindings/js/pkg/tests/auth.ts
@@ -32,7 +32,7 @@ test("Auth: 3rd party signup", async (t) => {
   const signupToken = await createSignupToken();
 
   const capabilities = "/pub/pubky.app/:rw,/pub/foo.bar/file:r";
-  const flow = sdk.startAuthFlow(capabilities, AuthFlowKind.signup(HOMESERVER_PUBLICKEY, signupToken), TESTNET_HTTP_RELAY);
+  const flow = sdk.startCookieAuthFlow(capabilities, AuthFlowKind.signup(HOMESERVER_PUBLICKEY, signupToken), TESTNET_HTTP_RELAY);
 
   type Flow = typeof flow;
   type SessionPromise = ReturnType<Flow["awaitApproval"]>;
@@ -70,7 +70,7 @@ test("Auth: 3rd party signin", async (t) => {
   const pubky = signer.publicKey.z32();
 
   const capabilities = "/pub/pubky.app/:rw,/pub/foo.bar/file:r";
-  const flow = sdk.startAuthFlow(capabilities, AuthFlowKind.signin(), TESTNET_HTTP_RELAY);
+  const flow = sdk.startCookieAuthFlow(capabilities, AuthFlowKind.signin(), TESTNET_HTTP_RELAY);
 
   type Flow = typeof flow;
   type SessionPromise = ReturnType<Flow["awaitApproval"]>;
@@ -199,14 +199,14 @@ test("Grant auth: 3rd party signup", async (t) => {
   t.end();
 });
 
-test("startAuthFlow: rejects malformed capabilities; normalizes valid; allows empty", async (t) => {
+test("startCookieAuthFlow: rejects malformed capabilities; normalizes valid; allows empty", async (t) => {
   const sdk = Pubky.testnet(); // uses local testnet mapping so URLs are resolvable in-node
 
   // 1) Invalid entries -> throws InvalidInput with a precise message
   try {
     // @ts-ignore: invalid capabilities string format. Emulating plain JS validation rules.
-    sdk.startAuthFlow("/ok/:rw,not/a/cap,/also:bad:x", AuthFlowKind.signin(), TESTNET_HTTP_RELAY);
-    t.fail("startAuthFlow() should throw on malformed capability entries");
+    sdk.startCookieAuthFlow("/ok/:rw,not/a/cap,/also:bad:x", AuthFlowKind.signin(), TESTNET_HTTP_RELAY);
+    t.fail("startCookieAuthFlow() should throw on malformed capability entries");
   } catch (error) {
     assertPubkyError(t, error);
     t.equal(error.name, "InvalidInput", "invalid caps -> InvalidInput");
@@ -241,7 +241,7 @@ test("startAuthFlow: rejects malformed capabilities; normalizes valid; allows em
   // 2) Valid entry with unordered actions -> normalized in URL (wr -> rw)
   {
     // @ts-ignore: invalid capabilities string format. Emulating plain JS normalization.
-    const flow = sdk.startAuthFlow("/pub/example/:wr", AuthFlowKind.signin(), TESTNET_HTTP_RELAY);
+    const flow = sdk.startCookieAuthFlow("/pub/example/:wr", AuthFlowKind.signin(), TESTNET_HTTP_RELAY);
     const url = new URL(flow.authorizationUrl);
     const caps = url.searchParams.get("caps");
     t.equal(
@@ -253,7 +253,7 @@ test("startAuthFlow: rejects malformed capabilities; normalizes valid; allows em
 
   // 3) Empty string -> allowed; caps param remains empty
   {
-    const flow = sdk.startAuthFlow("", AuthFlowKind.signin(), TESTNET_HTTP_RELAY);
+    const flow = sdk.startCookieAuthFlow("", AuthFlowKind.signin(), TESTNET_HTTP_RELAY);
     const url = new URL(flow.authorizationUrl);
     const caps = url.searchParams.get("caps");
     t.equal(caps, "", "empty input allowed (no scopes)");
@@ -403,7 +403,7 @@ test("Auth: resume signin flow reconnects to same channel", async (t) => {
   const capabilities = "/pub/pubky.app/:rw,/pub/foo.bar/file:r";
 
   // 1) Start a flow and save the URL (as the app would before a refresh).
-  const originalFlow = sdk.startAuthFlow(capabilities, AuthFlowKind.signin(), TESTNET_HTTP_RELAY);
+  const originalFlow = sdk.startCookieAuthFlow(capabilities, AuthFlowKind.signin(), TESTNET_HTTP_RELAY);
   const savedUrl = originalFlow.authorizationUrl;
   // Explicitly free the WASM handle — simulates page refresh killing WASM memory.
   // JS block scoping does NOT trigger WASM destructors; .free() does.
@@ -417,7 +417,7 @@ test("Auth: resume signin flow reconnects to same channel", async (t) => {
   }
 
   // 3) Resume from the saved URL — reconnects to the same relay channel.
-  const resumedFlow = sdk.resumeAuthFlow(savedUrl);
+  const resumedFlow = sdk.resumeCookieAuthFlow(savedUrl);
 
   t.equal(
     resumedFlow.authorizationUrl,
@@ -451,7 +451,7 @@ test("Auth: resume signup flow preserves signup params and channel", async (t) =
   const capabilities = "/pub/pubky.app/:rw,/pub/foo.bar/file:r";
 
   // 1) Start a signup flow and save URL before refresh.
-  const originalFlow = sdk.startAuthFlow(
+  const originalFlow = sdk.startCookieAuthFlow(
     capabilities,
     AuthFlowKind.signup(HOMESERVER_PUBLICKEY, signupToken),
     TESTNET_HTTP_RELAY,
@@ -479,7 +479,7 @@ test("Auth: resume signup flow preserves signup params and channel", async (t) =
   await signer.approveAuthRequest(savedUrl);
 
   // 3) Resume from persisted URL.
-  const resumedFlow = sdk.resumeAuthFlow(savedUrl);
+  const resumedFlow = sdk.resumeCookieAuthFlow(savedUrl);
 
   t.equal(
     resumedFlow.authorizationUrl,
@@ -515,12 +515,12 @@ test("Auth: resume signup flow preserves signup params and channel", async (t) =
   t.end();
 });
 
-test("resumeAuthFlow: rejects invalid URL", async (t) => {
+test("resumeCookieAuthFlow: rejects invalid URL", async (t) => {
   const sdk = Pubky.testnet();
 
   try {
-    sdk.resumeAuthFlow("https://not-a-pubkyauth-url.com");
-    t.fail("resumeAuthFlow() should throw on non-pubkyauth URL");
+    sdk.resumeCookieAuthFlow("https://not-a-pubkyauth-url.com");
+    t.fail("resumeCookieAuthFlow() should throw on non-pubkyauth URL");
   } catch (error) {
     assertPubkyError(t, error);
     t.equal(error.name, "AuthenticationError", "invalid URL -> AuthenticationError");
@@ -531,8 +531,8 @@ test("resumeAuthFlow: rejects invalid URL", async (t) => {
   }
 
   try {
-    sdk.resumeAuthFlow("pubkyauth://secret_export?secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8");
-    t.fail("resumeAuthFlow() should reject seed export URLs");
+    sdk.resumeCookieAuthFlow("pubkyauth://secret_export?secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8");
+    t.fail("resumeCookieAuthFlow() should reject seed export URLs");
   } catch (error) {
     assertPubkyError(t, error);
     t.equal(error.name, "AuthenticationError", "seed export URL -> AuthenticationError");

--- a/pubky-sdk/bindings/js/pkg/tests/auth_flow_state.ts
+++ b/pubky-sdk/bindings/js/pkg/tests/auth_flow_state.ts
@@ -7,7 +7,7 @@ const DEAD_RELAY = "http://127.0.0.1:9/inbox"; // port 9 is typically closed; yi
 // Ensure a second awaitApproval call returns a ClientStateError instead of panicking the WASM layer.
 test("AuthFlow: repeat awaitApproval reports ClientStateError", async (t) => {
   const sdk = Pubky.testnet();
-  const flow = sdk.startAuthFlow("", AuthFlowKind.signin() ,DEAD_RELAY);
+  const flow = sdk.startCookieAuthFlow("", AuthFlowKind.signin() ,DEAD_RELAY);
 
   // First call is expected to reject because the relay is unreachable.
   await flow.awaitApproval().catch(() => {});
@@ -30,7 +30,7 @@ test("AuthFlow: repeat awaitApproval reports ClientStateError", async (t) => {
 // Ensure in-flight polling prevents another awaitApproval from consuming the WASM handle.
 test("AuthFlow: awaitApproval blocked while tryPollOnce is in-flight", async (t) => {
   const sdk = Pubky.testnet();
-  const flow = sdk.startAuthFlow("", AuthFlowKind.signin(), DEAD_RELAY);
+  const flow = sdk.startCookieAuthFlow("", AuthFlowKind.signin(), DEAD_RELAY);
 
   // Kick off a poll without awaiting it to keep an extra handle alive.
   const pendingPoll = flow.tryPollOnce();
@@ -56,7 +56,7 @@ test("AuthFlow: awaitApproval blocked while tryPollOnce is in-flight", async (t)
 // Ensure borrow-based calls after completion surface a clear ClientStateError instead of null pointer panics.
 test("AuthFlow: tryPollOnce after completion reports ClientStateError", async (t) => {
   const sdk = Pubky.testnet();
-  const flow = sdk.startAuthFlow("", AuthFlowKind.signin(), DEAD_RELAY);
+  const flow = sdk.startCookieAuthFlow("", AuthFlowKind.signin(), DEAD_RELAY);
 
   await flow.awaitApproval().catch(() => {});
 

--- a/pubky-sdk/bindings/js/src/actors/auth_flow.rs
+++ b/pubky-sdk/bindings/js/src/actors/auth_flow.rs
@@ -21,7 +21,7 @@ use crate::{
 /// Start and control a pubkyauth authorization flow.
 ///
 /// Typical flow:
-/// 1) `AuthFlow.start(...)` or `pubky.startAuthFlow(...)`
+/// 1) `AuthFlow.start(...)` or `pubky.startCookieAuthFlow(...)`
 /// 2) Show `authorizationUrl()` as QR/deeplink to the user’s signing device
 /// 3) `awaitApproval()` to receive a ready `Session`
 ///
@@ -36,7 +36,7 @@ pub struct AuthFlow {
 #[wasm_bindgen]
 impl AuthFlow {
     /// Start a flow (standalone).
-    /// Prefer `pubky.startAuthFlow()` to reuse a facade client.
+    /// Prefer `pubky.startCookieAuthFlow()` to reuse a facade client.
     ///
     /// @param {string} capabilities
     /// Comma-separated capabilities, e.g. `"/pub/app/:rw,/priv/foo.txt:r"`.
@@ -104,10 +104,10 @@ impl AuthFlow {
     }
 
     /// Resume a previously started auth flow from its saved `authorizationUrl` (standalone).
-    /// Prefer `pubky.resumeAuthFlow()` to reuse a facade client; this creates a default (mainnet) client.
+    /// Prefer `pubky.resumeCookieAuthFlow()` to reuse a facade client; this creates a default (mainnet) client.
     ///
     /// Relay messages expire after ~5 minutes; resume is only viable in that window.
-    /// See `Pubky.resumeAuthFlow()` / `Pubky.startAuthFlow()` for full guidance.
+    /// See `Pubky.resumeCookieAuthFlow()` / `Pubky.startCookieAuthFlow()` for full guidance.
     ///
     /// **Security:** `authorizationUrl` contains the `client_secret`.
     /// Delete it from storage as soon as resume completes or is abandoned.
@@ -130,7 +130,7 @@ impl AuthFlow {
             Some(c) => pubky::Pubky::with_client(c),
             None => pubky::Pubky::new()?,
         };
-        let flow = pubky.resume_auth_flow(&authorization_url)?;
+        let flow = pubky.resume_cookie_auth_flow(&authorization_url)?;
         Ok(flow.into())
     }
 
@@ -138,7 +138,7 @@ impl AuthFlow {
     ///
     /// **Security:** This URL contains the `client_secret` in plaintext.
     /// Treat it as a short-lived secret and delete it after the flow completes.
-    /// See `Pubky.startAuthFlow()` docs for storage guidance.
+    /// See `Pubky.startCookieAuthFlow()` docs for storage guidance.
     ///
     /// @returns {string} A `pubkyauth://…` or `https://…` URL with channel info.
     ///

--- a/pubky-sdk/bindings/js/src/pubky.rs
+++ b/pubky-sdk/bindings/js/src/pubky.rs
@@ -93,13 +93,12 @@ impl Pubky {
     /// - `{ name: "RequestError" }` if the flow cannot be started (network/relay)
     ///
     /// @example
-    /// const flow = pubky.startAuthFlow("/pub/my-cool-app/:rw");
+    /// const flow = pubky.startCookieAuthFlow("/pub/my-cool-app/:rw");
     /// renderQr(flow.authorizationUrl);
     /// const session = await flow.awaitApproval();
     ///
-    /// @deprecated Use `Pubky.startGrantAuthFlow(...)` instead.
-    #[wasm_bindgen(js_name = "startAuthFlow")]
-    pub fn start_auth_flow(
+    #[wasm_bindgen(js_name = "startCookieAuthFlow")]
+    pub fn start_cookie_auth_flow(
         &self,
         #[wasm_bindgen(unchecked_param_type = "Capabilities")] capabilities: String,
         kind: AuthFlowKind,
@@ -145,15 +144,15 @@ impl Pubky {
     ///
     /// **Security:** The URL contains the `client_secret` in plaintext.
     /// Delete it from storage as soon as the resumed flow completes.
-    /// See `startAuthFlow()` docs for full storage guidance.
+    /// See `startCookieAuthFlow()` docs for full storage guidance.
     ///
     /// @param {string} authorizationUrl The `pubkyauth://…` URL from a previous flow.
     /// @returns {AuthFlow} A flow reconnected to the original relay channel.
     /// @throws {PubkyError}
     /// - `{ name: "AuthenticationError" }` if the URL is invalid or not a signin/signup link
     /// - `{ name: "RequestError" }` on network/relay failure
-    #[wasm_bindgen(js_name = "resumeAuthFlow")]
-    pub fn resume_auth_flow(&self, authorization_url: String) -> JsResult<AuthFlow> {
+    #[wasm_bindgen(js_name = "resumeCookieAuthFlow")]
+    pub fn resume_cookie_auth_flow(&self, authorization_url: String) -> JsResult<AuthFlow> {
         AuthFlow::resume_with_client(authorization_url, Some(self.0.client().clone()))
     }
 

--- a/pubky-sdk/bindings/js/src/wrappers/auth_token.rs
+++ b/pubky-sdk/bindings/js/src/wrappers/auth_token.rs
@@ -8,7 +8,7 @@
 //
 //    import { AuthFlow } from "@synonymdev/pubky";
 //
-//    const flow = pubky.startAuthFlow("", relay); // no capabilities => auth-only
+//    const flow = pubky.startCookieAuthFlow("", relay); // no capabilities => auth-only
 //    const token = await flow.awaitToken();       // <- AuthToken
 //
 //    // Who just authenticated?
@@ -33,7 +33,7 @@ use crate::wrappers::keys::PublicKey;
 /// ### Typical usage
 /// ```js
 /// // Start an auth-only flow (no capabilities)
-/// const flow = pubky.startAuthFlow("", relay);
+/// const flow = pubky.startCookieAuthFlow("", relay);
 ///
 /// // Wait for the signer to approve; returns an AuthToken
 /// const token = await flow.awaitToken();
@@ -112,7 +112,7 @@ impl AuthToken {
 
     /// Returns the **capabilities** requested by the flow at the time this token was signed.
     ///
-    /// Most auth-only flows pass an empty string to `startAuthFlow("", relay)`, so this will
+    /// Most auth-only flows pass an empty string to `startCookieAuthFlow("", relay)`, so this will
     /// commonly be an empty array.
     ///
     /// Returns: `string[]`, where each item is the canonical entry `"<scope>:<actions>"`.

--- a/pubky-sdk/src/actors/auth/cookie/flow.rs
+++ b/pubky-sdk/src/actors/auth/cookie/flow.rs
@@ -288,7 +288,7 @@ mod tests {
             .await
             .unwrap();
 
-        let resumed = pubky.resume_auth_flow(&auth_url_str).unwrap();
+        let resumed = pubky.resume_cookie_auth_flow(&auth_url_str).unwrap();
 
         assert_eq!(
             resumed.authorization_url().as_str(),
@@ -320,7 +320,7 @@ mod tests {
         let client = PubkyHttpClient::new().unwrap();
         let pubky = Pubky::with_client(client);
 
-        let result = pubky.resume_auth_flow("https://not-a-pubkyauth-url.com");
+        let result = pubky.resume_cookie_auth_flow("https://not-a-pubkyauth-url.com");
         assert!(result.is_err(), "non-pubkyauth URL should fail to resume");
     }
 
@@ -330,7 +330,7 @@ mod tests {
         let pubky = Pubky::with_client(client);
 
         let url = "pubkyauth://secret_export?secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8";
-        let result = pubky.resume_auth_flow(url);
+        let result = pubky.resume_cookie_auth_flow(url);
         assert!(result.is_err(), "seed export URL should fail to resume");
     }
 }

--- a/pubky-sdk/src/pubky.rs
+++ b/pubky-sdk/src/pubky.rs
@@ -15,7 +15,7 @@
 //! let pubky = Pubky::new()?; // or Pubky::testnet() / Pubky::with_client(...)
 //!
 //! let caps = Capabilities::builder().write("/pub/demoapp/").finish();
-//! let flow = pubky.start_auth_flow(&caps, AuthFlowKind::signin())?;
+//! let flow = pubky.start_cookie_auth_flow(&caps, AuthFlowKind::signin())?;
 //! println!("Scan to sign in: {}", flow.authorization_url());
 //!
 //! let session = flow.await_approval().await?;
@@ -123,7 +123,7 @@ impl Pubky {
         deprecated,
         reason = "Cookie flow is intentionally exposed via this facade while deprecated"
     )]
-    pub fn start_auth_flow(
+    pub fn start_cookie_auth_flow(
         &self,
         caps: &Capabilities,
         auth_kind: AuthFlowKind,
@@ -162,10 +162,11 @@ impl Pubky {
     ///
     /// The relay inbox persists messages for **~5 minutes**; resume is only
     /// viable within that window. After the TTL expires the channel is gone
-    /// and you must start a fresh flow with [`start_auth_flow`](Self::start_auth_flow).
+    /// and you must start a fresh flow with
+    /// [`start_cookie_auth_flow`](Self::start_cookie_auth_flow).
     ///
     /// The `authorization_url` contains the `client_secret`; follow
-    /// [`start_auth_flow`](Self::start_auth_flow) storage guidance and delete it
+    /// [`start_cookie_auth_flow`](Self::start_cookie_auth_flow) storage guidance and delete it
     /// once resume completes or is abandoned.
     ///
     /// # Errors
@@ -175,7 +176,7 @@ impl Pubky {
         deprecated,
         reason = "Cookie flow is intentionally exposed via this facade while deprecated"
     )]
-    pub fn resume_auth_flow(&self, authorization_url: &str) -> Result<PubkyCookieAuthFlow> {
+    pub fn resume_cookie_auth_flow(&self, authorization_url: &str) -> Result<PubkyCookieAuthFlow> {
         let (caps, relay, secret, auth_kind) = parse_auth_deep_link(authorization_url)?;
 
         PubkyCookieAuthFlow::builder(&caps, auth_kind)


### PR DESCRIPTION
This PR introduces a breaking change. It renames `pubky.startAuthFlow` to `startCookieAuthFlow`. This is to clearly indicate that is is cookie auth, not grant auth. Grant auth itself already uses `startGrandAuthFlow`.

At the same time, this PR adds a v0.10 migration guide. The goal is to release a `v0.10.0-alpha.0` version to unblock the `main` branch from being released as a new version. The migration guide only shows the cookie breaking changes. Grant auth is available but not well tested yet and missing features/examples/migration guides.

Related issue: https://github.com/pubky/pubky-core/issues/401