### PR TITLE
chore: v0.10.0-alpha.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,23 @@ jobs:
       - name: Build and publish npm package
         working-directory: pubky-sdk/bindings/js/pkg
         run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+
+          if [[ "$VERSION" != *-* ]]; then
+            NPM_TAG="latest"
+          else
+            PRERELEASE="${VERSION#*-}"
+            case "$PRERELEASE" in
+              alpha*|beta*|rc*)
+                NPM_TAG="${PRERELEASE%%.*}"
+                ;;
+              *)
+                NPM_TAG="next"
+                ;;
+            esac
+          fi
+
+          echo "Publishing npm package with dist-tag: $NPM_TAG"
           npm ci
           npm run build
-          npm publish --provenance
+          npm publish --provenance --tag "$NPM_TAG"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,7 +1592,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e"
-version = "0.9.0"
+version = "0.10.0-alpha.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4023,7 +4023,7 @@ checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "pubky"
-version = "0.9.0"
+version = "0.10.0-alpha.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-common"
-version = "0.9.0"
+version = "0.10.0-alpha.0"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-core-examples"
-version = "0.9.0"
+version = "0.10.0-alpha.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-homeserver"
-version = "0.9.0"
+version = "0.10.0-alpha.0"
 dependencies = [
  "anyhow",
  "async-dropper",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-testnet"
-version = "0.9.0"
+version = "0.10.0-alpha.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4194,7 +4194,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-wasm"
-version = "0.9.0"
+version = "0.10.0-alpha.0"
 dependencies = [
  "base64 0.22.1",
  "console_log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0-alpha.0"
 rust-version = "1.89"
 edition = "2021"
 authors = [
@@ -54,10 +54,10 @@ js-sys = "0.3"
 log = "0.4"
 pkarr = { version = "6", default-features = false }
 pkarr-relay = { version = "0.12" }
-pubky = { path = "pubky-sdk", version = "0.9", default-features = false }
-pubky-common = { path = "pubky-common", version = "0.9" }
-pubky-homeserver = { path = "pubky-homeserver", version = "0.9", default-features = false }
-pubky-testnet = { path = "pubky-testnet", version = "0.9" }
+pubky = { path = "pubky-sdk", version = "0.10.0-alpha.0", default-features = false }
+pubky-common = { path = "pubky-common", version = "0.10.0-alpha.0" }
+pubky-homeserver = { path = "pubky-homeserver", version = "0.10.0-alpha.0", default-features = false }
+pubky-testnet = { path = "pubky-testnet", version = "0.10.0-alpha.0" }
 pubky_test_utils = { path = "test_utils/pubky_test", version = "0.1" }
 rand = "0.10"
 reqwest = { version = "0.13", default-features = false }

--- a/pubky-sdk/bindings/js/pkg/package-lock.json
+++ b/pubky-sdk/bindings/js/pkg/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@synonymdev/pubky",
-  "version": "0.9.0",
+  "version": "0.10.0-alpha.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@synonymdev/pubky",
-      "version": "0.9.0",
+      "version": "0.10.0-alpha.0",
       "license": "MIT",
       "dependencies": {
         "fetch-cookie": "^3.0.1"

--- a/pubky-sdk/bindings/js/pkg/package.json
+++ b/pubky-sdk/bindings/js/pkg/package.json
@@ -2,7 +2,7 @@
   "name": "@synonymdev/pubky",
   "type": "module",
   "description": "Pubky client",
-  "version": "0.9.0",
+  "version": "0.10.0-alpha.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This branch bumps the version to `v0.10.0-alpha.0`. 

It also updates the npm public workflow. So far, every release was a "latest" release even if it was an rc, alpha, or beta version. A latest release is installed when doing `npm install @synonymdev/pubky`. This is unnecessary and counterproductive with prereleases like this though.

WE DO NOT MERGE THIS PR. This is for review only. It sets certain versions from `0.10` to `0.10.0-alpha.0`. This is need for this release but not necessary for the main branch. This PR is for a review only. After approval, it is closed and the commit is tagged directly for a release.

Related: https://github.com/pubky/pubky-core/issues/401