### PR TITLE
docs(testnet): gate Docker Postgres doctest by feature

### DIFF
--- a/pubky-testnet/README.md
+++ b/pubky-testnet/README.md
@@ -139,6 +139,8 @@ Use `DockerPostgres::shared()` to start **one** container and share its connecti
 Docker handles cleanup automatically when the process exits.
 
 ```rust
+# #[cfg(feature = "docker-postgres")]
+# mod docker_postgres_example {
 use pubky_testnet::EphemeralTestnet;
 use pubky_testnet::docker_postgres::DockerPostgres;
 
@@ -163,6 +165,7 @@ async fn test_two() {
         .unwrap();
     // ... test code
 }
+# }
 ```
 
 Each testnet still gets its own ephemeral database within the shared PostgreSQL instance, so tests remain isolated.


### PR DESCRIPTION
Wrap the README example in a hidden cfg module so plain doctests do
not try to import the feature-gated `docker_postgres` module.
