### PR TITLE
chore: v0.9.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1592,7 +1592,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e"
-version = "0.9.0"
+version = "0.9.3"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4023,7 +4023,7 @@ checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "pubky"
-version = "0.9.0"
+version = "0.9.3"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4054,7 +4054,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-common"
-version = "0.9.0"
+version = "0.9.3"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -4073,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-core-examples"
-version = "0.9.0"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4092,7 +4092,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-homeserver"
-version = "0.9.0"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "async-dropper",
@@ -4156,7 +4156,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-testnet"
-version = "0.9.0"
+version = "0.9.3"
 dependencies = [
  "anyhow",
  "clap",
@@ -4194,7 +4194,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-wasm"
-version = "0.9.0"
+version = "0.9.3"
 dependencies = [
  "base64 0.22.1",
  "console_log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.9.3"
 rust-version = "1.89"
 edition = "2021"
 authors = [

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -104,7 +104,7 @@ git push origin v0.8.1
 
 ### 4. Back-port to main
 
-After the release, cherry-pick or merge the fix into `main` so it isn't lost:
+After the release, cherry-pick or merge the fix and version bump into `main` so it isn't lost:
 
 ```bash
 git checkout main

--- a/pubky-sdk/bindings/js/pkg/package-lock.json
+++ b/pubky-sdk/bindings/js/pkg/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@synonymdev/pubky",
-  "version": "0.9.0",
+  "version": "0.9.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@synonymdev/pubky",
-      "version": "0.9.0",
+      "version": "0.9.3",
       "license": "MIT",
       "dependencies": {
         "fetch-cookie": "^3.0.1"

--- a/pubky-sdk/bindings/js/pkg/package.json
+++ b/pubky-sdk/bindings/js/pkg/package.json
@@ -2,7 +2,7 @@
   "name": "@synonymdev/pubky",
   "type": "module",
   "description": "Decentralized identity, auth flows, and user-owned storage",
-  "version": "0.9.0",
+  "version": "0.9.3",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This should have been cherry-picked from hot fix `v0.9.3` branch https://github.com/pubky/pubky-core/tree/hot_fix_v0.9.3.