### PR TITLE
feat(homeserver): events admin endpoint

### DIFF
--- a/e2e/src/tests/admin.rs
+++ b/e2e/src/tests/admin.rs
@@ -456,11 +456,16 @@ async fn allowed_write_paths_enforced_via_http() {
     );
 }
 
-/// End-to-end: a real `/priv/` write surfaces in the admin events feed
-/// while the public client-server feed stays public-only and never leaks the private path.
+/// End-to-end over raw HTTP/SSE: real `/pub/` and `/priv/` writes surface in the admin
+/// `/events-stream` (batch + live), a wrong password is rejected, and the public client-server
+/// feed stays public-only and never leaks the private path.
 #[tokio::test]
 #[pubky_testnet::test]
-async fn admin_events_feed_exposes_private_events() {
+async fn admin_event_stream_exposes_private_events() {
+    use eventsource_stream::Eventsource;
+    use futures::StreamExt;
+    use tokio::time::{timeout, Duration};
+
     let config = ConfigToml::default_test_config();
     let admin_password = config.admin.admin_password.clone();
 
@@ -476,15 +481,14 @@ async fn admin_events_feed_exposes_private_events() {
         .admin_server()
         .expect("admin server should be enabled")
         .listen_socket();
+    let stream_url = format!("http://{admin_socket}/events-stream");
 
     // Create a user/session and write one public and one private file.
     let signer = pubky.signer(Keypair::random());
-    let pubkey_z32 = signer.public_key().z32();
     let session = signer
         .signup_cookie(&server.public_key(), None)
         .await
         .unwrap();
-
     session
         .storage()
         .put("/pub/note.txt", vec![1, 2, 3])
@@ -496,34 +500,75 @@ async fn admin_events_feed_exposes_private_events() {
         .await
         .unwrap();
 
-    // Admin feed (password-authenticated) returns BOTH events, including the private one,
-    // and must not be cached.
-    let admin_resp = PubkyHttpClient::new()
-        .unwrap()
-        .request(Method::GET, &format!("http://{admin_socket}/events"))
+    let admin_client = PubkyHttpClient::new().unwrap();
+
+    // Batch mode: the SSE stream replays every event (public + private) then closes.
+    let response = admin_client
+        .request(Method::GET, &stream_url)
         .header("X-Admin-Password", &admin_password)
         .send()
         .await
         .unwrap();
-    assert_eq!(admin_resp.status(), StatusCode::OK);
+    assert_eq!(response.status(), StatusCode::OK);
     assert_eq!(
-        admin_resp
+        response
             .headers()
             .get("cache-control")
             .and_then(|v| v.to_str().ok()),
         Some("no-store"),
     );
-    let admin_body = admin_resp.text().await.unwrap();
+    let mut stream = response.bytes_stream().eventsource();
+    let mut data = String::new();
+    while let Ok(Some(Ok(event))) = timeout(Duration::from_secs(5), stream.next()).await {
+        data.push_str(&event.data);
+        data.push('\n');
+    }
     assert!(
-        admin_body.contains(&format!("PUT pubky://{pubkey_z32}/pub/note.txt")),
-        "admin feed should include the public event: {admin_body}"
+        data.contains("/pub/note.txt"),
+        "admin stream should include the public event: {data}"
     );
     assert!(
-        admin_body.contains(&format!("PUT pubky://{pubkey_z32}/priv/app/secret.txt")),
-        "admin feed should include the private event: {admin_body}"
+        data.contains("/priv/app/secret.txt"),
+        "admin stream should include the private event: {data}"
     );
 
-    // The public client-server feed is public-only, it must NOT leak the private path.
+    // A wrong admin password is rejected with 401.
+    let unauthorized = admin_client
+        .request(Method::GET, &stream_url)
+        .header("X-Admin-Password", "wrong-password")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(unauthorized.status(), StatusCode::UNAUTHORIZED);
+
+    // Live mode: after replaying history, a brand-new private write is delivered.
+    let response = admin_client
+        .request(Method::GET, &format!("{stream_url}?live=true"))
+        .header("X-Admin-Password", &admin_password)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let mut live = response.bytes_stream().eventsource();
+    session
+        .storage()
+        .put("/priv/app/new.txt", vec![7, 8, 9])
+        .await
+        .unwrap();
+    let mut saw_new = false;
+    while let Ok(Some(Ok(event))) = timeout(Duration::from_secs(10), live.next()).await {
+        if event.data.contains("/priv/app/new.txt") {
+            saw_new = true;
+            break;
+        }
+    }
+    assert!(
+        saw_new,
+        "live admin stream should deliver the new private event"
+    );
+    drop(live); // close the live connection
+
+    // The public client-server feed is public-only; it must NOT leak the private paths.
     let feed_url = format!("https://{}/events/", server.public_key().z32());
     let public_body = session
         .client()
@@ -535,7 +580,7 @@ async fn admin_events_feed_exposes_private_events() {
         .await
         .unwrap();
     assert!(
-        public_body.contains(&format!("PUT pubky://{pubkey_z32}/pub/note.txt")),
+        public_body.contains("/pub/note.txt"),
         "public feed should include the public event: {public_body}"
     );
     assert!(

--- a/e2e/src/tests/admin.rs
+++ b/e2e/src/tests/admin.rs
@@ -455,3 +455,91 @@ async fn allowed_write_paths_enforced_via_http() {
         "Expected 403 FORBIDDEN on delete but got: {err:?}"
     );
 }
+
+/// End-to-end: a real `/priv/` write surfaces in the admin events feed
+/// while the public client-server feed stays public-only and never leaks the private path.
+#[tokio::test]
+#[pubky_testnet::test]
+async fn admin_events_feed_exposes_private_events() {
+    let config = ConfigToml::default_test_config();
+    let admin_password = config.admin.admin_password.clone();
+
+    let mut testnet = Testnet::new().await.unwrap();
+    let pubky = testnet.sdk().unwrap();
+    let mock_dir = MockDataDir::new(config, Some(Keypair::random())).unwrap();
+    let server = testnet
+        .create_homeserver_app_with_mock(mock_dir)
+        .await
+        .unwrap();
+
+    let admin_socket = server
+        .admin_server()
+        .expect("admin server should be enabled")
+        .listen_socket();
+
+    // Create a user/session and write one public and one private file.
+    let signer = pubky.signer(Keypair::random());
+    let pubkey_z32 = signer.public_key().z32();
+    let session = signer
+        .signup_cookie(&server.public_key(), None)
+        .await
+        .unwrap();
+
+    session
+        .storage()
+        .put("/pub/note.txt", vec![1, 2, 3])
+        .await
+        .unwrap();
+    session
+        .storage()
+        .put("/priv/app/secret.txt", vec![4, 5, 6])
+        .await
+        .unwrap();
+
+    // Admin feed (password-authenticated) returns BOTH events, including the private one,
+    // and must not be cached.
+    let admin_resp = PubkyHttpClient::new()
+        .unwrap()
+        .request(Method::GET, &format!("http://{admin_socket}/events"))
+        .header("X-Admin-Password", &admin_password)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(admin_resp.status(), StatusCode::OK);
+    assert_eq!(
+        admin_resp
+            .headers()
+            .get("cache-control")
+            .and_then(|v| v.to_str().ok()),
+        Some("no-store"),
+    );
+    let admin_body = admin_resp.text().await.unwrap();
+    assert!(
+        admin_body.contains(&format!("PUT pubky://{pubkey_z32}/pub/note.txt")),
+        "admin feed should include the public event: {admin_body}"
+    );
+    assert!(
+        admin_body.contains(&format!("PUT pubky://{pubkey_z32}/priv/app/secret.txt")),
+        "admin feed should include the private event: {admin_body}"
+    );
+
+    // The public client-server feed is public-only, it must NOT leak the private path.
+    let feed_url = format!("https://{}/events/", server.public_key().z32());
+    let public_body = session
+        .client()
+        .request(Method::GET, &feed_url)
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    assert!(
+        public_body.contains(&format!("PUT pubky://{pubkey_z32}/pub/note.txt")),
+        "public feed should include the public event: {public_body}"
+    );
+    assert!(
+        !public_body.contains("/priv/"),
+        "public feed must not leak private paths: {public_body}"
+    );
+}

--- a/pubky-homeserver/openapi.yml
+++ b/pubky-homeserver/openapi.yml
@@ -676,7 +676,7 @@ paths:
           description: Maximum total events to send.
           schema:
             type: integer
-            minimum: 0
+            minimum: 1
             maximum: 65535
         - name: reverse
           in: query

--- a/pubky-homeserver/openapi.yml
+++ b/pubky-homeserver/openapi.yml
@@ -626,6 +626,13 @@ paths:
         data: cursor: 42
         data: content_hash: r0NJufX5oaagQE3qNtzJSZvLJcmtwRK3zJqTyuQfMmI=
         ```
+
+        **Admin server variant.** The admin server (`http://localhost:6288`) exposes the same
+        `GET /events-stream` SSE protocol, but authenticated with the `X-Admin-Password` header
+        instead of a session. It streams **all** events, including private (`/priv/...`) paths, and
+        responds with `Cache-Control: no-store`. There, `user` is an *optional* filter (omit it to
+        stream every user's events) and a single global `cursor` paginates the combined feed;
+        `limit`, `live`, `reverse`, and `path` behave as below.
       operationId: getEventStream
       parameters:
         - name: user
@@ -702,53 +709,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/AdminInfoResponse"
-        "401":
-          description: Missing or invalid admin password
-
-  /events:
-    get:
-      tags: [Admin]
-      summary: All events feed (plain text, includes private paths)
-      description: |
-        Same plain-text, cursor-paginated format as the public `GET /events/` feed, but exposes
-        all events including private (`/priv/...`) paths. Response is `Cache-Control: no-store`.
-      operationId: getAdminEventFeed
-      servers:
-        - url: http://localhost:6288
-      security:
-        - adminPassword: []
-      parameters:
-        - name: cursor
-          in: query
-          description: Starting cursor position. Defaults to `"0"` (beginning) when omitted.
-          schema:
-            type: string
-        - name: limit
-          in: query
-          description: Maximum number of events to return.
-          schema:
-            type: integer
-            minimum: 1
-            maximum: 65535
-      responses:
-        "200":
-          description: Event feed (public and private events)
-          headers:
-            Cache-Control:
-              schema:
-                type: string
-                example: no-store
-          content:
-            text/plain:
-              schema:
-                type: string
-              example: |
-                PUT pubky://o1gg96ewuo.../pub/example.txt
-                PUT pubky://o1gg96ewuo.../priv/app/secret.txt
-                DEL pubky://o1gg96ewuo.../pub/old.txt
-                cursor: 12345
-        "400":
-          description: Invalid cursor
         "401":
           description: Missing or invalid admin password
 

--- a/pubky-homeserver/openapi.yml
+++ b/pubky-homeserver/openapi.yml
@@ -664,6 +664,13 @@ paths:
               value: [o1gg96ewuojmopcjbz8895478wdtxtzzuxnfjjz8o8e77csa1ngo]
             withCursor:
               value: ["o1gg96ewuojmopcjbz8895478wdtxtzzuxnfjjz8o8e77csa1ngo:42"]
+        - name: cursor
+          in: query
+          description: |
+            Resume from a single global cursor (admin server). On the client server, append
+            `:cursor` to each `user` value instead.
+          schema:
+            type: string
         - name: limit
           in: query
           description: Maximum total events to send.

--- a/pubky-homeserver/openapi.yml
+++ b/pubky-homeserver/openapi.yml
@@ -627,24 +627,32 @@ paths:
         data: content_hash: r0NJufX5oaagQE3qNtzJSZvLJcmtwRK3zJqTyuQfMmI=
         ```
 
-        **Admin server variant.** The admin server (`http://localhost:6288`) exposes the same
-        `GET /events-stream` SSE protocol, but authenticated with the `X-Admin-Password` header
-        instead of a session. It streams **all** events, including private (`/priv/...`) paths, and
-        responds with `Cache-Control: no-store`. There, `user` is an *optional* filter (omit it to
-        stream every user's events) and a single global `cursor` paginates the combined feed;
-        `limit`, `live`, `reverse`, and `path` behave as below.
+        This path is served by **two servers with different contracts** (select the server below):
+        - **Client server** (`http://localhost:6287`): session-authenticated. `user` is **required**;
+          `/priv/...` paths require an authorized session capability (otherwise `401`/`403`).
+        - **Admin server** (`http://localhost:6288`): authenticated with the `X-Admin-Password`
+          header. Streams **all** events including private (`/priv/...`) paths and responds with
+          `Cache-Control: no-store`. `user` is **optional** (omit to stream every user); a single
+          global `cursor` paginates the combined feed.
       operationId: getEventStream
+      servers:
+        - url: http://localhost:6287
+          description: Client server (session auth)
+        - url: http://localhost:6288
+          description: Admin server (X-Admin-Password)
       security:
         - {}
         - bearerAuth: []
         - cookieAuth: []
+        - adminPassword: []
       parameters:
         - name: user
           in: query
-          required: true
+          required: false
           description: |
             One or more user public keys (z-base-32). Repeat for multiple users.
             Optionally append `:cursor` to start from a specific position.
+            **Required** on the client server; **optional** on the admin server (omit to stream all users).
           schema:
             type: array
             items:
@@ -677,7 +685,11 @@ paths:
             default: false
         - name: path
           in: query
-          description: Path filter. /priv/ paths require an authorized session.
+          description: |
+            Path filter (repeatable; union — an event matches if it satisfies any). A trailing slash
+            matches a directory and its descendants; otherwise it matches that exact file. On the
+            client server, `/priv/...` paths require an authorized session capability; the admin
+            server returns all paths.
           schema:
             type: array
             items:
@@ -701,9 +713,11 @@ paths:
             Invalid user pubkey, missing user parameter, too many users,
             live + reverse combination, or invalid path.
         "401":
-          description: A private path was requested without a session.
+          description: |
+            Client server: a private path was requested without a session.
+            Admin server: missing or invalid `X-Admin-Password`.
         "403":
-          description: "Missing path read capability"
+          description: "Client server: missing path read capability"
         "404":
           description: User not found
 

--- a/pubky-homeserver/openapi.yml
+++ b/pubky-homeserver/openapi.yml
@@ -705,6 +705,53 @@ paths:
         "401":
           description: Missing or invalid admin password
 
+  /events:
+    get:
+      tags: [Admin]
+      summary: All events feed (plain text, includes private paths)
+      description: |
+        Same plain-text, cursor-paginated format as the public `GET /events/` feed, but exposes
+        all events including private (`/priv/...`) paths. Response is `Cache-Control: no-store`.
+      operationId: getAdminEventFeed
+      servers:
+        - url: http://localhost:6288
+      security:
+        - adminPassword: []
+      parameters:
+        - name: cursor
+          in: query
+          description: Starting cursor position. Defaults to `"0"` (beginning) when omitted.
+          schema:
+            type: string
+        - name: limit
+          in: query
+          description: Maximum number of events to return.
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 65535
+      responses:
+        "200":
+          description: Event feed (public and private events)
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+                example: no-store
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: |
+                PUT pubky://o1gg96ewuo.../pub/example.txt
+                PUT pubky://o1gg96ewuo.../priv/app/secret.txt
+                DEL pubky://o1gg96ewuo.../pub/old.txt
+                cursor: 12345
+        "400":
+          description: Invalid cursor
+        "401":
+          description: Missing or invalid admin password
+
   /generate_signup_token:
     get:
       tags: [Admin]

--- a/pubky-homeserver/openapi.yml
+++ b/pubky-homeserver/openapi.yml
@@ -676,7 +676,7 @@ paths:
           description: Maximum total events to send.
           schema:
             type: integer
-            minimum: 1
+            minimum: 0
             maximum: 65535
         - name: reverse
           in: query
@@ -1341,10 +1341,10 @@ components:
             - type: string
               enum: [unlimited]
         rate_read:
-          description: "Read bandwidth limit (e.g. `\"200mb/m\"`, `\"unlimited\"`, or `null`)."
+          description: 'Read bandwidth limit (e.g. `"200mb/m"`, `"unlimited"`, or `null`).'
           type: string
         rate_write:
-          description: "Write bandwidth limit (e.g. `\"100mb/m\"`, `\"unlimited\"`, or `null`)."
+          description: 'Write bandwidth limit (e.g. `"100mb/m"`, `"unlimited"`, or `null`).'
           type: string
         rate_read_burst:
           description: |
@@ -1387,10 +1387,10 @@ components:
               enum: [unlimited]
             - type: "null"
         rate_read:
-          description: "Read bandwidth limit string, `\"unlimited\"`, or `null` to reset."
+          description: 'Read bandwidth limit string, `"unlimited"`, or `null` to reset.'
           type: ["string", "null"]
         rate_write:
-          description: "Write bandwidth limit string, `\"unlimited\"`, or `null` to reset."
+          description: 'Write bandwidth limit string, `"unlimited"`, or `null` to reset.'
           type: ["string", "null"]
         rate_read_burst:
           description: "Burst for read rate limit (in rate's natural unit), or `null` to reset to default."

--- a/pubky-homeserver/src/admin_server/app.rs
+++ b/pubky-homeserver/src/admin_server/app.rs
@@ -635,6 +635,7 @@ mod tests {
             "?cursor=notanumber",
             "?live=true&reverse=true",
             "?limit=abc",
+            "?limit=0",
         ] {
             let response = server
                 .get(&format!("/events-stream{query}"))
@@ -678,10 +679,6 @@ mod tests {
         assert_eq!(count_sse_events(&body), 1);
         assert!(body.contains(&format!("pubky://{}/pub/a.txt", pubkey.z32())));
         assert!(!body.contains("/priv/app/secret.txt"));
-
-        // `limit=0` sends nothing.
-        let body = admin_stream_body(&server, "?limit=0").await;
-        assert_eq!(count_sse_events(&body), 0);
     }
 
     /// `user=` is an optional filter: it restricts the stream to the named users.

--- a/pubky-homeserver/src/admin_server/app.rs
+++ b/pubky-homeserver/src/admin_server/app.rs
@@ -28,7 +28,7 @@ fn create_protected_router(password: &str) -> Router<AppState> {
                 .post(generate_signup_token::generate_signup_token_with_limits),
         )
         .route("/info", get(info::info))
-        .route("/events", get(admin_events::feed))
+        .route("/events-stream", get(admin_events::feed_stream))
         .route("/signup_tokens", get(signup_tokens::list_signup_tokens))
         .route("/webdav/{*entry_path}", delete(delete_entry::delete_entry))
         .route("/users/{pubkey}/disable", post(disable_user))
@@ -120,6 +120,7 @@ impl AdminServer {
             &password,
             context.user_service.clone(),
             context.events_service.clone(),
+            context.metrics.clone(),
         )
         .with_metadata_from_config(
             context.keypair.public_key().z32(),
@@ -211,6 +212,7 @@ mod tests {
                 "",
                 context.user_service.clone(),
                 context.events_service.clone(),
+                context.metrics.clone(),
             ),
             "test",
         ))
@@ -250,24 +252,12 @@ mod tests {
         pubkey
     }
 
-    /// Split an admin feed body into its event lines and the trailing `cursor: <id>` value
-    /// (if any), the way a client consuming the plain-text feed would.
-    fn parse_admin_feed(body: &str) -> (Vec<String>, Option<String>) {
-        let mut lines: Vec<String> = body.lines().map(|l| l.to_string()).collect();
-        let cursor = lines
-            .last()
-            .and_then(|l| l.strip_prefix("cursor: "))
-            .map(|c| c.to_string());
-        if cursor.is_some() {
-            lines.pop();
-        }
-        (lines, cursor)
-    }
-
-    /// GET the admin feed with the test password, assert it is a 200 with `Cache-Control: no-store`
-    async fn admin_feed_body(server: &TestServer, query: &str) -> String {
+    /// GET the admin event stream in **batch** mode (no `live`) and return the raw SSE
+    /// body, asserting a 200 with `Cache-Control: no-store`. Only use for non-live requests —
+    /// the body is finite, so it can be buffered to a string.
+    async fn admin_stream_body(server: &TestServer, query: &str) -> String {
         let response = server
-            .get(&format!("/events{query}"))
+            .get(&format!("/events-stream{query}"))
             .add_header("X-Admin-Password", "test")
             .expect_success()
             .await;
@@ -278,9 +268,14 @@ mod tests {
                 .get(axum::http::header::CACHE_CONTROL)
                 .and_then(|v| v.to_str().ok()),
             Some("no-store"),
-            "admin feed must be Cache-Control: no-store"
+            "admin stream must be Cache-Control: no-store"
         );
         response.text()
+    }
+
+    /// Count SSE event frames (`event: <TYPE>` lines) in a batch body.
+    fn count_sse_events(body: &str) -> usize {
+        body.lines().filter(|l| l.starts_with("event: ")).count()
     }
 
     #[tokio::test]
@@ -616,83 +611,97 @@ mod tests {
         assert_eq!(limits.rate_write, QuotaOverride::Default);
     }
 
-    /// The feed rejects unauthenticated and malformed requests.
+    /// The stream rejects unauthenticated and malformed requests.
     #[tokio::test]
     #[pubky_test_utils::test]
-    async fn test_admin_events_feed_rejects_unauthorized_and_invalid() {
+    async fn test_admin_stream_rejects_unauthorized_and_invalid() {
         let context = AppContext::test().await;
         let server = create_test_server(&context);
 
-        // Missing password → 401 (the feed lives behind AdminAuthLayer).
-        let response = server.get("/events").expect_failure().await;
+        // Missing password → 401 (the stream lives behind AdminAuthLayer).
+        let response = server.get("/events-stream").expect_failure().await;
         response.assert_status_unauthorized();
 
         // Wrong password → 401.
         let response = server
-            .get("/events")
+            .get("/events-stream")
             .add_header("X-Admin-Password", "wrongpassword")
             .expect_failure()
             .await;
         response.assert_status_unauthorized();
 
-        // Valid password but a malformed cursor → 400 (same as the public feed).
-        let response = server
-            .get("/events?cursor=notanumber")
-            .add_header("X-Admin-Password", "test")
-            .expect_failure()
-            .await;
-        response.assert_status_bad_request();
+        // The malformed-request cases all 400 with a valid password.
+        for query in [
+            "?cursor=notanumber",
+            "?live=true&reverse=true",
+            "?limit=abc",
+        ] {
+            let response = server
+                .get(&format!("/events-stream{query}"))
+                .add_header("X-Admin-Password", "test")
+                .expect_failure()
+                .await;
+            response.assert_status_bad_request();
+        }
     }
 
-    /// The admin feed returns every event — public and private — and paginates correctly.
+    /// Batch mode returns every event — public and private — with `limit` enforced and the
+    /// SSE framing/no-store header the client expects. Empty DB yields an empty body.
     #[tokio::test]
     #[pubky_test_utils::test]
-    async fn test_admin_events_feed_returns_all_events_paginated() {
+    async fn test_admin_stream_returns_all_events() {
         let context = AppContext::test().await;
         let server = create_test_server(&context);
 
-        // Empty feed: a 200 with an empty body and no `cursor:` line.
-        assert_eq!(admin_feed_body(&server, "").await, "");
+        // Empty stream: 200, no-store (asserted in helper), no event frames.
+        assert_eq!(count_sse_events(&admin_stream_body(&server, "").await), 0);
 
-        // Interleave public and private events (ids 1..=5 in this fresh DB).
-        let pubkey = seed_put_events(
-            &context,
-            &["/pub/a", "/priv/b", "/pub/c", "/priv/d", "/pub/e"],
-        )
-        .await;
-        let uri = |p: &str| format!("PUT pubky://{}{}", pubkey.z32(), p);
+        // ids 1=/pub/a.txt, 2=/priv/app/secret.txt in this fresh DB.
+        let pubkey = seed_put_events(&context, &["/pub/a.txt", "/priv/app/secret.txt"]).await;
 
-        // Page 1: `limit=2` is enforced and exposes both /pub and /priv, cursor points at id 2.
-        let (page1, cursor1) = parse_admin_feed(&admin_feed_body(&server, "?limit=2").await);
-        assert_eq!(page1, vec![uri("/pub/a"), uri("/priv/b")]);
-        assert_eq!(cursor1.as_deref(), Some("2"));
-
-        // Page 2: resume from the page-1 cursor → ids 3,4.
-        let (page2, cursor2) = parse_admin_feed(
-            &admin_feed_body(&server, &format!("?limit=2&cursor={}", cursor1.unwrap())).await,
+        // Full firehose: both visibilities present, framed as PUT events.
+        let body = admin_stream_body(&server, "").await;
+        assert_eq!(count_sse_events(&body), 2);
+        assert!(
+            body.contains(&format!("pubky://{}/pub/a.txt", pubkey.z32())),
+            "stream should include the public event: {body}"
         );
-        assert_eq!(page2, vec![uri("/pub/c"), uri("/priv/d")]);
-        assert_eq!(cursor2.as_deref(), Some("4"));
-
-        // Page 3: partial final page → id 5.
-        let (page3, _) = parse_admin_feed(
-            &admin_feed_body(&server, &format!("?limit=2&cursor={}", cursor2.unwrap())).await,
+        assert!(
+            body.contains(&format!("pubky://{}/priv/app/secret.txt", pubkey.z32())),
+            "stream should include the private event: {body}"
         );
-        assert_eq!(page3, vec![uri("/pub/e")]);
+        assert!(body.contains("event: PUT"), "expected SSE framing: {body}");
+        assert!(body.contains("cursor: "), "expected cursor lines: {body}");
 
-        // Concatenating the pages reproduces the full ordered set — no dup, no gap, private included.
-        let mut all = page1;
-        all.extend(page2);
-        all.extend(page3);
-        assert_eq!(
-            all,
-            vec![
-                uri("/pub/a"),
-                uri("/priv/b"),
-                uri("/pub/c"),
-                uri("/priv/d"),
-                uri("/pub/e"),
-            ]
-        );
+        // `limit=1` stops after the first event (the public one).
+        let body = admin_stream_body(&server, "?limit=1").await;
+        assert_eq!(count_sse_events(&body), 1);
+        assert!(body.contains(&format!("pubky://{}/pub/a.txt", pubkey.z32())));
+        assert!(!body.contains("/priv/app/secret.txt"));
+
+        // `limit=0` sends nothing.
+        let body = admin_stream_body(&server, "?limit=0").await;
+        assert_eq!(count_sse_events(&body), 0);
+    }
+
+    /// `user=` is an optional filter: it restricts the stream to the named users.
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_admin_stream_user_filter() {
+        let context = AppContext::test().await;
+        let server = create_test_server(&context);
+
+        let alice = seed_put_events(&context, &["/pub/alice.txt"]).await;
+        let bob = seed_put_events(&context, &["/pub/bob.txt"]).await;
+
+        // No filter → both users' events.
+        let body = admin_stream_body(&server, "").await;
+        assert_eq!(count_sse_events(&body), 2);
+
+        // Filter to alice → only alice's event.
+        let body = admin_stream_body(&server, &format!("?user={}", alice.z32())).await;
+        assert_eq!(count_sse_events(&body), 1);
+        assert!(body.contains(&format!("pubky://{}/pub/alice.txt", alice.z32())));
+        assert!(!body.contains(&format!("pubky://{}/pub/bob.txt", bob.z32())));
     }
 }

--- a/pubky-homeserver/src/admin_server/app.rs
+++ b/pubky-homeserver/src/admin_server/app.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use super::routes::{
-    dav_handler, delete_entry,
+    admin_events, dav_handler, delete_entry,
     disable_users::{disable_user, enable_user},
     generate_signup_token, info, root, signup_tokens, user_quota,
 };
@@ -28,6 +28,7 @@ fn create_protected_router(password: &str) -> Router<AppState> {
                 .post(generate_signup_token::generate_signup_token_with_limits),
         )
         .route("/info", get(info::info))
+        .route("/events", get(admin_events::feed))
         .route("/signup_tokens", get(signup_tokens::list_signup_tokens))
         .route("/webdav/{*entry_path}", delete(delete_entry::delete_entry))
         .route("/users/{pubkey}/disable", post(disable_user))
@@ -118,6 +119,7 @@ impl AdminServer {
             context.file_service.clone(),
             &password,
             context.user_service.clone(),
+            context.events_service.clone(),
         )
         .with_metadata_from_config(
             context.keypair.public_key().z32(),
@@ -208,10 +210,77 @@ mod tests {
                 FileService::new_from_context(context).unwrap(),
                 "",
                 context.user_service.clone(),
+                context.events_service.clone(),
             ),
             "test",
         ))
         .unwrap()
+    }
+
+    /// Seed `paths` as PUT events for a fresh random user, returning that user's pubkey.
+    /// Within a test's fresh database, event ids are assigned in `paths` order starting at 1.
+    async fn seed_put_events(
+        context: &AppContext,
+        paths: &[&str],
+    ) -> pubky_common::crypto::PublicKey {
+        use crate::persistence::files::events::EventType;
+        use crate::persistence::sql::user::UserRepository;
+        use crate::shared::webdav::{EntryPath, WebDavPath};
+        use pubky_common::crypto::{Hash, Keypair};
+
+        let pubkey = Keypair::random().public_key();
+        let user = UserRepository::create(&pubkey, &mut context.sql_db.pool().into())
+            .await
+            .unwrap();
+        for p in paths {
+            let path = EntryPath::new(pubkey.clone(), WebDavPath::new(p).unwrap());
+            context
+                .events_service
+                .create_event(
+                    user.id,
+                    EventType::Put {
+                        content_hash: Hash::from_bytes([0; 32]),
+                    },
+                    &path,
+                    &mut context.sql_db.pool().into(),
+                )
+                .await
+                .unwrap();
+        }
+        pubkey
+    }
+
+    /// Split an admin feed body into its event lines and the trailing `cursor: <id>` value
+    /// (if any), the way a client consuming the plain-text feed would.
+    fn parse_admin_feed(body: &str) -> (Vec<String>, Option<String>) {
+        let mut lines: Vec<String> = body.lines().map(|l| l.to_string()).collect();
+        let cursor = lines
+            .last()
+            .and_then(|l| l.strip_prefix("cursor: "))
+            .map(|c| c.to_string());
+        if cursor.is_some() {
+            lines.pop();
+        }
+        (lines, cursor)
+    }
+
+    /// GET the admin feed with the test password, assert it is a 200 with `Cache-Control: no-store`
+    async fn admin_feed_body(server: &TestServer, query: &str) -> String {
+        let response = server
+            .get(&format!("/events{query}"))
+            .add_header("X-Admin-Password", "test")
+            .expect_success()
+            .await;
+        response.assert_status_ok();
+        assert_eq!(
+            response
+                .headers()
+                .get(axum::http::header::CACHE_CONTROL)
+                .and_then(|v| v.to_str().ok()),
+            Some("no-store"),
+            "admin feed must be Cache-Control: no-store"
+        );
+        response.text()
     }
 
     #[tokio::test]
@@ -545,5 +614,85 @@ mod tests {
         assert_eq!(limits.storage_quota_mb, QuotaOverride::Value(1024));
         assert_eq!(limits.rate_read, QuotaOverride::Value(bw("200mb/m")));
         assert_eq!(limits.rate_write, QuotaOverride::Default);
+    }
+
+    /// The feed rejects unauthenticated and malformed requests.
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_admin_events_feed_rejects_unauthorized_and_invalid() {
+        let context = AppContext::test().await;
+        let server = create_test_server(&context);
+
+        // Missing password → 401 (the feed lives behind AdminAuthLayer).
+        let response = server.get("/events").expect_failure().await;
+        response.assert_status_unauthorized();
+
+        // Wrong password → 401.
+        let response = server
+            .get("/events")
+            .add_header("X-Admin-Password", "wrongpassword")
+            .expect_failure()
+            .await;
+        response.assert_status_unauthorized();
+
+        // Valid password but a malformed cursor → 400 (same as the public feed).
+        let response = server
+            .get("/events?cursor=notanumber")
+            .add_header("X-Admin-Password", "test")
+            .expect_failure()
+            .await;
+        response.assert_status_bad_request();
+    }
+
+    /// The admin feed returns every event — public and private — and paginates correctly.
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_admin_events_feed_returns_all_events_paginated() {
+        let context = AppContext::test().await;
+        let server = create_test_server(&context);
+
+        // Empty feed: a 200 with an empty body and no `cursor:` line.
+        assert_eq!(admin_feed_body(&server, "").await, "");
+
+        // Interleave public and private events (ids 1..=5 in this fresh DB).
+        let pubkey = seed_put_events(
+            &context,
+            &["/pub/a", "/priv/b", "/pub/c", "/priv/d", "/pub/e"],
+        )
+        .await;
+        let uri = |p: &str| format!("PUT pubky://{}{}", pubkey.z32(), p);
+
+        // Page 1: `limit=2` is enforced and exposes both /pub and /priv, cursor points at id 2.
+        let (page1, cursor1) = parse_admin_feed(&admin_feed_body(&server, "?limit=2").await);
+        assert_eq!(page1, vec![uri("/pub/a"), uri("/priv/b")]);
+        assert_eq!(cursor1.as_deref(), Some("2"));
+
+        // Page 2: resume from the page-1 cursor → ids 3,4.
+        let (page2, cursor2) = parse_admin_feed(
+            &admin_feed_body(&server, &format!("?limit=2&cursor={}", cursor1.unwrap())).await,
+        );
+        assert_eq!(page2, vec![uri("/pub/c"), uri("/priv/d")]);
+        assert_eq!(cursor2.as_deref(), Some("4"));
+
+        // Page 3: partial final page → id 5.
+        let (page3, _) = parse_admin_feed(
+            &admin_feed_body(&server, &format!("?limit=2&cursor={}", cursor2.unwrap())).await,
+        );
+        assert_eq!(page3, vec![uri("/pub/e")]);
+
+        // Concatenating the pages reproduces the full ordered set — no dup, no gap, private included.
+        let mut all = page1;
+        all.extend(page2);
+        all.extend(page3);
+        assert_eq!(
+            all,
+            vec![
+                uri("/pub/a"),
+                uri("/priv/b"),
+                uri("/pub/c"),
+                uri("/priv/d"),
+                uri("/pub/e"),
+            ]
+        );
     }
 }

--- a/pubky-homeserver/src/admin_server/app.rs
+++ b/pubky-homeserver/src/admin_server/app.rs
@@ -704,4 +704,45 @@ mod tests {
         assert!(body.contains(&format!("pubky://{}/pub/alice.txt", alice.z32())));
         assert!(!body.contains(&format!("pubky://{}/pub/bob.txt", bob.z32())));
     }
+
+    /// Repeated `path=` unions the filters (file-vs-directory matching).
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_admin_stream_repeated_path_filter() {
+        let context = AppContext::test().await;
+        let server = create_test_server(&context);
+
+        let pubkey = seed_put_events(&context, &["/pub/a.txt", "/pub/b.txt", "/priv/x.txt"]).await;
+
+        // Exact file `/pub/a.txt` OR the `/priv/` subtree — not the sibling `/pub/b.txt`.
+        let body = admin_stream_body(&server, "?path=/pub/a.txt&path=/priv/").await;
+        assert_eq!(count_sse_events(&body), 2);
+        assert!(body.contains(&format!("pubky://{}/pub/a.txt", pubkey.z32())));
+        assert!(body.contains(&format!("pubky://{}/priv/x.txt", pubkey.z32())));
+        assert!(
+            !body.contains("/pub/b.txt"),
+            "sibling file must be excluded: {body}"
+        );
+    }
+
+    /// A single global `cursor=` resumes after the given event id.
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_admin_stream_cursor_resume() {
+        let context = AppContext::test().await;
+        let server = create_test_server(&context);
+
+        // ids 1,2,3 in this fresh DB.
+        let pubkey = seed_put_events(&context, &["/pub/a.txt", "/pub/b.txt", "/pub/c.txt"]).await;
+
+        // Resume after cursor 1 → only the later two events.
+        let body = admin_stream_body(&server, "?cursor=1").await;
+        assert_eq!(count_sse_events(&body), 2);
+        assert!(
+            !body.contains("/pub/a.txt"),
+            "cursor=1 must skip the first event: {body}"
+        );
+        assert!(body.contains(&format!("pubky://{}/pub/b.txt", pubkey.z32())));
+        assert!(body.contains(&format!("pubky://{}/pub/c.txt", pubkey.z32())));
+    }
 }

--- a/pubky-homeserver/src/admin_server/app_state.rs
+++ b/pubky-homeserver/src/admin_server/app_state.rs
@@ -2,7 +2,10 @@ use dav_server::{fakels::FakeLs, DavHandler};
 use dav_server_opendalfs::OpendalFs;
 
 use crate::data_directory::DefaultQuotasToml;
-use crate::persistence::{files::FileService, sql::SqlDb};
+use crate::persistence::{
+    files::{events::EventsService, FileService},
+    sql::SqlDb,
+};
 use crate::services::user_service::UserService;
 use crate::ConfigToml;
 
@@ -23,6 +26,8 @@ pub(crate) struct AppState {
     pub(crate) metadata: AdminMetadata,
     /// User service for quota cache eviction on admin updates.
     pub(crate) user_service: UserService,
+    /// Event service for the admin all-events feed.
+    pub(crate) events_service: EventsService,
     /// System-wide default quotas for resolving effective values.
     pub(crate) default_storage_mb: Option<u64>,
     pub(crate) default_quotas: DefaultQuotasToml,
@@ -34,6 +39,7 @@ impl AppState {
         file_service: FileService,
         admin_password: &str,
         user_service: UserService,
+        events_service: EventsService,
     ) -> Self {
         let webdavfs = OpendalFs::new(file_service.opendal.admin_operator.clone());
         let inner_dav_handler = DavHandler::builder()
@@ -49,6 +55,7 @@ impl AppState {
             inner_dav_handler,
             metadata: AdminMetadata::default(),
             user_service,
+            events_service,
             default_storage_mb: None,
             default_quotas: DefaultQuotasToml::default(),
         }

--- a/pubky-homeserver/src/admin_server/app_state.rs
+++ b/pubky-homeserver/src/admin_server/app_state.rs
@@ -2,7 +2,7 @@ use dav_server::{fakels::FakeLs, DavHandler};
 use dav_server_opendalfs::OpendalFs;
 
 use crate::data_directory::DefaultQuotasToml;
-use crate::metrics_server::routes::metrics::Metrics;
+use crate::observability::Metrics;
 use crate::persistence::{
     files::{events::EventsService, FileService},
     sql::SqlDb,

--- a/pubky-homeserver/src/admin_server/app_state.rs
+++ b/pubky-homeserver/src/admin_server/app_state.rs
@@ -2,6 +2,7 @@ use dav_server::{fakels::FakeLs, DavHandler};
 use dav_server_opendalfs::OpendalFs;
 
 use crate::data_directory::DefaultQuotasToml;
+use crate::metrics_server::routes::metrics::Metrics;
 use crate::persistence::{
     files::{events::EventsService, FileService},
     sql::SqlDb,
@@ -26,8 +27,10 @@ pub(crate) struct AppState {
     pub(crate) metadata: AdminMetadata,
     /// User service for quota cache eviction on admin updates.
     pub(crate) user_service: UserService,
-    /// Event service for the admin all-events feed.
+    /// Event service for the admin all-events stream.
     pub(crate) events_service: EventsService,
+    /// Metrics shared with the rest of the homeserver.
+    pub(crate) metrics: Metrics,
     /// System-wide default quotas for resolving effective values.
     pub(crate) default_storage_mb: Option<u64>,
     pub(crate) default_quotas: DefaultQuotasToml,
@@ -40,6 +43,7 @@ impl AppState {
         admin_password: &str,
         user_service: UserService,
         events_service: EventsService,
+        metrics: Metrics,
     ) -> Self {
         let webdavfs = OpendalFs::new(file_service.opendal.admin_operator.clone());
         let inner_dav_handler = DavHandler::builder()
@@ -56,6 +60,7 @@ impl AppState {
             metadata: AdminMetadata::default(),
             user_service,
             events_service,
+            metrics,
             default_storage_mb: None,
             default_quotas: DefaultQuotasToml::default(),
         }

--- a/pubky-homeserver/src/admin_server/routes/admin_events.rs
+++ b/pubky-homeserver/src/admin_server/routes/admin_events.rs
@@ -1,63 +1,316 @@
-//! Admin-only historical events feed.
-//!
-//! it exposes all events — public (`/pub/...`) and private (`/priv/...`) alike — for operational tooling,
-//! debugging, and maintenance.
-//!
-//! The public feed (/events) is public-only and never leaks private paths, this endpoint is the one
-//! place private paths are surfaced over the events feed, hence the admin auth requirement
-//! and the `Cache-Control: no-store` header.
+//! Admin-only event stream (SSE): mirrors the client `/events-stream` but, gated by the admin
+//! password, streams **all** events including private (`/priv/...`) paths. `user=` is an optional
+//! filter (omit for every user); a single global `cursor` paginates. Response is `no-store`.
+
+use std::{convert::Infallible, time::Instant};
 
 use axum::{
-    body::Body,
-    extract::State,
-    http::{header, Response, StatusCode},
-    response::IntoResponse,
+    extract::{RawQuery, State},
+    http::{header, HeaderValue},
+    response::{
+        sse::{Event, KeepAlive, Sse},
+        IntoResponse,
+    },
 };
+use pubky_common::crypto::PublicKey;
+use url::form_urlencoded;
 
 use super::super::app_state::AppState;
 use crate::{
-    client_server::{query_params::ListQueryParams, routes::events::format_events_feed},
-    shared::{HttpError, HttpResult},
+    metrics_server::routes::metrics::ConnectionGuard,
+    persistence::{
+        files::events::{EventCursor, EventEntity, MAX_EVENT_STREAM_USERS},
+        sql::user::UserRepository,
+    },
+    shared::{webdav::WebDavPath, HttpError, HttpResult},
 };
 
-/// Admin-only historical events feed returning **all** events (public and private).
+/// Parsed query parameters for the admin event stream.
+struct AdminStreamParams {
+    /// Optional user filter.
+    users: Vec<PublicKey>,
+    /// Optional starting cursor (global). None = from the beginning.
+    cursor: Option<String>,
+    /// Maximum total events to send before closing.
+    limit: Option<u16>,
+    /// Live streaming mode (cannot be combined with `reverse`).
+    live: bool,
+    /// Reverse (newest-first) ordering; batch-only.
+    reverse: bool,
+    /// Optional path-prefix filter (literal prefix — use a trailing slash to scope to a directory).
+    path: Option<WebDavPath>,
+}
+
+/// Parse the raw query string, handling repeated `user=` params.
 ///
-/// ## Query Parameters
-/// - `cursor` (optional): Starting cursor position. Default: `"0"` (beginning).
-/// - `limit` (optional): Maximum number of events to return.
-///
-/// ## Response Format
-/// Identical to the public `GET /events/` feed — plain text, one line per event,
-/// followed by the next cursor:
-/// ```text
-/// PUT pubky://user_pubkey/pub/example.txt
-/// PUT pubky://user_pubkey/priv/app/secret.txt
-/// DEL pubky://user_pubkey/pub/old.txt
-/// cursor: 12345
-/// ```
-pub async fn feed(
+/// `user=` is optional (absent = all users) and the cursor
+/// is a single global `cursor=` value rather than a per-user `user=<pk>:<cursor>` suffix.
+fn parse_admin_stream_query(query: &str) -> Result<AdminStreamParams, HttpError> {
+    let mut users: Vec<PublicKey> = Vec::new();
+    let mut cursor = None;
+    let mut limit = None;
+    let mut live = false;
+    let mut reverse = false;
+    let mut path: Option<String> = None;
+
+    for (key, value) in form_urlencoded::parse(query.as_bytes()) {
+        match key.as_ref() {
+            "user" => {
+                if value.is_empty() {
+                    continue;
+                }
+                if PublicKey::is_pubky_prefixed(value.as_ref()) {
+                    return Err(HttpError::bad_request(format!(
+                        "Invalid public key: {value}"
+                    )));
+                }
+                let pk = PublicKey::try_from_z32(value.as_ref())
+                    .map_err(|_| HttpError::bad_request(format!("Invalid public key: {value}")))?;
+                if !users.contains(&pk) {
+                    users.push(pk);
+                }
+            }
+            "cursor" => {
+                if !value.is_empty() {
+                    cursor = Some(value.to_string());
+                }
+            }
+            "limit" => {
+                limit = Some(
+                    value
+                        .parse::<u16>()
+                        .map_err(|_| HttpError::bad_request(format!("Invalid limit: {value}")))?,
+                );
+            }
+            "live" => live = value == "true" || value == "1",
+            "reverse" => reverse = value == "true" || value == "1",
+            "path" => {
+                if !value.is_empty() {
+                    path = Some(value.to_string());
+                }
+            }
+            _ => {} // Ignore unknown parameters
+        }
+    }
+
+    if live && reverse {
+        return Err(HttpError::bad_request(
+            "Cannot use live mode with reverse ordering",
+        ));
+    }
+    if users.len() > MAX_EVENT_STREAM_USERS {
+        return Err(HttpError::bad_request(format!(
+            "Too many users. Maximum allowed: {MAX_EVENT_STREAM_USERS}"
+        )));
+    }
+
+    let path = match path {
+        Some(p) => {
+            // Automatically prepend "/" if not present for caller convenience.
+            let normalized = if p.starts_with('/') {
+                p
+            } else {
+                format!("/{p}")
+            };
+            Some(
+                WebDavPath::new(&normalized)
+                    .map_err(|_| HttpError::bad_request(format!("Invalid path: {normalized}")))?,
+            )
+        }
+        None => None,
+    };
+
+    Ok(AdminStreamParams {
+        users,
+        cursor,
+        limit,
+        live,
+        reverse,
+        path,
+    })
+}
+
+/// Decide whether a live (broadcast) event belongs in the stream.
+fn admin_should_include_live_event(
+    event: &EventEntity,
+    last_cursor: Option<EventCursor>,
+    user_ids: Option<&[i32]>,
+    path_filter: Option<&WebDavPath>,
+) -> bool {
+    if let Some(cursor) = last_cursor {
+        if event.cursor() <= cursor {
+            return false;
+        }
+    }
+    if let Some(ids) = user_ids {
+        if !ids.contains(&event.user_id) {
+            return false;
+        }
+    }
+    if let Some(path) = path_filter {
+        if !event.path.path().as_str().starts_with(path.as_str()) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Admin-only SSE stream over **all** events (public and private). See [`AdminStreamParams`]
+/// for the query parameters. Response is `text/event-stream`, `Cache-Control: no-store`, with the
+/// same per-event framing as the client `/events-stream` (see [`EventEntity::to_sse_data`]).
+pub async fn feed_stream(
     State(state): State<AppState>,
-    params: ListQueryParams,
+    RawQuery(raw_query): RawQuery,
 ) -> HttpResult<impl IntoResponse> {
-    // Treat a missing or empty cursor as "from the beginning", matching the public feed.
-    let cursor_str = params.cursor.unwrap_or_else(|| "0".to_string());
+    let params = parse_admin_stream_query(raw_query.as_deref().unwrap_or(""))?;
 
-    let cursor = state
-        .events_service
-        .parse_cursor(cursor_str.as_str(), &mut state.sql_db.pool().into())
-        .await
-        .map_err(|_| HttpError::bad_request("Invalid cursor"))?;
+    // Resolve the optional user filter to user ids. None = all users (firehose).
+    let user_ids: Option<Vec<i32>> = if params.users.is_empty() {
+        None
+    } else {
+        let mut ids = Vec::with_capacity(params.users.len());
+        for pk in &params.users {
+            let id = UserRepository::get_id(pk, &mut state.sql_db.pool().into())
+                .await
+                .map_err(|e| match e {
+                    sqlx::Error::RowNotFound => HttpError::not_found(),
+                    e => HttpError::from(e),
+                })?;
+            ids.push(id);
+        }
+        Some(ids)
+    };
 
-    let events = state
-        .events_service
-        .get_all_by_cursor(Some(cursor), params.limit, &mut state.sql_db.pool().into())
-        .await?;
+    // Parse the starting cursor (None = from the beginning).
+    let start_cursor = match params.cursor.as_deref() {
+        Some(c) => Some(
+            state
+                .events_service
+                .parse_cursor(c, &mut state.sql_db.pool().into())
+                .await
+                .map_err(|_| HttpError::bad_request("Invalid cursor"))?,
+        ),
+        None => None,
+    };
 
-    Ok(Response::builder()
-        .status(StatusCode::OK)
-        .header(header::CONTENT_TYPE, "text/plain")
-        // This feed exposes private paths; never let it be cached.
-        .header(header::CACHE_CONTROL, "no-store")
-        .body(Body::from(format_events_feed(&events)))
-        .unwrap())
+    let reverse = params.reverse;
+    let live = params.live;
+    let limit = params.limit;
+    let path = params.path;
+
+    let mut total_sent: usize = 0;
+    let mut last_cursor: Option<EventCursor> = start_cursor;
+
+    let stream = async_stream::stream! {
+        // Cleanup + connection metrics on any exit path.
+        let _guard = ConnectionGuard::new(state.metrics.clone());
+
+        // Subscribe up front so events that occur during Phase 1 are buffered, not missed.
+        let mut rx = state.events_service.subscribe();
+
+        // Phase 1: historical replay over a single advancing global cursor.
+        loop {
+            // Drain buffered events; they'll be covered by this or a later DB query.
+            while rx.try_recv().is_ok() {}
+
+            let query_start = Instant::now();
+            let events = match state
+                .events_service
+                .get_all_events(
+                    last_cursor,
+                    None,
+                    reverse,
+                    path.as_ref().map(|p| p.as_str()),
+                    user_ids.as_deref(),
+                    &mut state.sql_db.pool().into(),
+                )
+                .await
+            {
+                Ok(events) => events,
+                Err(e) => {
+                    tracing::error!("Database error while fetching admin events: {}", e);
+                    break;
+                }
+            };
+            state
+                .metrics
+                .record_event_stream_db_query(query_start.elapsed().as_millis());
+
+            let event_count = events.len();
+            for event in events {
+                // Check the limit before yielding so `limit=0` sends nothing.
+                if let Some(max) = limit {
+                    if total_sent >= max as usize {
+                        return;
+                    }
+                }
+                last_cursor = Some(event.cursor());
+                yield Ok::<_, Infallible>(
+                    Event::default()
+                        .event(event.event_type.to_string())
+                        .data(event.to_sse_data()),
+                );
+                total_sent += 1;
+            }
+
+            // A query with no events means we've replayed everything up to `last_cursor`.
+            if event_count == 0 {
+                if !live {
+                    return;
+                }
+                break;
+            }
+        }
+
+        // Phase 2: live mode (ascending only; reverse+live is rejected at parse time).
+        if live {
+            let half_capacity = state.events_service.channel_capacity() / 2;
+            loop {
+                match rx.recv().await {
+                    Ok(event) => {
+                        if rx.len() >= half_capacity {
+                            state.metrics.record_broadcast_half_full();
+                        }
+                        if !admin_should_include_live_event(
+                            &event,
+                            last_cursor,
+                            user_ids.as_deref(),
+                            path.as_ref(),
+                        ) {
+                            continue;
+                        }
+                        // Check the limit before yielding so `limit=0` sends nothing.
+                        if let Some(max) = limit {
+                            if total_sent >= max as usize {
+                                return;
+                            }
+                        }
+                        last_cursor = Some(event.cursor());
+                        yield Ok::<_, Infallible>(
+                            Event::default()
+                                .event(event.event_type.to_string())
+                                .data(event.to_sse_data()),
+                        );
+                        total_sent += 1;
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                        state.metrics.record_broadcast_lagged();
+                        tracing::warn!(
+                            "Slow admin client detected: broadcast channel lagged by {} events. Closing connection.",
+                            skipped
+                        );
+                        return;
+                    }
+                    Err(_) => break, // Channel closed
+                }
+            }
+        }
+    };
+
+    let sse = Sse::new(stream).keep_alive(KeepAlive::default());
+    // The feed surfaces private paths; never cache it.
+    Ok((
+        [(header::CACHE_CONTROL, HeaderValue::from_static("no-store"))],
+        sse,
+    ))
 }

--- a/pubky-homeserver/src/admin_server/routes/admin_events.rs
+++ b/pubky-homeserver/src/admin_server/routes/admin_events.rs
@@ -78,11 +78,13 @@ fn parse_admin_stream_query(query: &str) -> Result<AdminStreamParams, HttpError>
                 }
             }
             "limit" => {
-                limit = Some(
-                    value
-                        .parse::<u16>()
-                        .map_err(|_| HttpError::bad_request(format!("Invalid limit: {value}")))?,
-                );
+                let parsed = value
+                    .parse::<u16>()
+                    .map_err(|_| HttpError::bad_request(format!("Invalid limit: {value}")))?;
+                if parsed == 0 {
+                    return Err(HttpError::bad_request("limit must be at least 1"));
+                }
+                limit = Some(parsed);
             }
             "live" => live = value == "true" || value == "1",
             "reverse" => reverse = value == "true" || value == "1",

--- a/pubky-homeserver/src/admin_server/routes/admin_events.rs
+++ b/pubky-homeserver/src/admin_server/routes/admin_events.rs
@@ -1,0 +1,63 @@
+//! Admin-only historical events feed.
+//!
+//! it exposes all events — public (`/pub/...`) and private (`/priv/...`) alike — for operational tooling,
+//! debugging, and maintenance.
+//!
+//! The public feed (/events) is public-only and never leaks private paths, this endpoint is the one
+//! place private paths are surfaced over the events feed, hence the admin auth requirement
+//! and the `Cache-Control: no-store` header.
+
+use axum::{
+    body::Body,
+    extract::State,
+    http::{header, Response, StatusCode},
+    response::IntoResponse,
+};
+
+use super::super::app_state::AppState;
+use crate::{
+    client_server::{query_params::ListQueryParams, routes::events::format_events_feed},
+    shared::{HttpError, HttpResult},
+};
+
+/// Admin-only historical events feed returning **all** events (public and private).
+///
+/// ## Query Parameters
+/// - `cursor` (optional): Starting cursor position. Default: `"0"` (beginning).
+/// - `limit` (optional): Maximum number of events to return.
+///
+/// ## Response Format
+/// Identical to the public `GET /events/` feed — plain text, one line per event,
+/// followed by the next cursor:
+/// ```text
+/// PUT pubky://user_pubkey/pub/example.txt
+/// PUT pubky://user_pubkey/priv/app/secret.txt
+/// DEL pubky://user_pubkey/pub/old.txt
+/// cursor: 12345
+/// ```
+pub async fn feed(
+    State(state): State<AppState>,
+    params: ListQueryParams,
+) -> HttpResult<impl IntoResponse> {
+    // Treat a missing or empty cursor as "from the beginning", matching the public feed.
+    let cursor_str = params.cursor.unwrap_or_else(|| "0".to_string());
+
+    let cursor = state
+        .events_service
+        .parse_cursor(cursor_str.as_str(), &mut state.sql_db.pool().into())
+        .await
+        .map_err(|_| HttpError::bad_request("Invalid cursor"))?;
+
+    let events = state
+        .events_service
+        .get_all_by_cursor(Some(cursor), params.limit, &mut state.sql_db.pool().into())
+        .await?;
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/plain")
+        // This feed exposes private paths; never let it be cached.
+        .header(header::CACHE_CONTROL, "no-store")
+        .body(Body::from(format_events_feed(&events)))
+        .unwrap())
+}

--- a/pubky-homeserver/src/admin_server/routes/admin_events.rs
+++ b/pubky-homeserver/src/admin_server/routes/admin_events.rs
@@ -2,7 +2,7 @@
 //! password, streams **all** events including private (`/priv/...`) paths. `user=` is an optional
 //! filter (omit for every user); a single global `cursor` paginates. Response is `no-store`.
 
-use std::{convert::Infallible, time::Instant};
+use std::convert::Infallible;
 
 use axum::{
     extract::{RawQuery, State},
@@ -12,14 +12,14 @@ use axum::{
         IntoResponse,
     },
 };
+use futures_util::StreamExt;
 use pubky_common::crypto::PublicKey;
 use url::form_urlencoded;
 
 use super::super::app_state::AppState;
 use crate::{
-    metrics_server::routes::metrics::ConnectionGuard,
     persistence::{
-        files::events::{EventCursor, EventEntity, MAX_EVENT_STREAM_USERS},
+        files::events::{AllEventsFilter, MAX_EVENT_STREAM_USERS},
         sql::user::UserRepository,
     },
     shared::{webdav::WebDavPath, HttpError, HttpResult},
@@ -130,42 +130,12 @@ fn parse_admin_stream_query(query: &str) -> Result<AdminStreamParams, HttpError>
     })
 }
 
-/// Decide whether a live (broadcast) event belongs in the stream.
-fn admin_should_include_live_event(
-    event: &EventEntity,
-    last_cursor: Option<EventCursor>,
-    user_ids: Option<&[i32]>,
-    path_filter: Option<&WebDavPath>,
-) -> bool {
-    if let Some(cursor) = last_cursor {
-        if event.cursor() <= cursor {
-            return false;
-        }
-    }
-    if let Some(ids) = user_ids {
-        if !ids.contains(&event.user_id) {
-            return false;
-        }
-    }
-    if let Some(path) = path_filter {
-        if !event.path.path().as_str().starts_with(path.as_str()) {
-            return false;
-        }
-    }
-    true
-}
-
-/// Admin-only SSE stream over **all** events (public and private). See [`AdminStreamParams`]
-/// for the query parameters. Response is `text/event-stream`, `Cache-Control: no-store`, with the
-/// same per-event framing as the client `/events-stream` (see [`EventEntity::to_sse_data`]).
-pub async fn feed_stream(
-    State(state): State<AppState>,
-    RawQuery(raw_query): RawQuery,
-) -> HttpResult<impl IntoResponse> {
-    let params = parse_admin_stream_query(raw_query.as_deref().unwrap_or(""))?;
-
-    // Resolve the optional user filter to user ids. None = all users (firehose).
-    let user_ids: Option<Vec<i32>> = if params.users.is_empty() {
+/// Resolve parsed params into a service-layer [`AllEventsFilter`]: `404` for an unknown `user=`,
+/// `400` for an invalid cursor. This is the route's only real work — the streaming itself lives in
+/// [`EventsService::all_events_stream`].
+async fn resolve_filter(state: &AppState, params: AdminStreamParams) -> HttpResult<AllEventsFilter> {
+    // None = all users (firehose); otherwise resolve each pubkey to its id.
+    let user_ids = if params.users.is_empty() {
         None
     } else {
         let mut ids = Vec::with_capacity(params.users.len());
@@ -181,7 +151,6 @@ pub async fn feed_stream(
         Some(ids)
     };
 
-    // Parse the starting cursor (None = from the beginning).
     let start_cursor = match params.cursor.as_deref() {
         Some(c) => Some(
             state
@@ -193,121 +162,40 @@ pub async fn feed_stream(
         None => None,
     };
 
-    let reverse = params.reverse;
-    let live = params.live;
-    let limit = params.limit;
-    let path = params.path;
+    Ok(AllEventsFilter {
+        start_cursor,
+        user_ids,
+        path: params.path,
+        reverse: params.reverse,
+        live: params.live,
+        limit: params.limit,
+    })
+}
 
-    let mut total_sent: usize = 0;
-    let mut last_cursor: Option<EventCursor> = start_cursor;
+/// Admin-only SSE stream over **all** events (public and private). See [`AdminStreamParams`] for the
+/// query parameters; the streaming lives in [`EventsService::all_events_stream`]. Response is
+/// `text/event-stream`, `Cache-Control: no-store`.
+pub async fn feed_stream(
+    State(state): State<AppState>,
+    RawQuery(raw_query): RawQuery,
+) -> HttpResult<impl IntoResponse> {
+    let params = parse_admin_stream_query(raw_query.as_deref().unwrap_or(""))?;
+    let filter = resolve_filter(&state, params).await?;
 
-    let stream = async_stream::stream! {
-        // Cleanup + connection metrics on any exit path.
-        let _guard = ConnectionGuard::new(state.metrics.clone());
-
-        // Subscribe up front so events that occur during Phase 1 are buffered, not missed.
-        let mut rx = state.events_service.subscribe();
-
-        // Phase 1: historical replay over a single advancing global cursor.
-        loop {
-            // Drain buffered events; they'll be covered by this or a later DB query.
-            while rx.try_recv().is_ok() {}
-
-            let query_start = Instant::now();
-            let events = match state
-                .events_service
-                .get_all_events(
-                    last_cursor,
-                    None,
-                    reverse,
-                    path.as_ref().map(|p| p.as_str()),
-                    user_ids.as_deref(),
-                    &mut state.sql_db.pool().into(),
-                )
-                .await
-            {
-                Ok(events) => events,
-                Err(e) => {
-                    tracing::error!("Database error while fetching admin events: {}", e);
-                    break;
-                }
-            };
-            state
-                .metrics
-                .record_event_stream_db_query(query_start.elapsed().as_millis());
-
-            let event_count = events.len();
-            for event in events {
-                // Check the limit before yielding so `limit=0` sends nothing.
-                if let Some(max) = limit {
-                    if total_sent >= max as usize {
-                        return;
-                    }
-                }
-                last_cursor = Some(event.cursor());
-                yield Ok::<_, Infallible>(
+    let sse = Sse::new(
+        state
+            .events_service
+            .all_events_stream(state.sql_db.clone(), state.metrics.clone(), filter)
+            .map(|event| {
+                Ok::<_, Infallible>(
                     Event::default()
                         .event(event.event_type.to_string())
                         .data(event.to_sse_data()),
-                );
-                total_sent += 1;
-            }
+                )
+            }),
+    )
+    .keep_alive(KeepAlive::default());
 
-            // A query with no events means we've replayed everything up to `last_cursor`.
-            if event_count == 0 {
-                if !live {
-                    return;
-                }
-                break;
-            }
-        }
-
-        // Phase 2: live mode (ascending only; reverse+live is rejected at parse time).
-        if live {
-            let half_capacity = state.events_service.channel_capacity() / 2;
-            loop {
-                match rx.recv().await {
-                    Ok(event) => {
-                        if rx.len() >= half_capacity {
-                            state.metrics.record_broadcast_half_full();
-                        }
-                        if !admin_should_include_live_event(
-                            &event,
-                            last_cursor,
-                            user_ids.as_deref(),
-                            path.as_ref(),
-                        ) {
-                            continue;
-                        }
-                        // Check the limit before yielding so `limit=0` sends nothing.
-                        if let Some(max) = limit {
-                            if total_sent >= max as usize {
-                                return;
-                            }
-                        }
-                        last_cursor = Some(event.cursor());
-                        yield Ok::<_, Infallible>(
-                            Event::default()
-                                .event(event.event_type.to_string())
-                                .data(event.to_sse_data()),
-                        );
-                        total_sent += 1;
-                    }
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
-                        state.metrics.record_broadcast_lagged();
-                        tracing::warn!(
-                            "Slow admin client detected: broadcast channel lagged by {} events. Closing connection.",
-                            skipped
-                        );
-                        return;
-                    }
-                    Err(_) => break, // Channel closed
-                }
-            }
-        }
-    };
-
-    let sse = Sse::new(stream).keep_alive(KeepAlive::default());
     // The feed surfaces private paths; never cache it.
     Ok((
         [(header::CACHE_CONTROL, HeaderValue::from_static("no-store"))],

--- a/pubky-homeserver/src/admin_server/routes/admin_events.rs
+++ b/pubky-homeserver/src/admin_server/routes/admin_events.rs
@@ -37,9 +37,10 @@ struct AdminStreamParams {
     live: bool,
     /// Reverse (newest-first) ordering; batch-only.
     reverse: bool,
-    /// Optional path filter. A trailing slash matches a directory and its descendants; without
-    /// one it matches that exact file (see [`PathFilter`]).
-    path: Option<WebDavPath>,
+    /// Path filters (repeatable; union — an event matches if it satisfies any). A trailing slash
+    /// matches a directory and its descendants; without one it matches that exact file (see
+    /// [`PathFilter`]).
+    paths: Vec<WebDavPath>,
 }
 
 /// Parse the raw query string, handling repeated `user=` params.
@@ -52,7 +53,7 @@ fn parse_admin_stream_query(query: &str) -> Result<AdminStreamParams, HttpError>
     let mut limit = None;
     let mut live = false;
     let mut reverse = false;
-    let mut path: Option<String> = None;
+    let mut paths: Vec<WebDavPath> = Vec::new();
 
     for (key, value) in form_urlencoded::parse(query.as_bytes()) {
         match key.as_ref() {
@@ -86,9 +87,18 @@ fn parse_admin_stream_query(query: &str) -> Result<AdminStreamParams, HttpError>
             "live" => live = value == "true" || value == "1",
             "reverse" => reverse = value == "true" || value == "1",
             "path" => {
-                if !value.is_empty() {
-                    path = Some(value.to_string());
+                if value.is_empty() {
+                    continue;
                 }
+                // Prepend "/" if missing, for caller convenience.
+                let normalized = if value.starts_with('/') {
+                    value.into_owned()
+                } else {
+                    format!("/{value}")
+                };
+                let path = WebDavPath::new(&normalized)
+                    .map_err(|_| HttpError::bad_request(format!("Invalid path: {normalized}")))?;
+                paths.push(path);
             }
             _ => {} // Ignore unknown parameters
         }
@@ -105,29 +115,13 @@ fn parse_admin_stream_query(query: &str) -> Result<AdminStreamParams, HttpError>
         )));
     }
 
-    let path = match path {
-        Some(p) => {
-            // Automatically prepend "/" if not present for caller convenience.
-            let normalized = if p.starts_with('/') {
-                p
-            } else {
-                format!("/{p}")
-            };
-            Some(
-                WebDavPath::new(&normalized)
-                    .map_err(|_| HttpError::bad_request(format!("Invalid path: {normalized}")))?,
-            )
-        }
-        None => None,
-    };
-
     Ok(AdminStreamParams {
         users,
         cursor,
         limit,
         live,
         reverse,
-        path,
+        paths,
     })
 }
 
@@ -169,7 +163,7 @@ async fn resolve_filter(
     Ok(AllEventsFilter {
         start_cursor,
         user_ids,
-        path: params.path.map(PathFilter::from),
+        paths: params.paths.into_iter().map(PathFilter::from).collect(),
         reverse: params.reverse,
         live: params.live,
         limit: params.limit,

--- a/pubky-homeserver/src/admin_server/routes/admin_events.rs
+++ b/pubky-homeserver/src/admin_server/routes/admin_events.rs
@@ -134,7 +134,10 @@ fn parse_admin_stream_query(query: &str) -> Result<AdminStreamParams, HttpError>
 /// Resolve parsed params into a service-layer [`AllEventsFilter`]: `404` for an unknown `user=`,
 /// `400` for an invalid cursor. This is the route's only real work — the streaming itself lives in
 /// [`EventsService::all_events_stream`].
-async fn resolve_filter(state: &AppState, params: AdminStreamParams) -> HttpResult<AllEventsFilter> {
+async fn resolve_filter(
+    state: &AppState,
+    params: AdminStreamParams,
+) -> HttpResult<AllEventsFilter> {
     // None = all users (firehose); otherwise resolve each pubkey to its id.
     let user_ids = if params.users.is_empty() {
         None

--- a/pubky-homeserver/src/admin_server/routes/admin_events.rs
+++ b/pubky-homeserver/src/admin_server/routes/admin_events.rs
@@ -19,7 +19,7 @@ use url::form_urlencoded;
 use super::super::app_state::AppState;
 use crate::{
     persistence::{
-        files::events::{AllEventsFilter, MAX_EVENT_STREAM_USERS},
+        files::events::{AllEventsFilter, PathFilter, MAX_EVENT_STREAM_USERS},
         sql::user::UserRepository,
     },
     shared::{webdav::WebDavPath, HttpError, HttpResult},
@@ -37,7 +37,8 @@ struct AdminStreamParams {
     live: bool,
     /// Reverse (newest-first) ordering; batch-only.
     reverse: bool,
-    /// Optional path-prefix filter (literal prefix — use a trailing slash to scope to a directory).
+    /// Optional path filter. A trailing slash matches a directory and its descendants; without
+    /// one it matches that exact file (see [`PathFilter`]).
     path: Option<WebDavPath>,
 }
 
@@ -165,7 +166,7 @@ async fn resolve_filter(state: &AppState, params: AdminStreamParams) -> HttpResu
     Ok(AllEventsFilter {
         start_cursor,
         user_ids,
-        path: params.path,
+        path: params.path.map(PathFilter::from),
         reverse: params.reverse,
         live: params.live,
         limit: params.limit,

--- a/pubky-homeserver/src/admin_server/routes/admin_events.rs
+++ b/pubky-homeserver/src/admin_server/routes/admin_events.rs
@@ -19,7 +19,7 @@ use url::form_urlencoded;
 use super::super::app_state::AppState;
 use crate::{
     persistence::{
-        files::events::{AllEventsFilter, PathFilter, MAX_EVENT_STREAM_USERS},
+        files::events::{AllEventsFilter, Mode, PathFilter, MAX_EVENT_STREAM_USERS},
         sql::user::UserRepository,
     },
     shared::{webdav::WebDavPath, HttpError, HttpResult},
@@ -33,10 +33,8 @@ struct AdminStreamParams {
     cursor: Option<String>,
     /// Maximum total events to send before closing.
     limit: Option<u16>,
-    /// Live streaming mode (cannot be combined with `reverse`).
-    live: bool,
-    /// Reverse (newest-first) ordering; batch-only.
-    reverse: bool,
+    /// Ordering + live behavior; the incompatible reverse-and-live combination is unrepresentable.
+    mode: Mode,
     /// Path filters (repeatable; union — an event matches if it satisfies any). A trailing slash
     /// matches a directory and its descendants; without one it matches that exact file (see
     /// [`PathFilter`]).
@@ -106,11 +104,18 @@ fn parse_admin_stream_query(query: &str) -> Result<AdminStreamParams, HttpError>
         }
     }
 
-    if live && reverse {
-        return Err(HttpError::bad_request(
-            "Cannot use live mode with reverse ordering",
-        ));
-    }
+    // Collapse the two flags into a mode; the incompatible combination is rejected here so
+    // nothing downstream can represent it.
+    let mode = match (live, reverse) {
+        (false, false) => Mode::Forward,
+        (true, false) => Mode::ForwardLive,
+        (false, true) => Mode::Reverse,
+        (true, true) => {
+            return Err(HttpError::bad_request(
+                "Cannot use live mode with reverse ordering",
+            ))
+        }
+    };
     if users.len() > MAX_EVENT_STREAM_USERS {
         return Err(HttpError::bad_request(format!(
             "Too many users. Maximum allowed: {MAX_EVENT_STREAM_USERS}"
@@ -121,8 +126,7 @@ fn parse_admin_stream_query(query: &str) -> Result<AdminStreamParams, HttpError>
         users,
         cursor,
         limit,
-        live,
-        reverse,
+        mode,
         paths,
     })
 }
@@ -166,8 +170,7 @@ async fn resolve_filter(
         start_cursor,
         user_ids,
         paths: params.paths.into_iter().map(PathFilter::from).collect(),
-        reverse: params.reverse,
-        live: params.live,
+        mode: params.mode,
         limit: params.limit,
     })
 }

--- a/pubky-homeserver/src/admin_server/routes/delete_entry.rs
+++ b/pubky-homeserver/src/admin_server/routes/delete_entry.rs
@@ -52,6 +52,7 @@ mod tests {
             "",
             context.user_service.clone(),
             context.events_service.clone(),
+            context.metrics.clone(),
         );
         let router = Router::new()
             .route("/webdav/{*entry_path}", delete(delete_entry))
@@ -114,6 +115,7 @@ mod tests {
             "",
             context.user_service.clone(),
             context.events_service.clone(),
+            context.metrics.clone(),
         );
         let router = Router::new()
             .route("/webdav/{*entry_path}", delete(delete_entry))
@@ -139,6 +141,7 @@ mod tests {
             "",
             context.user_service.clone(),
             context.events_service.clone(),
+            context.metrics.clone(),
         );
         let router = Router::new()
             .route("/webdav/{*entry_path}", delete(delete_entry))

--- a/pubky-homeserver/src/admin_server/routes/delete_entry.rs
+++ b/pubky-homeserver/src/admin_server/routes/delete_entry.rs
@@ -51,6 +51,7 @@ mod tests {
             file_service.clone(),
             "",
             context.user_service.clone(),
+            context.events_service.clone(),
         );
         let router = Router::new()
             .route("/webdav/{*entry_path}", delete(delete_entry))
@@ -112,6 +113,7 @@ mod tests {
             FileService::new_from_context(&context).unwrap(),
             "",
             context.user_service.clone(),
+            context.events_service.clone(),
         );
         let router = Router::new()
             .route("/webdav/{*entry_path}", delete(delete_entry))
@@ -136,6 +138,7 @@ mod tests {
             FileService::new_from_context(&context).unwrap(),
             "",
             context.user_service.clone(),
+            context.events_service.clone(),
         );
         let router = Router::new()
             .route("/webdav/{*entry_path}", delete(delete_entry))

--- a/pubky-homeserver/src/admin_server/routes/disable_users.rs
+++ b/pubky-homeserver/src/admin_server/routes/disable_users.rs
@@ -99,6 +99,7 @@ mod tests {
             FileService::new_from_context(&context).unwrap(),
             "",
             context.user_service.clone(),
+            context.events_service.clone(),
         );
         let router = Router::new()
             .route("/users/{pubkey}/disable", post(disable_user))

--- a/pubky-homeserver/src/admin_server/routes/disable_users.rs
+++ b/pubky-homeserver/src/admin_server/routes/disable_users.rs
@@ -100,6 +100,7 @@ mod tests {
             "",
             context.user_service.clone(),
             context.events_service.clone(),
+            context.metrics.clone(),
         );
         let router = Router::new()
             .route("/users/{pubkey}/disable", post(disable_user))

--- a/pubky-homeserver/src/admin_server/routes/mod.rs
+++ b/pubky-homeserver/src/admin_server/routes/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod admin_events;
 pub(crate) mod dav_handler;
 pub(crate) mod delete_entry;
 pub(crate) mod disable_users;

--- a/pubky-homeserver/src/admin_server/routes/signup_tokens.rs
+++ b/pubky-homeserver/src/admin_server/routes/signup_tokens.rs
@@ -98,6 +98,7 @@ mod tests {
                 FileService::new_from_context(context).unwrap(),
                 "",
                 context.user_service.clone(),
+                context.events_service.clone(),
             ),
             "test",
         ))

--- a/pubky-homeserver/src/admin_server/routes/signup_tokens.rs
+++ b/pubky-homeserver/src/admin_server/routes/signup_tokens.rs
@@ -99,6 +99,7 @@ mod tests {
                 "",
                 context.user_service.clone(),
                 context.events_service.clone(),
+                context.metrics.clone(),
             ),
             "test",
         ))

--- a/pubky-homeserver/src/admin_server/routes/user_quota.rs
+++ b/pubky-homeserver/src/admin_server/routes/user_quota.rs
@@ -89,6 +89,7 @@ mod tests {
                 "",
                 context.user_service.clone(),
                 context.events_service.clone(),
+                context.metrics.clone(),
             ),
             "test",
         ))
@@ -105,6 +106,7 @@ mod tests {
             "",
             context.user_service.clone(),
             context.events_service.clone(),
+            context.metrics.clone(),
         );
         state.default_storage_mb = Some(100);
         state.default_quotas = DefaultQuotasToml {

--- a/pubky-homeserver/src/admin_server/routes/user_quota.rs
+++ b/pubky-homeserver/src/admin_server/routes/user_quota.rs
@@ -88,6 +88,7 @@ mod tests {
                 FileService::new_from_context(context).unwrap(),
                 "",
                 context.user_service.clone(),
+                context.events_service.clone(),
             ),
             "test",
         ))
@@ -103,6 +104,7 @@ mod tests {
             FileService::new_from_context(context).unwrap(),
             "",
             context.user_service.clone(),
+            context.events_service.clone(),
         );
         state.default_storage_mb = Some(100);
         state.default_quotas = DefaultQuotasToml {

--- a/pubky-homeserver/src/app_context.rs
+++ b/pubky-homeserver/src/app_context.rs
@@ -9,7 +9,7 @@ use crate::services::user_service::UserService;
 #[cfg(any(test, feature = "testing"))]
 use crate::MockDataDir;
 use crate::{
-    metrics_server::routes::metrics::{Metrics, MetricsInitError},
+    observability::{Metrics, MetricsInitError},
     persistence::{
         files::{events::EventsService, FileIoError, FileService},
         sql::{Migrator, PgEventListener, SqlDb},

--- a/pubky-homeserver/src/client_server/app_state.rs
+++ b/pubky-homeserver/src/client_server/app_state.rs
@@ -1,7 +1,7 @@
 use axum::extract::FromRef;
 
 use crate::client_server::auth::AuthState;
-use crate::metrics_server::routes::metrics::Metrics;
+use crate::observability::Metrics;
 use crate::persistence::files::events::EventsService;
 use crate::persistence::files::FileService;
 use crate::persistence::sql::SqlDb;

--- a/pubky-homeserver/src/client_server/auth/state.rs
+++ b/pubky-homeserver/src/client_server/auth/state.rs
@@ -2,7 +2,7 @@
 
 use super::cookie::verifier::CookieAuthVerifier;
 use crate::app_context::AppContext;
-use crate::metrics_server::routes::metrics::Metrics;
+use crate::observability::Metrics;
 
 use super::cookie::service::CookieAuthService;
 use super::{GrantAuthService, SignupService};

--- a/pubky-homeserver/src/client_server/mod.rs
+++ b/pubky-homeserver/src/client_server/mod.rs
@@ -8,7 +8,7 @@ mod app;
 pub(crate) mod app_state;
 pub(crate) mod auth;
 mod middleware;
-pub(crate) mod query_params;
+mod query_params;
 pub(crate) mod routes;
 
 pub use app::create_app;

--- a/pubky-homeserver/src/client_server/mod.rs
+++ b/pubky-homeserver/src/client_server/mod.rs
@@ -8,7 +8,7 @@ mod app;
 pub(crate) mod app_state;
 pub(crate) mod auth;
 mod middleware;
-mod query_params;
+pub(crate) mod query_params;
 pub(crate) mod routes;
 
 pub use app::create_app;

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -28,7 +28,7 @@ use crate::{
         AppState,
     },
     constants::PUBLIC_ROOT,
-    metrics_server::routes::metrics::ConnectionGuard,
+    observability::ConnectionGuard,
     persistence::{
         files::events::{
             EventCursor, EventEntity, EventsService, PathFilter, MAX_EVENT_STREAM_USERS,

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -216,11 +216,29 @@ impl TryFrom<RawEventStreamQueryParams> for EventStreamQueryParams {
 /// data: cursor: 42
 /// data: content_hash: r0NJufX5oaagQE3qNtzJSZvLJcmtwRK3zJqTyuQfMmI= (only for PUT events, base64-encoded blake3 hash)
 /// ```
-fn formatted_event_path(entity: &EventEntity) -> String {
+pub(crate) fn formatted_event_path(entity: &EventEntity) -> String {
     // TODO: switch this formatter to use the shared `PubkyResource` type from `pubky-sdk`
     // once the homeserver crate depends on it directly, so we avoid ad-hoc string
     // reconstruction here.
     format!("pubky://{}{}", entity.user_pubkey.z32(), entity.path.path())
+}
+
+/// Render a batch of events as the plain-text feed body used by `GET /events/`.
+///
+/// One line per event (`<TYPE> pubky://<user>/<path>`), followed by a trailing
+/// `cursor: <id>` line pointing at the last event so the caller can resume.
+/// Returns an empty string when there are no events (and therefore no cursor line).
+pub(crate) fn format_events_feed(events: &[EventEntity]) -> String {
+    let mut result = events
+        .iter()
+        .map(|event| format!("{} {}", event.event_type, formatted_event_path(event)))
+        .collect::<Vec<String>>();
+
+    if let Some(next_cursor) = events.last().map(|event| event.id.to_string()) {
+        result.push(format!("cursor: {}", next_cursor));
+    }
+
+    result.join("\n")
 }
 
 fn event_to_sse_data(entity: &EventEntity) -> String {
@@ -281,20 +299,10 @@ pub async fn feed(
         .metrics
         .record_events_db_query(query_start.elapsed().as_millis());
 
-    let mut result = events
-        .iter()
-        .map(|event| format!("{} {}", event.event_type, formatted_event_path(event)))
-        .collect::<Vec<String>>();
-    let next_cursor = events.last().map(|event| event.id.to_string());
-
-    if let Some(next_cursor) = next_cursor {
-        result.push(format!("cursor: {}", next_cursor));
-    }
-
     Ok(Response::builder()
         .status(StatusCode::OK)
         .header(header::CONTENT_TYPE, "text/plain")
-        .body(Body::from(result.join("\n")))
+        .body(Body::from(format_events_feed(&events)))
         .unwrap())
 }
 

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -23,7 +23,7 @@ use url::form_urlencoded;
 
 use crate::{
     client_server::{query_params::ListQueryParams, AppState},
-    metrics_server::routes::metrics::Metrics,
+    metrics_server::routes::metrics::ConnectionGuard,
     persistence::{
         files::events::{EventCursor, EventEntity, EventsService, MAX_EVENT_STREAM_USERS},
         sql::SqlDb,
@@ -206,32 +206,15 @@ impl TryFrom<RawEventStreamQueryParams> for EventStreamQueryParams {
     }
 }
 
-/// Format an event entity as SSE event data.
-/// Returns the multiline data field content.
-/// Each line will be prefixed with "data: " by the SSE library.
-///
-/// ## Format
-/// ```text
-/// data: pubky://user_pubkey/pub/example.txt
-/// data: cursor: 42
-/// data: content_hash: r0NJufX5oaagQE3qNtzJSZvLJcmtwRK3zJqTyuQfMmI= (only for PUT events, base64-encoded blake3 hash)
-/// ```
-pub(crate) fn formatted_event_path(entity: &EventEntity) -> String {
-    // TODO: switch this formatter to use the shared `PubkyResource` type from `pubky-sdk`
-    // once the homeserver crate depends on it directly, so we avoid ad-hoc string
-    // reconstruction here.
-    format!("pubky://{}{}", entity.user_pubkey.z32(), entity.path.path())
-}
-
 /// Render a batch of events as the plain-text feed body used by `GET /events/`.
 ///
 /// One line per event (`<TYPE> pubky://<user>/<path>`), followed by a trailing
 /// `cursor: <id>` line pointing at the last event so the caller can resume.
 /// Returns an empty string when there are no events (and therefore no cursor line).
-pub(crate) fn format_events_feed(events: &[EventEntity]) -> String {
+fn format_events_feed(events: &[EventEntity]) -> String {
     let mut result = events
         .iter()
-        .map(|event| format!("{} {}", event.event_type, formatted_event_path(event)))
+        .map(|event| format!("{} {}", event.event_type, event.pubky_uri()))
         .collect::<Vec<String>>();
 
     if let Some(next_cursor) = events.last().map(|event| event.id.to_string()) {
@@ -239,19 +222,6 @@ pub(crate) fn format_events_feed(events: &[EventEntity]) -> String {
     }
 
     result.join("\n")
-}
-
-fn event_to_sse_data(entity: &EventEntity) -> String {
-    let path = formatted_event_path(entity);
-    let cursor_line = format!("cursor: {}", entity.cursor());
-
-    let mut lines = vec![path, cursor_line];
-    if let Some(hash) = entity.event_type.content_hash() {
-        let hash_base64 =
-            base64::Engine::encode(&base64::engine::general_purpose::STANDARD, hash.as_bytes());
-        lines.push(format!("content_hash: {}", hash_base64));
-    }
-    lines.join("\n")
 }
 
 /// Legacy text-based endpoint for fetching historical events.
@@ -380,7 +350,7 @@ pub async fn feed_stream(
 
                 yield Ok(Event::default()
                     .event(event.event_type.to_string())
-                    .data(event_to_sse_data(&event)));
+                    .data(event.to_sse_data()));
 
                 total_sent += 1;
 
@@ -428,7 +398,7 @@ pub async fn feed_stream(
 
                         yield Ok(Event::default()
                             .event(event.event_type.to_string())
-                            .data(event_to_sse_data(&event)));
+                            .data(event.to_sse_data()));
 
                         total_sent += 1;
 
@@ -524,113 +494,4 @@ fn should_include_live_event(
     }
 
     true
-}
-
-/// Guard to ensure connection cleanup on any exit path
-struct ConnectionGuard {
-    metrics: Metrics,
-    start: Instant,
-}
-
-impl ConnectionGuard {
-    fn new(metrics: Metrics) -> Self {
-        metrics.increment_active_connections();
-        Self {
-            metrics,
-            start: Instant::now(),
-        }
-    }
-}
-
-impl Drop for ConnectionGuard {
-    fn drop(&mut self) {
-        self.metrics.decrement_active_connections();
-        self.metrics
-            .record_connection_closed(self.start.elapsed().as_millis());
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn connection_guard_drops_on_early_return() {
-        let metrics = Metrics::new().expect("Failed to create metrics");
-
-        // Create guard and return early - guard should still decrement
-        fn early_return_fn(metrics: Metrics) -> Result<(), &'static str> {
-            let _guard = ConnectionGuard::new(metrics.clone());
-            // Simulate early return (e.g., error condition)
-            return Err("early exit");
-            #[allow(unreachable_code)]
-            {
-                Ok(())
-            }
-        }
-
-        let result = early_return_fn(metrics.clone());
-        assert!(result.is_err(), "Should have returned early");
-
-        // Verify guard cleaned up properly despite early return
-        let output = metrics.render().expect("Failed to render metrics");
-        assert!(
-            output.contains("event_stream_active_connections") && output.contains("} 0"),
-            "Should have 0 active connections after early return: {}",
-            output
-        );
-        assert!(
-            output.contains("event_stream_connection_duration_ms_count"),
-            "Should have recorded connection duration: {}",
-            output
-        );
-    }
-
-    #[tokio::test]
-    async fn connection_guard_concurrent() {
-        let metrics = Metrics::new().expect("Failed to create metrics");
-
-        // Create 5 concurrent guards using tokio::spawn
-        let handles: Vec<_> = (0..5)
-            .map(|i| {
-                let metrics_clone = metrics.clone();
-                tokio::spawn(async move {
-                    let _guard = ConnectionGuard::new(metrics_clone);
-                    // Simulate some work
-                    tokio::time::sleep(tokio::time::Duration::from_millis(10 * i)).await;
-                    // Guard will be dropped here
-                })
-            })
-            .collect();
-
-        // While tasks are running, check active connections
-        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
-        let output = metrics.render().expect("Failed to render metrics");
-        // We should have some active connections (implementation dependent on timing)
-        assert!(
-            output.contains("event_stream_active_connections"),
-            "Should have active connections metric: {}",
-            output
-        );
-
-        // Wait for all tasks to complete
-        for handle in handles {
-            handle.await.unwrap();
-        }
-
-        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
-
-        // All guards should be cleaned up
-        let output = metrics.render().expect("Failed to render metrics");
-        assert!(
-            output.contains("event_stream_active_connections") && output.contains("} 0"),
-            "Should have 0 active connections after all concurrent guards dropped: {}",
-            output
-        );
-        assert!(
-            output.contains("event_stream_connection_duration_ms_count") && output.contains("} 5"),
-            "Should have recorded 5 connection durations: {}",
-            output
-        );
-    }
 }

--- a/pubky-homeserver/src/lib.rs
+++ b/pubky-homeserver/src/lib.rs
@@ -18,6 +18,7 @@ mod constants;
 mod data_directory;
 mod homeserver_app;
 mod metrics_server;
+mod observability;
 mod persistence;
 mod republishers;
 mod services;

--- a/pubky-homeserver/src/metrics_server/app.rs
+++ b/pubky-homeserver/src/metrics_server/app.rs
@@ -1,7 +1,7 @@
 use std::net::SocketAddr;
 use std::time::Duration;
 
-use crate::metrics_server::routes::metrics::Metrics;
+use crate::observability::Metrics;
 use crate::AppContext;
 use crate::AppContextConversionError;
 use axum::routing::get;

--- a/pubky-homeserver/src/metrics_server/mod.rs
+++ b/pubky-homeserver/src/metrics_server/mod.rs
@@ -4,6 +4,5 @@
 //! connections, database query latencies, and broadcast channel health.
 
 mod app;
-pub mod routes;
 
 pub use app::{MetricsServer, MetricsServerBuildError};

--- a/pubky-homeserver/src/metrics_server/routes/metrics.rs
+++ b/pubky-homeserver/src/metrics_server/routes/metrics.rs
@@ -2,6 +2,7 @@ use opentelemetry::metrics::{Counter, Histogram, Meter, MeterProvider, UpDownCou
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use prometheus::{Encoder, Registry, TextEncoder};
 use std::sync::Arc;
+use std::time::Instant;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -165,9 +166,117 @@ fn init_metrics() -> Result<(Registry, SdkMeterProvider, Meter), MetricsInitErro
     Ok((registry, provider, meter))
 }
 
+/// RAII guard that tracks an active event-stream (SSE) connection.
+///
+/// Increments the active-connection gauge on creation and, on drop (any exit path),
+/// decrements it and records the connection duration. Shared by the public and admin
+/// event-stream endpoints so both record the same metrics.
+pub(crate) struct ConnectionGuard {
+    metrics: Metrics,
+    start: Instant,
+}
+
+impl ConnectionGuard {
+    pub(crate) fn new(metrics: Metrics) -> Self {
+        metrics.increment_active_connections();
+        Self {
+            metrics,
+            start: Instant::now(),
+        }
+    }
+}
+
+impl Drop for ConnectionGuard {
+    fn drop(&mut self) {
+        self.metrics.decrement_active_connections();
+        self.metrics
+            .record_connection_closed(self.start.elapsed().as_millis());
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn connection_guard_drops_on_early_return() {
+        let metrics = Metrics::new().expect("Failed to create metrics");
+
+        // Create guard and return early - guard should still decrement
+        fn early_return_fn(metrics: Metrics) -> Result<(), &'static str> {
+            let _guard = ConnectionGuard::new(metrics.clone());
+            // Simulate early return (e.g., error condition)
+            return Err("early exit");
+            #[allow(unreachable_code)]
+            {
+                Ok(())
+            }
+        }
+
+        let result = early_return_fn(metrics.clone());
+        assert!(result.is_err(), "Should have returned early");
+
+        // Verify guard cleaned up properly despite early return
+        let output = metrics.render().expect("Failed to render metrics");
+        assert!(
+            output.contains("event_stream_active_connections") && output.contains("} 0"),
+            "Should have 0 active connections after early return: {}",
+            output
+        );
+        assert!(
+            output.contains("event_stream_connection_duration_ms_count"),
+            "Should have recorded connection duration: {}",
+            output
+        );
+    }
+
+    #[tokio::test]
+    async fn connection_guard_concurrent() {
+        let metrics = Metrics::new().expect("Failed to create metrics");
+
+        // Create 5 concurrent guards using tokio::spawn
+        let handles: Vec<_> = (0..5)
+            .map(|i| {
+                let metrics_clone = metrics.clone();
+                tokio::spawn(async move {
+                    let _guard = ConnectionGuard::new(metrics_clone);
+                    // Simulate some work
+                    tokio::time::sleep(tokio::time::Duration::from_millis(10 * i)).await;
+                    // Guard will be dropped here
+                })
+            })
+            .collect();
+
+        // While tasks are running, check active connections
+        tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+        let output = metrics.render().expect("Failed to render metrics");
+        // We should have some active connections (implementation dependent on timing)
+        assert!(
+            output.contains("event_stream_active_connections"),
+            "Should have active connections metric: {}",
+            output
+        );
+
+        // Wait for all tasks to complete
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        // All guards should be cleaned up
+        let output = metrics.render().expect("Failed to render metrics");
+        assert!(
+            output.contains("event_stream_active_connections") && output.contains("} 0"),
+            "Should have 0 active connections after all concurrent guards dropped: {}",
+            output
+        );
+        assert!(
+            output.contains("event_stream_connection_duration_ms_count") && output.contains("} 5"),
+            "Should have recorded 5 connection durations: {}",
+            output
+        );
+    }
 
     #[test]
     fn test_metrics_recording() {

--- a/pubky-homeserver/src/metrics_server/routes/mod.rs
+++ b/pubky-homeserver/src/metrics_server/routes/mod.rs
@@ -1,1 +1,0 @@
-pub(crate) mod metrics;

--- a/pubky-homeserver/src/observability.rs
+++ b/pubky-homeserver/src/observability.rs
@@ -1,3 +1,10 @@
+//! Metrics recorder and connection tracking.
+//!
+//! Neutral observability layer: the [`Metrics`] recorder (OpenTelemetry + Prometheus) and the
+//! [`ConnectionGuard`] RAII helper live here so any subsystem can record without depending on a
+//! server route. The `metrics_server` *serves* this over HTTP; subsystems (`persistence`,
+//! `client_server`, …) only *record* into it.
+
 use opentelemetry::metrics::{Counter, Histogram, Meter, MeterProvider, UpDownCounter};
 use opentelemetry_sdk::metrics::SdkMeterProvider;
 use prometheus::{Encoder, Registry, TextEncoder};
@@ -166,8 +173,6 @@ fn init_metrics() -> Result<(Registry, SdkMeterProvider, Meter), MetricsInitErro
     Ok((registry, provider, meter))
 }
 
-/// RAII guard that tracks an active event-stream (SSE) connection.
-///
 /// Increments the active-connection gauge on creation and, on drop (any exit path),
 /// decrements it and records the connection duration. Shared by the public and admin
 /// event-stream endpoints so both record the same metrics.

--- a/pubky-homeserver/src/persistence/files/events/events_entity.rs
+++ b/pubky-homeserver/src/persistence/files/events/events_entity.rs
@@ -23,6 +23,23 @@ impl EventEntity {
     pub fn cursor(&self) -> EventCursor {
         EventCursor::new(self.id)
     }
+
+    /// Full `pubky://` URI of this event's resource, e.g. `pubky://<z32>/pub/file.txt`.
+    pub(crate) fn pubky_uri(&self) -> String {
+        format!("pubky://{}{}", self.user_pubkey.z32(), self.path.path())
+    }
+
+    /// Multiline SSE `data:` payload (path, `cursor:`, and `content_hash:` for PUTs) shared by the
+    /// public and admin event streams. Each line is prefixed with `data: ` by the SSE layer.
+    pub(crate) fn to_sse_data(&self) -> String {
+        let mut lines = vec![self.pubky_uri(), format!("cursor: {}", self.cursor())];
+        if let Some(hash) = self.event_type.content_hash() {
+            let hash_base64 =
+                base64::Engine::encode(&base64::engine::general_purpose::STANDARD, hash.as_bytes());
+            lines.push(format!("content_hash: {hash_base64}"));
+        }
+        lines.join("\n")
+    }
 }
 
 impl FromRow<'_, PgRow> for EventEntity {

--- a/pubky-homeserver/src/persistence/files/events/events_repository.rs
+++ b/pubky-homeserver/src/persistence/files/events/events_repository.rs
@@ -1,6 +1,6 @@
 use pubky_common::events::{EventCursor, EventType};
 use pubky_common::timestamp::Timestamp;
-use sea_query::{Condition, Expr, Iden, LikeExpr, Order, PostgresQueryBuilder, Query, SimpleExpr};
+use sea_query::{Condition, Expr, Iden, Order, PostgresQueryBuilder, Query, SimpleExpr};
 use sea_query_binder::SqlxBinder;
 use sqlx::{
     postgres::PgRow,
@@ -313,13 +313,14 @@ impl EventRepository {
     }
 
     /// Get **all** events (public and private) by a single global cursor, with optional reverse,
-    /// path-prefix, and user-id filters. Backs the admin events stream — it applies no
-    /// `/pub`-vs-`/priv` visibility predicate, so reach it only from admin-authenticated callers.
+    /// path, and user-id filters. The path filter uses [`PathFilter`] (file-vs-directory matching).
+    /// Backs the admin events stream — it applies no `/pub`-vs-`/priv` visibility predicate, so
+    /// reach it only from admin-authenticated callers.
     pub async fn get_all_filtered_by_cursor<'a>(
         cursor: Option<EventCursor>,
         limit: Option<u16>,
         reverse: bool,
-        path_prefix: Option<&str>,
+        path_filter: Option<&PathFilter>,
         user_ids: Option<&[i32]>,
         executor: &mut UnifiedExecutor<'a>,
     ) -> Result<Vec<EventEntity>, sqlx::Error> {
@@ -363,19 +364,8 @@ impl EventRepository {
                 .to_owned();
         }
 
-        if let Some(prefix) = path_prefix {
-            // Escape special LIKE characters: %, _, and \
-            let escaped_prefix = prefix
-                .replace('\\', "\\\\")
-                .replace('_', "\\_")
-                .replace('%', "\\%");
-            let like_pattern = format!("{}%", escaped_prefix);
-            statement = statement
-                .and_where(
-                    Expr::col((EVENT_TABLE, EventIden::Path))
-                        .like(LikeExpr::new(like_pattern).escape('\\')),
-                )
-                .to_owned();
+        if let Some(filter) = path_filter {
+            statement = statement.and_where(filter.to_condition()).to_owned();
         }
 
         if let Some(ids) = user_ids {

--- a/pubky-homeserver/src/persistence/files/events/events_repository.rs
+++ b/pubky-homeserver/src/persistence/files/events/events_repository.rs
@@ -313,14 +313,14 @@ impl EventRepository {
     }
 
     /// Get **all** events (public and private) by a single global cursor, with optional reverse,
-    /// path, and user-id filters. The path filter uses [`PathFilter`] (file-vs-directory matching).
-    /// Backs the admin events stream — it applies no `/pub`-vs-`/priv` visibility predicate, so
-    /// reach it only from admin-authenticated callers.
+    /// path, and user-id filters. `path_filters` is a union — an event is returned if it matches
+    /// **any** of them (empty = no path restriction); each uses [`PathFilter`] file-vs-directory
+    /// matching. Backs the admin events stream.
     pub async fn get_all_filtered_by_cursor<'a>(
         cursor: Option<EventCursor>,
         limit: Option<u16>,
         reverse: bool,
-        path_filter: Option<&PathFilter>,
+        path_filters: &[PathFilter],
         user_ids: Option<&[i32]>,
         executor: &mut UnifiedExecutor<'a>,
     ) -> Result<Vec<EventEntity>, sqlx::Error> {
@@ -364,8 +364,13 @@ impl EventRepository {
                 .to_owned();
         }
 
-        if let Some(filter) = path_filter {
-            statement = statement.and_where(filter.to_condition()).to_owned();
+        // Union of path filters: an event matches if it satisfies ANY of them.
+        if !path_filters.is_empty() {
+            let mut path_condition = Condition::any();
+            for filter in path_filters {
+                path_condition = path_condition.add(filter.to_condition());
+            }
+            statement = statement.cond_where(path_condition).to_owned();
         }
 
         if let Some(ids) = user_ids {

--- a/pubky-homeserver/src/persistence/files/events/events_repository.rs
+++ b/pubky-homeserver/src/persistence/files/events/events_repository.rs
@@ -312,6 +312,84 @@ impl EventRepository {
         let events: Vec<EventEntity> = sqlx::query_as_with(&query, values).fetch_all(con).await?;
         Ok(events)
     }
+
+    /// Get **all** events (public and private) by a single global cursor, with optional reverse,
+    /// path-prefix, and user-id filters. Backs the admin events stream — it applies no
+    /// `/pub`-vs-`/priv` visibility predicate, so reach it only from admin-authenticated callers.
+    pub async fn get_all_filtered_by_cursor<'a>(
+        cursor: Option<EventCursor>,
+        limit: Option<u16>,
+        reverse: bool,
+        path_prefix: Option<&str>,
+        user_ids: Option<&[i32]>,
+        executor: &mut UnifiedExecutor<'a>,
+    ) -> Result<Vec<EventEntity>, sqlx::Error> {
+        // An explicit empty user filter matches nothing; short-circuit before querying.
+        if matches!(user_ids, Some(ids) if ids.is_empty()) {
+            return Ok(Vec::new());
+        }
+
+        let limit = limit
+            .unwrap_or(DEFAULT_LIST_LIMIT)
+            .min(DEFAULT_MAX_LIST_LIMIT);
+        let order = if reverse { Order::Desc } else { Order::Asc };
+
+        let mut statement = Query::select()
+            .columns([
+                (EVENT_TABLE, EventIden::Id),
+                (EVENT_TABLE, EventIden::User),
+                (EVENT_TABLE, EventIden::Type),
+                (EVENT_TABLE, EventIden::Path),
+                (EVENT_TABLE, EventIden::CreatedAt),
+                (EVENT_TABLE, EventIden::ContentHash),
+            ])
+            .column((USER_TABLE, UserIden::PublicKey))
+            .from(EVENT_TABLE)
+            .left_join(
+                USER_TABLE,
+                Expr::col((EVENT_TABLE, EventIden::User)).eq(Expr::col((USER_TABLE, UserIden::Id))),
+            )
+            .order_by((EVENT_TABLE, EventIden::Id), order)
+            .limit(limit as u64)
+            .to_owned();
+
+        if let Some(cursor) = cursor {
+            let id_col = Expr::col((EVENT_TABLE, EventIden::Id));
+            statement = statement
+                .and_where(if reverse {
+                    id_col.lt(cursor.id())
+                } else {
+                    id_col.gt(cursor.id())
+                })
+                .to_owned();
+        }
+
+        if let Some(prefix) = path_prefix {
+            // Escape special LIKE characters: %, _, and \
+            let escaped_prefix = prefix
+                .replace('\\', "\\\\")
+                .replace('_', "\\_")
+                .replace('%', "\\%");
+            let like_pattern = format!("{}%", escaped_prefix);
+            statement = statement
+                .and_where(
+                    Expr::col((EVENT_TABLE, EventIden::Path))
+                        .like(LikeExpr::new(like_pattern).escape('\\')),
+                )
+                .to_owned();
+        }
+
+        if let Some(ids) = user_ids {
+            statement = statement
+                .and_where(Expr::col((EVENT_TABLE, EventIden::User)).is_in(ids.iter().copied()))
+                .to_owned();
+        }
+
+        let (query, values) = statement.build_sqlx(PostgresQueryBuilder);
+        let con = executor.get_con().await?;
+        let events: Vec<EventEntity> = sqlx::query_as_with(&query, values).fetch_all(con).await?;
+        Ok(events)
+    }
 }
 
 #[derive(Iden)]

--- a/pubky-homeserver/src/persistence/files/events/events_service.rs
+++ b/pubky-homeserver/src/persistence/files/events/events_service.rs
@@ -29,6 +29,18 @@ pub struct EventsService {
     channel_capacity: usize,
 }
 
+/// Ordering + live behavior for the admin all-events stream. Encoding the mutually exclusive
+/// options as one enum makes the invalid reverse-and-live combination unrepresentable.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Mode {
+    /// Batch, oldest-first; close when caught up.
+    Forward,
+    /// Batch oldest-first, then stay open for live events.
+    ForwardLive,
+    /// Batch, newest-first; close when caught up.
+    Reverse,
+}
+
 /// Resolved filter for the admin all-events stream. The route builds this after authorizing the
 /// request (pubkeys → user ids, cursor parsed); it drives [`EventsService::all_events_stream`].
 pub(crate) struct AllEventsFilter {
@@ -38,10 +50,8 @@ pub(crate) struct AllEventsFilter {
     pub user_ids: Option<Vec<i32>>,
     /// Path filters
     pub paths: Vec<PathFilter>,
-    /// Newest-first ordering (batch only).
-    pub reverse: bool,
-    /// Stay open for live events after replaying history.
-    pub live: bool,
+    /// Ordering + live behavior.
+    pub mode: Mode,
     /// Maximum total events to send before closing.
     pub limit: Option<u16>,
 }
@@ -187,7 +197,7 @@ impl EventsService {
     }
 
     /// Stream **all** events (the admin firehose): replay history over a single advancing global
-    /// cursor, then — when `filter.live` — stay open on the broadcast channel. Yields domain
+    /// cursor, then — in `ForwardLive` mode — stay open on the broadcast channel. Yields domain
     /// [`EventEntity`]s for the caller to frame (e.g. SSE). Exposes private paths, so only
     /// admin-authenticated routes may call it.
     pub(crate) fn all_events_stream(
@@ -206,6 +216,8 @@ impl EventsService {
 
             let mut last_cursor = filter.start_cursor;
             let mut total_sent: usize = 0;
+            let reverse = filter.mode == Mode::Reverse;
+            let live = filter.mode == Mode::ForwardLive;
 
             // Phase 1: historical replay over a single advancing global cursor.
             loop {
@@ -226,7 +238,7 @@ impl EventsService {
                     .get_all_events(
                         last_cursor,
                         batch_limit,
-                        filter.reverse,
+                        reverse,
                         &filter.paths,
                         filter.user_ids.as_deref(),
                         &mut sql_db.pool().into(),
@@ -249,15 +261,15 @@ impl EventsService {
                     total_sent += 1;
                 }
                 if caught_up {
-                    if !filter.live {
+                    if !live {
                         return;
                     }
                     break;
                 }
             }
 
-            // Phase 2: live mode (reverse+live is rejected before we get here).
-            if filter.live {
+            // Phase 2: live mode (only `Mode::ForwardLive` reaches here).
+            if live {
                 loop {
                     match rx.recv().await {
                         Ok(event) => {

--- a/pubky-homeserver/src/persistence/files/events/events_service.rs
+++ b/pubky-homeserver/src/persistence/files/events/events_service.rs
@@ -212,11 +212,20 @@ impl EventsService {
                 // Drain buffered events; they'll be covered by this or a later DB query.
                 while rx.try_recv().is_ok() {}
 
+                // Only fetch the events still owed under `limit`
+                let batch_limit = match filter.limit {
+                    Some(max) => match (max as usize).saturating_sub(total_sent) {
+                        0 => return,
+                        remaining => Some(remaining as u16),
+                    },
+                    None => None,
+                };
+
                 let query_start = Instant::now();
                 let events = match service
                     .get_all_events(
                         last_cursor,
-                        None,
+                        batch_limit,
                         filter.reverse,
                         &filter.paths,
                         filter.user_ids.as_deref(),
@@ -235,10 +244,6 @@ impl EventsService {
                 // An empty batch means we've replayed everything up to `last_cursor`.
                 let caught_up = events.is_empty();
                 for event in events {
-                    // Check the limit before yielding so `limit=0` sends nothing.
-                    if filter.limit.is_some_and(|max| total_sent >= max as usize) {
-                        return;
-                    }
                     last_cursor = Some(event.cursor());
                     yield event;
                     total_sent += 1;

--- a/pubky-homeserver/src/persistence/files/events/events_service.rs
+++ b/pubky-homeserver/src/persistence/files/events/events_service.rs
@@ -122,6 +122,21 @@ impl EventsService {
         EventRepository::get_by_cursor(cursor, limit, EventVisibility::Public, executor).await
     }
 
+    /// Get a list of all events (public `/pub/...` and private `/priv/...`)
+    /// starting from a cursor position.
+    ///
+    /// ## Parameters
+    /// - `cursor`: Starting position (None = from beginning)
+    /// - `limit`: Maximum number of events to return (None = default limit)
+    pub async fn get_all_by_cursor<'a>(
+        &self,
+        cursor: Option<EventCursor>,
+        limit: Option<u16>,
+        executor: &mut UnifiedExecutor<'a>,
+    ) -> Result<Vec<EventEntity>, sqlx::Error> {
+        EventRepository::get_by_cursor(cursor, limit, EventVisibility::All, executor).await
+    }
+
     /// Get events for multiple users with individual cursor positions.
     ///
     /// ## Parameters
@@ -241,5 +256,46 @@ mod tests {
             .unwrap();
         assert_eq!(page.len(), 1);
         assert_eq!(page[0].id, 5); // /pub/c (skips /priv/y at id 4)
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_events_service_get_all_by_cursor_includes_private() {
+        let db = SqlDb::test().await;
+        let events_service = EventsService::new(100);
+
+        let user_pubkey = Keypair::random().public_key();
+        let user = UserRepository::create(&user_pubkey, &mut db.pool().into())
+            .await
+            .unwrap();
+
+        // Same interleaving as the public test: ids 1=/pub/a, 2=/priv/x,
+        // 3=/pub/b, 4=/priv/y, 5=/pub/c.
+        let paths = ["/pub/a", "/priv/x", "/pub/b", "/priv/y", "/pub/c"];
+        for p in paths {
+            let path = EntryPath::new(user_pubkey.clone(), WebDavPath::new(p).unwrap());
+            events_service
+                .create_event(
+                    user.id,
+                    EventType::Put {
+                        content_hash: pubky_common::crypto::Hash::from_bytes([0; 32]),
+                    },
+                    &path,
+                    &mut db.pool().into(),
+                )
+                .await
+                .unwrap();
+        }
+
+        // The admin view returns every event, private ones included, in id order.
+        let events = events_service
+            .get_all_by_cursor(None, None, &mut db.pool().into())
+            .await
+            .unwrap();
+        let returned: Vec<&str> = events.iter().map(|e| e.path.path().as_str()).collect();
+        assert_eq!(
+            returned,
+            vec!["/pub/a", "/priv/x", "/pub/b", "/priv/y", "/pub/c"]
+        );
     }
 }

--- a/pubky-homeserver/src/persistence/files/events/events_service.rs
+++ b/pubky-homeserver/src/persistence/files/events/events_service.rs
@@ -4,7 +4,7 @@ use futures_util::Stream;
 use sqlx::PgPool;
 use tokio::sync::broadcast;
 
-use crate::metrics_server::routes::metrics::{ConnectionGuard, Metrics};
+use crate::observability::{ConnectionGuard, Metrics};
 use crate::persistence::{
     files::events::{
         EventCursor, EventEntity, EventRepository, EventType, EventVisibility, PathFilter,
@@ -36,9 +36,8 @@ pub(crate) struct AllEventsFilter {
     pub start_cursor: Option<EventCursor>,
     /// User filter. `None` = all users (firehose).
     pub user_ids: Option<Vec<i32>>,
-    /// Path filter (file-vs-directory matching: a trailing slash selects a directory and its
-    /// descendants, otherwise an exact file).
-    pub path: Option<PathFilter>,
+    /// Path filters
+    pub paths: Vec<PathFilter>,
     /// Newest-first ordering (batch only).
     pub reverse: bool,
     /// Stay open for live events after replaying history.
@@ -154,7 +153,7 @@ impl EventsService {
         cursor: Option<EventCursor>,
         limit: Option<u16>,
         reverse: bool,
-        path_filter: Option<&PathFilter>,
+        path_filters: &[PathFilter],
         user_ids: Option<&[i32]>,
         executor: &mut UnifiedExecutor<'a>,
     ) -> Result<Vec<EventEntity>, sqlx::Error> {
@@ -162,7 +161,7 @@ impl EventsService {
             cursor,
             limit,
             reverse,
-            path_filter,
+            path_filters,
             user_ids,
             executor,
         )
@@ -219,7 +218,7 @@ impl EventsService {
                         last_cursor,
                         None,
                         filter.reverse,
-                        filter.path.as_ref(),
+                        &filter.paths,
                         filter.user_ids.as_deref(),
                         &mut sql_db.pool().into(),
                     )
@@ -303,8 +302,9 @@ fn accept_live_event(
             return false;
         }
     }
-    if let Some(path) = filter.path.as_ref() {
-        if !path.matches(event.path.path().as_str()) {
+    if !filter.paths.is_empty() {
+        let path = event.path.path();
+        if !filter.paths.iter().any(|f| f.matches(path.as_str())) {
             return false;
         }
     }
@@ -446,7 +446,7 @@ mod tests {
 
         // No filters: every event, private ones included, in id order.
         let events = events_service
-            .get_all_events(None, None, false, None, None, &mut db.pool().into())
+            .get_all_events(None, None, false, &[], None, &mut db.pool().into())
             .await
             .unwrap();
         let returned: Vec<&str> = events.iter().map(|e| e.path.path().as_str()).collect();
@@ -457,7 +457,7 @@ mod tests {
 
         // reverse=true returns newest first.
         let events = events_service
-            .get_all_events(None, None, true, None, None, &mut db.pool().into())
+            .get_all_events(None, None, true, &[], None, &mut db.pool().into())
             .await
             .unwrap();
         let returned: Vec<&str> = events.iter().map(|e| e.path.path().as_str()).collect();
@@ -466,14 +466,14 @@ mod tests {
             vec!["/pub/c", "/priv/y", "/pub/b", "/priv/x", "/pub/a"]
         );
 
-        // A directory path filter scopes to a storage root (private included).
-        let priv_filter = PathFilter::from(WebDavPath::new("/priv/").unwrap());
+        // A union of path filters scopes to those roots (here a single private directory).
+        let path_filters = [PathFilter::from(WebDavPath::new("/priv/").unwrap())];
         let events = events_service
             .get_all_events(
                 None,
                 None,
                 false,
-                Some(&priv_filter),
+                &path_filters,
                 None,
                 &mut db.pool().into(),
             )
@@ -482,13 +482,32 @@ mod tests {
         let returned: Vec<&str> = events.iter().map(|e| e.path.path().as_str()).collect();
         assert_eq!(returned, vec!["/priv/x", "/priv/y"]);
 
+        // Multiple path filters union (any-match): an exact file OR a directory subtree.
+        let path_filters = [
+            PathFilter::from(WebDavPath::new("/pub/a").unwrap()),
+            PathFilter::from(WebDavPath::new("/priv/").unwrap()),
+        ];
+        let events = events_service
+            .get_all_events(
+                None,
+                None,
+                false,
+                &path_filters,
+                None,
+                &mut db.pool().into(),
+            )
+            .await
+            .unwrap();
+        let returned: Vec<&str> = events.iter().map(|e| e.path.path().as_str()).collect();
+        assert_eq!(returned, vec!["/pub/a", "/priv/x", "/priv/y"]);
+
         // user_ids filters to those users.
         let events = events_service
             .get_all_events(
                 None,
                 None,
                 false,
-                None,
+                &[],
                 Some(&[user.id]),
                 &mut db.pool().into(),
             )

--- a/pubky-homeserver/src/persistence/files/events/events_service.rs
+++ b/pubky-homeserver/src/persistence/files/events/events_service.rs
@@ -122,19 +122,26 @@ impl EventsService {
         EventRepository::get_by_cursor(cursor, limit, EventVisibility::Public, executor).await
     }
 
-    /// Get a list of all events (public `/pub/...` and private `/priv/...`)
-    /// starting from a cursor position.
-    ///
-    /// ## Parameters
-    /// - `cursor`: Starting position (None = from beginning)
-    /// - `limit`: Maximum number of events to return (None = default limit)
-    pub async fn get_all_by_cursor<'a>(
+    /// All events (public and private) by a single global cursor.
+    /// Admin-only, exposes private paths.
+    pub async fn get_all_events<'a>(
         &self,
         cursor: Option<EventCursor>,
         limit: Option<u16>,
+        reverse: bool,
+        path_prefix: Option<&str>,
+        user_ids: Option<&[i32]>,
         executor: &mut UnifiedExecutor<'a>,
     ) -> Result<Vec<EventEntity>, sqlx::Error> {
-        EventRepository::get_by_cursor(cursor, limit, EventVisibility::All, executor).await
+        EventRepository::get_all_filtered_by_cursor(
+            cursor,
+            limit,
+            reverse,
+            path_prefix,
+            user_ids,
+            executor,
+        )
+        .await
     }
 
     /// Get events for multiple users with individual cursor positions.
@@ -260,7 +267,7 @@ mod tests {
 
     #[tokio::test]
     #[pubky_test_utils::test]
-    async fn test_events_service_get_all_by_cursor_includes_private() {
+    async fn test_events_service_get_all_events_includes_private() {
         let db = SqlDb::test().await;
         let events_service = EventsService::new(100);
 
@@ -287,9 +294,9 @@ mod tests {
                 .unwrap();
         }
 
-        // The admin view returns every event, private ones included, in id order.
+        // No filters: every event, private ones included, in id order.
         let events = events_service
-            .get_all_by_cursor(None, None, &mut db.pool().into())
+            .get_all_events(None, None, false, None, None, &mut db.pool().into())
             .await
             .unwrap();
         let returned: Vec<&str> = events.iter().map(|e| e.path.path().as_str()).collect();
@@ -297,5 +304,45 @@ mod tests {
             returned,
             vec!["/pub/a", "/priv/x", "/pub/b", "/priv/y", "/pub/c"]
         );
+
+        // reverse=true returns newest first.
+        let events = events_service
+            .get_all_events(None, None, true, None, None, &mut db.pool().into())
+            .await
+            .unwrap();
+        let returned: Vec<&str> = events.iter().map(|e| e.path.path().as_str()).collect();
+        assert_eq!(
+            returned,
+            vec!["/pub/c", "/priv/y", "/pub/b", "/priv/x", "/pub/a"]
+        );
+
+        // path_prefix filters to a storage root (private included).
+        let events = events_service
+            .get_all_events(
+                None,
+                None,
+                false,
+                Some("/priv/"),
+                None,
+                &mut db.pool().into(),
+            )
+            .await
+            .unwrap();
+        let returned: Vec<&str> = events.iter().map(|e| e.path.path().as_str()).collect();
+        assert_eq!(returned, vec!["/priv/x", "/priv/y"]);
+
+        // user_ids filters to those users.
+        let events = events_service
+            .get_all_events(
+                None,
+                None,
+                false,
+                None,
+                Some(&[user.id]),
+                &mut db.pool().into(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(events.len(), 5);
     }
 }

--- a/pubky-homeserver/src/persistence/files/events/events_service.rs
+++ b/pubky-homeserver/src/persistence/files/events/events_service.rs
@@ -1,10 +1,15 @@
-use crate::persistence::{
-    files::events::{EventCursor, EventEntity, EventRepository, EventType, EventVisibility},
-    sql::UnifiedExecutor,
-};
-use crate::shared::webdav::EntryPath;
+use std::time::Instant;
+
+use futures_util::Stream;
 use sqlx::PgPool;
 use tokio::sync::broadcast;
+
+use crate::metrics_server::routes::metrics::{ConnectionGuard, Metrics};
+use crate::persistence::{
+    files::events::{EventCursor, EventEntity, EventRepository, EventType, EventVisibility},
+    sql::{SqlDb, UnifiedExecutor},
+};
+use crate::shared::webdav::{EntryPath, WebDavPath};
 
 /// Maximum number of users allowed in a single event stream request.
 /// Based on HTTP header size limits (~4KB) and typical URL encoding:
@@ -20,6 +25,23 @@ pub(crate) const PG_NOTIFY_CHANNEL: &str = "events";
 pub struct EventsService {
     event_tx: broadcast::Sender<EventEntity>,
     channel_capacity: usize,
+}
+
+/// Resolved filter for the admin all-events stream. The route builds this after authorizing the
+/// request (pubkeys → user ids, cursor parsed); it drives [`EventsService::all_events_stream`].
+pub(crate) struct AllEventsFilter {
+    /// Starting cursor (global). `None` = from the beginning.
+    pub start_cursor: Option<EventCursor>,
+    /// User filter. `None` = all users (firehose).
+    pub user_ids: Option<Vec<i32>>,
+    /// Path-prefix filter.
+    pub path: Option<WebDavPath>,
+    /// Newest-first ordering (batch only).
+    pub reverse: bool,
+    /// Stay open for live events after replaying history.
+    pub live: bool,
+    /// Maximum total events to send before closing.
+    pub limit: Option<u16>,
 }
 
 impl EventsService {
@@ -159,6 +181,129 @@ impl EventsService {
     ) -> Result<Vec<EventEntity>, sqlx::Error> {
         EventRepository::get_by_user_cursors(user_cursors, reverse, path_prefix, executor).await
     }
+
+    /// Stream **all** events (the admin firehose): replay history over a single advancing global
+    /// cursor, then — when `filter.live` — stay open on the broadcast channel. Yields domain
+    /// [`EventEntity`]s for the caller to frame (e.g. SSE). Exposes private paths, so only
+    /// admin-authenticated routes may call it.
+    pub(crate) fn all_events_stream(
+        &self,
+        sql_db: SqlDb,
+        metrics: Metrics,
+        filter: AllEventsFilter,
+    ) -> impl Stream<Item = EventEntity> {
+        let service = self.clone();
+        let mut rx = self.subscribe();
+        let half_capacity = self.channel_capacity() / 2;
+
+        async_stream::stream! {
+            // Cleanup + connection metrics on any exit path.
+            let _guard = ConnectionGuard::new(metrics.clone());
+
+            let mut last_cursor = filter.start_cursor;
+            let mut total_sent: usize = 0;
+
+            // Phase 1: historical replay over a single advancing global cursor.
+            loop {
+                // Drain buffered events; they'll be covered by this or a later DB query.
+                while rx.try_recv().is_ok() {}
+
+                let query_start = Instant::now();
+                let events = match service
+                    .get_all_events(
+                        last_cursor,
+                        None,
+                        filter.reverse,
+                        filter.path.as_ref().map(|p| p.as_str()),
+                        filter.user_ids.as_deref(),
+                        &mut sql_db.pool().into(),
+                    )
+                    .await
+                {
+                    Ok(events) => events,
+                    Err(e) => {
+                        tracing::error!("Database error while streaming admin events: {}", e);
+                        break;
+                    }
+                };
+                metrics.record_event_stream_db_query(query_start.elapsed().as_millis());
+
+                // An empty batch means we've replayed everything up to `last_cursor`.
+                let caught_up = events.is_empty();
+                for event in events {
+                    // Check the limit before yielding so `limit=0` sends nothing.
+                    if filter.limit.is_some_and(|max| total_sent >= max as usize) {
+                        return;
+                    }
+                    last_cursor = Some(event.cursor());
+                    yield event;
+                    total_sent += 1;
+                }
+                if caught_up {
+                    if !filter.live {
+                        return;
+                    }
+                    break;
+                }
+            }
+
+            // Phase 2: live mode (reverse+live is rejected before we get here).
+            if filter.live {
+                loop {
+                    match rx.recv().await {
+                        Ok(event) => {
+                            if rx.len() >= half_capacity {
+                                metrics.record_broadcast_half_full();
+                            }
+                            if !accept_live_event(&event, last_cursor, &filter) {
+                                continue;
+                            }
+                            if filter.limit.is_some_and(|max| total_sent >= max as usize) {
+                                return;
+                            }
+                            last_cursor = Some(event.cursor());
+                            yield event;
+                            total_sent += 1;
+                        }
+                        Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                            metrics.record_broadcast_lagged();
+                            tracing::warn!(
+                                "Slow admin client detected: broadcast channel lagged by {} events. Closing connection.",
+                                skipped
+                            );
+                            return;
+                        }
+                        Err(_) => break, // Channel closed
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Whether a live broadcast event belongs in an all-events stream: not already sent (cursor dedup),
+/// inside the optional user filter, and under the optional path prefix.
+fn accept_live_event(
+    event: &EventEntity,
+    last_cursor: Option<EventCursor>,
+    filter: &AllEventsFilter,
+) -> bool {
+    if let Some(cursor) = last_cursor {
+        if event.cursor() <= cursor {
+            return false;
+        }
+    }
+    if let Some(ids) = filter.user_ids.as_deref() {
+        if !ids.contains(&event.user_id) {
+            return false;
+        }
+    }
+    if let Some(path) = filter.path.as_ref() {
+        if !event.path.path().as_str().starts_with(path.as_str()) {
+            return false;
+        }
+    }
+    true
 }
 
 #[cfg(test)]

--- a/pubky-homeserver/src/persistence/files/events/events_service.rs
+++ b/pubky-homeserver/src/persistence/files/events/events_service.rs
@@ -11,7 +11,7 @@ use crate::persistence::{
     },
     sql::{SqlDb, UnifiedExecutor},
 };
-use crate::shared::webdav::{EntryPath, WebDavPath};
+use crate::shared::webdav::EntryPath;
 
 /// Maximum number of users allowed in a single event stream request.
 /// Based on HTTP header size limits (~4KB) and typical URL encoding:
@@ -36,8 +36,9 @@ pub(crate) struct AllEventsFilter {
     pub start_cursor: Option<EventCursor>,
     /// User filter. `None` = all users (firehose).
     pub user_ids: Option<Vec<i32>>,
-    /// Path-prefix filter.
-    pub path: Option<WebDavPath>,
+    /// Path filter (file-vs-directory matching: a trailing slash selects a directory and its
+    /// descendants, otherwise an exact file).
+    pub path: Option<PathFilter>,
     /// Newest-first ordering (batch only).
     pub reverse: bool,
     /// Stay open for live events after replaying history.
@@ -153,7 +154,7 @@ impl EventsService {
         cursor: Option<EventCursor>,
         limit: Option<u16>,
         reverse: bool,
-        path_prefix: Option<&str>,
+        path_filter: Option<&PathFilter>,
         user_ids: Option<&[i32]>,
         executor: &mut UnifiedExecutor<'a>,
     ) -> Result<Vec<EventEntity>, sqlx::Error> {
@@ -161,7 +162,7 @@ impl EventsService {
             cursor,
             limit,
             reverse,
-            path_prefix,
+            path_filter,
             user_ids,
             executor,
         )
@@ -218,7 +219,7 @@ impl EventsService {
                         last_cursor,
                         None,
                         filter.reverse,
-                        filter.path.as_ref().map(|p| p.as_str()),
+                        filter.path.as_ref(),
                         filter.user_ids.as_deref(),
                         &mut sql_db.pool().into(),
                     )
@@ -286,7 +287,7 @@ impl EventsService {
 }
 
 /// Whether a live broadcast event belongs in an all-events stream: not already sent (cursor dedup),
-/// inside the optional user filter, and under the optional path prefix.
+/// inside the optional user filter, and under the optional path filter.
 fn accept_live_event(
     event: &EventEntity,
     last_cursor: Option<EventCursor>,
@@ -303,7 +304,7 @@ fn accept_live_event(
         }
     }
     if let Some(path) = filter.path.as_ref() {
-        if !event.path.path().as_str().starts_with(path.as_str()) {
+        if !path.matches(event.path.path().as_str()) {
             return false;
         }
     }
@@ -465,13 +466,14 @@ mod tests {
             vec!["/pub/c", "/priv/y", "/pub/b", "/priv/x", "/pub/a"]
         );
 
-        // path_prefix filters to a storage root (private included).
+        // A directory path filter scopes to a storage root (private included).
+        let priv_filter = PathFilter::from(WebDavPath::new("/priv/").unwrap());
         let events = events_service
             .get_all_events(
                 None,
                 None,
                 false,
-                Some("/priv/"),
+                Some(&priv_filter),
                 None,
                 &mut db.pool().into(),
             )

--- a/pubky-homeserver/src/persistence/files/events/events_service.rs
+++ b/pubky-homeserver/src/persistence/files/events/events_service.rs
@@ -41,6 +41,17 @@ pub(crate) enum Mode {
     Reverse,
 }
 
+impl Mode {
+    /// Newest-first batch ordering.
+    fn reverse(self) -> bool {
+        matches!(self, Self::Reverse)
+    }
+    /// Stay open for live events after replaying history.
+    fn live(self) -> bool {
+        matches!(self, Self::ForwardLive)
+    }
+}
+
 /// Resolved filter for the admin all-events stream. The route builds this after authorizing the
 /// request (pubkeys → user ids, cursor parsed); it drives [`EventsService::all_events_stream`].
 pub(crate) struct AllEventsFilter {
@@ -216,10 +227,10 @@ impl EventsService {
 
             let mut last_cursor = filter.start_cursor;
             let mut total_sent: usize = 0;
-            let reverse = filter.mode == Mode::Reverse;
-            let live = filter.mode == Mode::ForwardLive;
+            let reverse = filter.mode.reverse();
+            let live = filter.mode.live();
 
-            // Phase 1: historical replay over a single advancing global cursor.
+            // Historical replay over a single advancing global cursor.
             loop {
                 // Drain buffered events; they'll be covered by this or a later DB query.
                 while rx.try_recv().is_ok() {}
@@ -268,7 +279,7 @@ impl EventsService {
                 }
             }
 
-            // Phase 2: live mode (only `Mode::ForwardLive` reaches here).
+            // The live tail, runs only for a live stream.
             if live {
                 loop {
                     match rx.recv().await {

--- a/pubky-homeserver/src/persistence/files/events/mod.rs
+++ b/pubky-homeserver/src/persistence/files/events/mod.rs
@@ -14,7 +14,7 @@ mod events_service;
 pub use events_entity::EventEntity;
 pub use events_layer::EventsLayer;
 pub use events_repository::{EventIden, EventRepository, EventVisibility};
-pub(crate) use events_service::PG_NOTIFY_CHANNEL;
+pub(crate) use events_service::{AllEventsFilter, PG_NOTIFY_CHANNEL};
 pub use events_service::{EventsService, MAX_EVENT_STREAM_USERS};
 
 // Re-export from pubky_common for convenience

--- a/pubky-homeserver/src/persistence/files/events/mod.rs
+++ b/pubky-homeserver/src/persistence/files/events/mod.rs
@@ -15,7 +15,7 @@ mod path_filter;
 pub use events_entity::EventEntity;
 pub use events_layer::EventsLayer;
 pub use events_repository::{EventIden, EventRepository, EventVisibility};
-pub(crate) use events_service::{AllEventsFilter, PG_NOTIFY_CHANNEL};
+pub(crate) use events_service::{AllEventsFilter, Mode, PG_NOTIFY_CHANNEL};
 pub use events_service::{EventsService, MAX_EVENT_STREAM_USERS};
 pub use path_filter::PathFilter;
 


### PR DESCRIPTION
## Summary

Closes [#427](https://github.com/pubky/pubky-core/issues/427)

Adds an admin-server counterpart to the client `GET /events-stream` SSE endpoint for operational tooling, moderation and debugging. Gated by the admin password (`X-Admin-Password`), it streams **all** events — public **and** private (`/priv/...`) — over Server-Sent Events.

It mirrors the client `/events-stream` contract (`limit`, `reverse`, `live`, repeatable `path`), with two admin differences: `user` is an *optional* filter (omit to stream every user) and a single global `cursor` paginates the combined feed. The streaming logic is shared via `EventsService::all_events_stream`. Because it surfaces private paths, the response is `Cache-Control: no-store`.

## Acceptance criteria
- [x] `GET /events-stream` with the admin password streams all events, including `/priv/...`, in batch and live mode.
- [x] `user` is optional (omit = all users); repeatable `path` filters union (file-vs-directory matching).
- [x] A single global `cursor` resumes the feed; `reverse` returns newest-first (batch only).
- [x] Missing or wrong admin password → `401`.
- [x] Malformed cursor → `400`.
- [x] Response is `Cache-Control: no-store`.
- [x] The public/client `GET /events-stream` stays unchanged (no regression).