### PR TITLE
feat: Add init cli command for generating config.toml and secrets

### DIFF
--- a/pubky-homeserver/src/data_directory/persistent_data_dir.rs
+++ b/pubky-homeserver/src/data_directory/persistent_data_dir.rs
@@ -61,6 +61,17 @@ impl PersistentDataDir {
     pub fn get_secret_file_path(&self) -> PathBuf {
         self.expanded_path.join("secret")
     }
+
+    /// Initialize the data directory without starting the server.
+    ///
+    /// Creates the directory, writes a sample config file (if absent),
+    /// and generates a server keypair (if absent).
+    pub fn init(&self) -> anyhow::Result<()> {
+        self.ensure_data_dir_exists_and_is_writable()?;
+        self.read_or_create_config_file()?;
+        self.read_or_create_keypair()?;
+        Ok(())
+    }
 }
 
 impl Default for PersistentDataDir {

--- a/pubky-homeserver/src/main.rs
+++ b/pubky-homeserver/src/main.rs
@@ -46,10 +46,8 @@ async fn main() -> Result<()> {
             let data_dir = PersistentDataDir::new(args.data_dir);
             data_dir.init()?;
             println!(
-                "Data directory initialized at {}.\n\
-                 Edit {} to configure PostgreSQL and other settings, then run `pubky-homeserver` to start.",
-                data_dir.path().display(),
-                data_dir.get_config_file_path().display(),
+                "Data directory initialized at {}.",
+                data_dir.path().display()
             );
         }
         None => {

--- a/pubky-homeserver/src/main.rs
+++ b/pubky-homeserver/src/main.rs
@@ -1,8 +1,10 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use clap::Parser;
-use pubky_homeserver::{tracing::init_tracing_logs_if_set, HomeserverApp};
+use clap::{Parser, Subcommand};
+use pubky_homeserver::{
+    tracing::init_tracing_logs_if_set, DataDir, HomeserverApp, PersistentDataDir,
+};
 
 fn default_config_dir_path() -> PathBuf {
     dirs::home_dir().unwrap_or_default().join(".pubky")
@@ -21,49 +23,73 @@ fn validate_config_dir_path(path: &str) -> Result<PathBuf, String> {
 #[derive(Parser, Debug)]
 #[command(version = env!("CARGO_PKG_VERSION"))]
 struct Cli {
-    /// Path to config file. Defaults to ~/.pubky/config.toml
+    /// Path to data directory. Defaults to ~/.pubky
     #[clap(short, long, default_value_os_t = default_config_dir_path(), value_parser = validate_config_dir_path)]
     data_dir: PathBuf,
+
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand, Debug)]
+enum Command {
+    /// Initialize the data directory (config and keypair) without starting the server.
+    Init,
 }
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Cli::parse();
-    init_tracing_logs_if_set(&args.data_dir)?;
 
-    tracing::info!("Use data directory: {}", args.data_dir.display());
-    let server = HomeserverApp::start_with_persistent_data_dir_path(args.data_dir).await?;
+    match args.command {
+        Some(Command::Init) => {
+            let data_dir = PersistentDataDir::new(args.data_dir);
+            data_dir.init()?;
+            println!(
+                "Data directory initialized at {}.\n\
+                 Edit {} to configure PostgreSQL and other settings, then run `pubky-homeserver` to start.",
+                data_dir.path().display(),
+                data_dir.get_config_file_path().display(),
+            );
+        }
+        None => {
+            init_tracing_logs_if_set(&args.data_dir)?;
 
-    tracing::info!(
-        "Homeserver HTTP listening on {}",
-        server.client_server().icann_http_url_string()
-    );
+            tracing::info!("Use data directory: {}", args.data_dir.display());
+            let server = HomeserverApp::start_with_persistent_data_dir_path(args.data_dir).await?;
 
-    tracing::info!(
-        "Homeserver Pubky TLS listening on {}",
-        server.client_server().pubky_tls_dns_url_string(),
-    );
-    tracing::info!(
-        "Homeserver Pubky TLS listening on {}",
-        server.client_server().pubky_tls_ip_url_ring()
-    );
-    if let Some(admin_server) = server.admin_server() {
-        tracing::info!(
-            "Admin server listening on http://{}",
-            admin_server.listen_socket()
-        );
+            tracing::info!(
+                "Homeserver HTTP listening on {}",
+                server.client_server().icann_http_url_string()
+            );
+
+            tracing::info!(
+                "Homeserver Pubky TLS listening on {}",
+                server.client_server().pubky_tls_dns_url_string(),
+            );
+            tracing::info!(
+                "Homeserver Pubky TLS listening on {}",
+                server.client_server().pubky_tls_ip_url_ring()
+            );
+            if let Some(admin_server) = server.admin_server() {
+                tracing::info!(
+                    "Admin server listening on http://{}",
+                    admin_server.listen_socket()
+                );
+            }
+            if let Some(metrics_server) = server.metrics_server() {
+                tracing::info!(
+                    "Metrics server listening on http://{}",
+                    metrics_server.listen_socket()
+                );
+            }
+
+            tracing::info!("Press Ctrl+C to stop the Homeserver");
+            tokio::signal::ctrl_c().await?;
+
+            tracing::info!("Shutting down Homeserver");
+        }
     }
-    if let Some(metrics_server) = server.metrics_server() {
-        tracing::info!(
-            "Metrics server listening on http://{}",
-            metrics_server.listen_socket()
-        );
-    }
-
-    tracing::info!("Press Ctrl+C to stop the Homeserver");
-    tokio::signal::ctrl_c().await?;
-
-    tracing::info!("Shutting down Homeserver");
 
     Ok(())
 }


### PR DESCRIPTION
Create config.toml without having to run Homeserver. This will be replaced by the [Homeserver CLI](https://github.com/pubky/pubky-core/pull/451) work but is useful now for the [new docs](https://github.com/pubky/pubky-core/pull/431).