### PR TITLE
feat(sdk): subscribe to private events

### DIFF
--- a/e2e/src/tests/events/stream_private.rs
+++ b/e2e/src/tests/events/stream_private.rs
@@ -375,3 +375,121 @@ async fn events_stream_live_authorized_receives_private() {
         "authorized live subscriber should receive the in-scope private event"
     );
 }
+
+/// Sign up a fresh cookie user; return its pubkey, the (kept-alive) session, and
+/// the raw `name=value` Cookie header for its session secret.
+async fn cookie_user(
+    testnet: &pubky_testnet::EphemeralTestnet,
+) -> (
+    pubky_testnet::pubky::PublicKey,
+    pubky_testnet::pubky::PubkySession,
+    String,
+) {
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+    let signer = pubky.signer(Keypair::random());
+    let session = signer
+        .signup_cookie(&server.public_key(), None)
+        .await
+        .unwrap();
+    // `export_secret()` returns `<pubkey_z32>:<secret>`; the wire cookie is
+    // `<pubkey_z32>=<secret>`.
+    let token = session.as_cookie().unwrap().export_secret().unwrap();
+    let (name, value) = token.split_once(':').unwrap();
+    (signer.public_key(), session, format!("{name}={value}"))
+}
+
+/// Raw `/events-stream?user=A&path=/priv/app/` with A's session cookie is
+/// authenticated (200): the server resolves the cookie by the single `user=`
+/// tenant even though the endpoint is homeserver-addressed.
+#[tokio::test]
+#[pubky_testnet::test]
+async fn events_stream_cookie_same_tenant_is_authorized() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+    let server_host = server.public_key().z32();
+
+    let (a, session, cookie) = cookie_user(&testnet).await;
+    session
+        .storage()
+        .put("/priv/app/secret.txt", vec![1])
+        .await
+        .unwrap();
+
+    let url = format!(
+        "https://{}/events-stream?user={}&path=/priv/app/&limit=1",
+        server_host,
+        a.z32()
+    );
+    let response = pubky
+        .client()
+        .request(Method::GET, &url)
+        .header("Cookie", cookie)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+/// A valid cookie value for A, presented under user B's cookie name for
+/// `user=B`, does not authenticate: the session belongs to A, not B → 401.
+#[tokio::test]
+#[pubky_testnet::test]
+async fn events_stream_cookie_cross_user_secret_is_unauthenticated() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+    let server_host = server.public_key().z32();
+
+    let (_a, _session, a_cookie) = cookie_user(&testnet).await;
+    let a_secret = a_cookie.split_once('=').unwrap().1.to_string();
+    let b = Keypair::random().public_key();
+
+    let url = format!(
+        "https://{}/events-stream?user={}&path=/priv/app/",
+        server_host,
+        b.z32()
+    );
+    let response = pubky
+        .client()
+        .request(Method::GET, &url)
+        .header("Cookie", format!("{}={}", b.z32(), a_secret))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// A valid cookie plus an invalid `Authorization: Bearer` is rejected: a
+/// presented bearer disables the cookie fallback (conservative precedence).
+#[tokio::test]
+#[pubky_testnet::test]
+async fn events_stream_cookie_not_used_when_bearer_present() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+    let server_host = server.public_key().z32();
+
+    let (a, session, cookie) = cookie_user(&testnet).await;
+    session
+        .storage()
+        .put("/priv/app/secret.txt", vec![1])
+        .await
+        .unwrap();
+
+    let url = format!(
+        "https://{}/events-stream?user={}&path=/priv/app/",
+        server_host,
+        a.z32()
+    );
+    let response = pubky
+        .client()
+        .request(Method::GET, &url)
+        .header("Cookie", cookie)
+        .header("Authorization", "Bearer not-a-real-token")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}

--- a/e2e/src/tests/events/stream_sdk.rs
+++ b/e2e/src/tests/events/stream_sdk.rs
@@ -2,7 +2,7 @@ use super::*;
 use futures::StreamExt;
 use pubky_testnet::pubky::errors::{Error, RequestError};
 use pubky_testnet::pubky::{ClientId, EventCursor, PubkySession, PublicKey};
-use tokio::time::{Duration, timeout};
+use tokio::time::{timeout, Duration};
 
 /// Sign up a fresh user and return its public key plus an authenticated
 /// (root-capability) grant session.

--- a/e2e/src/tests/events/stream_sdk.rs
+++ b/e2e/src/tests/events/stream_sdk.rs
@@ -1,4 +1,32 @@
 use super::*;
+use pubky_testnet::pubky::errors::{Error, RequestError};
+use pubky_testnet::pubky::{ClientId, PubkySession, PublicKey};
+
+/// Sign up a fresh user and return its public key plus an authenticated
+/// (root-capability) grant session.
+async fn signed_in_user(
+    testnet: &pubky_testnet::EphemeralTestnet,
+    client_id: &str,
+) -> (PublicKey, PubkySession) {
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+    let signer = pubky.signer(Keypair::random());
+    signer.signup(&server.public_key(), None).await.unwrap();
+    let session = signer
+        .signin(ClientId::new(client_id).unwrap())
+        .await
+        .unwrap();
+    (signer.public_key(), session)
+}
+
+/// Extract the HTTP status from a typed server-rejection error, so tests assert
+/// against `RequestError::Server { status, .. }` rather than a raw string.
+fn server_status(err: &Error) -> Option<StatusCode> {
+    match err {
+        Error::Request(RequestError::Server { status, .. }) => Some(*status),
+        _ => None,
+    }
+}
 
 /// Test the SDK builder API: `event_stream_for()` and `add_users()`
 /// This tests the high-level SDK interface rather than raw HTTP requests.
@@ -297,5 +325,175 @@ async fn events_stream_sdk_builder_api() {
         err.contains("50 users"),
         "add_users: Error should mention 50 user limit, got: {}",
         err
+    );
+}
+
+/// An authenticated owner subscribing via the SDK builder with
+/// `.session()` + a `/priv/` path receives that user's private events, scoped
+/// to the requested filter.
+#[tokio::test]
+#[pubky_testnet::test]
+async fn events_stream_sdk_private_authorized_receives() {
+    use futures::StreamExt;
+
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+    let (user, session) = signed_in_user(&testnet, "sdk-owner.test").await;
+
+    session.storage().put("/pub/a.txt", vec![1]).await.unwrap();
+    session
+        .storage()
+        .put("/priv/app/secret.txt", vec![2])
+        .await
+        .unwrap();
+    session
+        .storage()
+        .put("/priv/other/z.txt", vec![3])
+        .await
+        .unwrap();
+
+    // Single-user, authenticated, filtered to `/priv/app/`.
+    let mut stream = pubky
+        .event_stream_for(&server.public_key())
+        .add_users([(&user, None)])
+        .unwrap()
+        .session(&session)
+        .path("/priv/app/")
+        .limit(1)
+        .subscribe()
+        .await
+        .unwrap();
+
+    let event = stream
+        .next()
+        .await
+        .expect("should receive the in-scope private event")
+        .unwrap();
+    assert_eq!(event.resource.owner.z32(), user.z32());
+    assert!(
+        event
+            .resource
+            .path
+            .as_str()
+            .contains("/priv/app/secret.txt"),
+        "expected the in-scope private event, got: {}",
+        event.resource.path
+    );
+}
+
+/// A mixed `/pub/` + `/priv/app/` subscription returns the union
+/// and never an unrequested private scope.
+#[tokio::test]
+#[pubky_testnet::test]
+async fn events_stream_sdk_private_union_excludes_unrequested() {
+    use futures::StreamExt;
+
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+    let (user, session) = signed_in_user(&testnet, "sdk-union.test").await;
+
+    session.storage().put("/pub/a.txt", vec![1]).await.unwrap();
+    session
+        .storage()
+        .put("/priv/app/secret.txt", vec![2])
+        .await
+        .unwrap();
+    session
+        .storage()
+        .put("/priv/other/z.txt", vec![3])
+        .await
+        .unwrap();
+
+    let mut stream = pubky
+        .event_stream_for(&server.public_key())
+        .add_users([(&user, None)])
+        .unwrap()
+        .session(&session)
+        .path("/pub/")
+        .path("/priv/app/")
+        .limit(2)
+        .subscribe()
+        .await
+        .unwrap();
+
+    let mut paths = Vec::new();
+    while let Some(result) = stream.next().await {
+        let event = result.unwrap();
+        let p = event.resource.path.to_string();
+        assert!(
+            !p.contains("/priv/other/"),
+            "union leaked an unrequested private scope: {p}"
+        );
+        paths.push(p);
+        if paths.len() >= 2 {
+            break;
+        }
+    }
+    assert!(paths.iter().any(|p| p.contains("/pub/a.txt")));
+    assert!(paths.iter().any(|p| p.contains("/priv/app/secret.txt")));
+}
+
+/// A private-path subscription with no session is rejected by the
+/// homeserver and surfaced as a typed `401 Unauthorized`.
+#[tokio::test]
+#[pubky_testnet::test]
+async fn events_stream_sdk_private_without_session_is_unauthorized() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+    let (user, _session) = signed_in_user(&testnet, "sdk-401.test").await;
+
+    // No `.session()` → the homeserver rejects the private path.
+    let result = pubky
+        .event_stream_for(&server.public_key())
+        .add_users([(&user, None)])
+        .unwrap()
+        .path("/priv/app/")
+        .subscribe()
+        .await;
+
+    let err = match result {
+        Ok(_) => panic!("private path without a session must be rejected"),
+        Err(e) => e,
+    };
+    assert_eq!(
+        server_status(&err),
+        Some(StatusCode::UNAUTHORIZED),
+        "expected a typed 401 Server error, got: {err}"
+    );
+}
+
+/// A session may not read another user's private events; the homeserver
+/// rejection surfaces as a typed `403 Forbidden`.
+#[tokio::test]
+#[pubky_testnet::test]
+async fn events_stream_sdk_private_wrong_user_is_forbidden() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+
+    let (_a, session_a) = signed_in_user(&testnet, "sdk-403-a.test").await;
+    let (b, _session_b) = signed_in_user(&testnet, "sdk-403-b.test").await;
+
+    // A's session requesting B's private events → 403 (server-enforced).
+    let result = pubky
+        .event_stream_for(&server.public_key())
+        .add_users([(&b, None)])
+        .unwrap()
+        .session(&session_a)
+        .path("/priv/app/")
+        .subscribe()
+        .await;
+
+    let err = match result {
+        Ok(_) => panic!("a session may not read another user's private events"),
+        Err(e) => e,
+    };
+    assert_eq!(
+        server_status(&err),
+        Some(StatusCode::FORBIDDEN),
+        "expected a typed 403 Server error, got: {err}"
     );
 }

--- a/e2e/src/tests/events/stream_sdk.rs
+++ b/e2e/src/tests/events/stream_sdk.rs
@@ -1,6 +1,8 @@
 use super::*;
+use futures::StreamExt;
 use pubky_testnet::pubky::errors::{Error, RequestError};
-use pubky_testnet::pubky::{ClientId, PubkySession, PublicKey};
+use pubky_testnet::pubky::{ClientId, EventCursor, PubkySession, PublicKey};
+use tokio::time::{timeout, Duration};
 
 /// Sign up a fresh user and return its public key plus an authenticated
 /// (root-capability) grant session.
@@ -33,10 +35,6 @@ fn server_status(err: &Error) -> Option<StatusCode> {
 #[tokio::test]
 #[pubky_testnet::test]
 async fn events_stream_sdk_builder_api() {
-    use futures::StreamExt;
-    use pubky_testnet::pubky::EventCursor;
-    use tokio::time::{timeout, Duration};
-
     let testnet = build_full_testnet().await;
     let server = testnet.homeserver_app();
     let pubky = testnet.sdk().unwrap();
@@ -328,14 +326,13 @@ async fn events_stream_sdk_builder_api() {
     );
 }
 
-/// An authenticated owner subscribing via the SDK builder with
-/// `.session()` + a `/priv/` path receives that user's private events, scoped
-/// to the requested filter.
+/// An authenticated owner receives their own private events through the SDK
+/// builder: a single `/priv/app/` filter yields only the in-scope event, and a
+/// mixed `/pub/` + `/priv/app/` subscription returns the union without leaking
+/// an unrequested private scope.
 #[tokio::test]
 #[pubky_testnet::test]
-async fn events_stream_sdk_private_authorized_receives() {
-    use futures::StreamExt;
-
+async fn events_stream_sdk_private_authorized_scoping() {
     let testnet = build_full_testnet().await;
     let server = testnet.homeserver_app();
     let pubky = testnet.sdk().unwrap();
@@ -353,7 +350,7 @@ async fn events_stream_sdk_private_authorized_receives() {
         .await
         .unwrap();
 
-    // Single-user, authenticated, filtered to `/priv/app/`.
+    // A single `/priv/app/` filter yields only the in-scope private event.
     let mut stream = pubky
         .event_stream_for(&server.public_key())
         .add_users([(&user, None)])
@@ -380,32 +377,10 @@ async fn events_stream_sdk_private_authorized_receives() {
         "expected the in-scope private event, got: {}",
         event.resource.path
     );
-}
+    drop(stream);
 
-/// A mixed `/pub/` + `/priv/app/` subscription returns the union
-/// and never an unrequested private scope.
-#[tokio::test]
-#[pubky_testnet::test]
-async fn events_stream_sdk_private_union_excludes_unrequested() {
-    use futures::StreamExt;
-
-    let testnet = build_full_testnet().await;
-    let server = testnet.homeserver_app();
-    let pubky = testnet.sdk().unwrap();
-    let (user, session) = signed_in_user(&testnet, "sdk-union.test").await;
-
-    session.storage().put("/pub/a.txt", vec![1]).await.unwrap();
-    session
-        .storage()
-        .put("/priv/app/secret.txt", vec![2])
-        .await
-        .unwrap();
-    session
-        .storage()
-        .put("/priv/other/z.txt", vec![3])
-        .await
-        .unwrap();
-
+    // A mixed `/pub/` + `/priv/app/` subscription returns the union and never
+    // the unrequested `/priv/other/` scope.
     let mut stream = pubky
         .event_stream_for(&server.public_key())
         .add_users([(&user, None)])
@@ -454,10 +429,9 @@ async fn events_stream_sdk_private_without_session_is_unauthorized() {
         .subscribe()
         .await;
 
-    let err = match result {
-        Ok(_) => panic!("private path without a session must be rejected"),
-        Err(e) => e,
-    };
+    let err = result
+        .err()
+        .expect("private path without a session must be rejected");
     assert_eq!(
         server_status(&err),
         Some(StatusCode::UNAUTHORIZED),
@@ -487,10 +461,9 @@ async fn events_stream_sdk_private_wrong_user_is_forbidden() {
         .subscribe()
         .await;
 
-    let err = match result {
-        Ok(_) => panic!("a session may not read another user's private events"),
-        Err(e) => e,
-    };
+    let err = result
+        .err()
+        .expect("a session may not read another user's private events");
     assert_eq!(
         server_status(&err),
         Some(StatusCode::FORBIDDEN),
@@ -520,10 +493,9 @@ async fn events_stream_sdk_session_rejects_foreign_homeserver() {
         .subscribe()
         .await;
 
-    let err = match result {
-        Ok(_) => panic!("must refuse to send the session credential to a foreign homeserver"),
-        Err(e) => e,
-    };
+    let err = result
+        .err()
+        .expect("must refuse to send the session credential to a foreign homeserver");
     // Rejected client-side (no server was contacted), so there is no HTTP status.
     assert!(
         server_status(&err).is_none(),

--- a/e2e/src/tests/events/stream_sdk.rs
+++ b/e2e/src/tests/events/stream_sdk.rs
@@ -471,38 +471,66 @@ async fn events_stream_sdk_private_wrong_user_is_forbidden() {
     );
 }
 
-/// The session credential must never be sent to a homeserver that
-/// isn't the session owner's. Pointing the builder at a foreign homeserver
-/// fails early, client-side, before any request is issued.
+/// Attaching a session must not hijack the subscription's target.
+/// With two homeservers, subscribing to a user on HS2 while holding a session on
+/// HS1 still targets HS2 — the session is simply not attached (owner ≠ target).
 #[tokio::test]
 #[pubky_testnet::test]
-async fn events_stream_sdk_session_rejects_foreign_homeserver() {
-    let testnet = build_full_testnet().await;
-    let pubky = testnet.sdk().unwrap();
-    let (user, session) = signed_in_user(&testnet, "sdk-leak.test").await;
-
-    // A homeserver pubkey that is NOT the session owner's.
-    let foreign_homeserver = Keypair::random().public_key();
-
-    let result = pubky
-        .event_stream_for(&foreign_homeserver)
-        .add_users([(&user, None)])
+async fn events_stream_sdk_session_does_not_override_target_homeserver() {
+    let mut testnet = build_full_testnet().await;
+    let hs1 = testnet.homeserver_app().public_key();
+    let hs2 = testnet
+        .create_random_homeserver()
+        .await
         .unwrap()
-        .session(&session)
-        .path("/priv/app/")
-        .subscribe()
-        .await;
+        .public_key();
+    assert_ne!(hs1, hs2, "test needs two distinct homeservers");
 
-    let err = result
-        .err()
-        .expect("must refuse to send the session credential to a foreign homeserver");
-    // Rejected client-side (no server was contacted), so there is no HTTP status.
+    let pubky = testnet.sdk().unwrap();
+
+    // `me` holds a session on HS1.
+    let me = pubky.signer(Keypair::random());
+    me.signup(&hs1, None).await.unwrap();
+    let my_session = me
+        .signin(ClientId::new("sdk-override.test").unwrap())
+        .await
+        .unwrap();
+
+    // `other` lives on HS2 and writes a public event there.
+    let other_signer = pubky.signer(Keypair::random());
+    other_signer.signup(&hs2, None).await.unwrap();
+    let other = other_signer.public_key();
+    let other_session = other_signer
+        .signin(ClientId::new("sdk-override-other.test").unwrap())
+        .await
+        .unwrap();
+    other_session
+        .storage()
+        .put("/pub/hello.txt", vec![1])
+        .await
+        .unwrap();
+
+    // Subscribe to `other`'s public events with MY (HS1) session attached. The
+    // builder must resolve `other`'s homeserver (HS2), not mine (HS1), and stream
+    // `other`'s event; the mismatched session is silently not attached.
+    let mut stream = pubky
+        .event_stream_for_user(&other, None)
+        .session(&my_session)
+        .path("/pub/")
+        .limit(1)
+        .subscribe()
+        .await
+        .unwrap();
+
+    let event = stream
+        .next()
+        .await
+        .expect("should receive other's public event from their own homeserver")
+        .unwrap();
+    assert_eq!(event.resource.owner.z32(), other.z32());
     assert!(
-        server_status(&err).is_none(),
-        "should fail before contacting any server, got: {err}"
-    );
-    assert!(
-        err.to_string().contains("homeserver"),
-        "error should explain the homeserver mismatch, got: {err}"
+        event.resource.path.as_str().contains("/pub/hello.txt"),
+        "expected other's public event, got: {}",
+        event.resource.path
     );
 }

--- a/e2e/src/tests/events/stream_sdk.rs
+++ b/e2e/src/tests/events/stream_sdk.rs
@@ -2,7 +2,7 @@ use super::*;
 use futures::StreamExt;
 use pubky_testnet::pubky::errors::{Error, RequestError};
 use pubky_testnet::pubky::{ClientId, EventCursor, PubkySession, PublicKey};
-use tokio::time::{timeout, Duration};
+use tokio::time::{Duration, timeout};
 
 /// Sign up a fresh user and return its public key plus an authenticated
 /// (root-capability) grant session.
@@ -627,6 +627,54 @@ async fn events_stream_sdk_cookie_backed_private_authorized() {
     assert!(
         !event.resource.path.as_str().contains("/priv/other/"),
         "out-of-scope private event leaked: {}",
+        event.resource.path
+    );
+}
+
+/// A locally signed cookie signin binds to the homeserver used for `/session`,
+/// so its private stream can authenticate immediately.
+#[tokio::test]
+#[pubky_testnet::test]
+async fn events_stream_sdk_signin_cookie_private_authorized() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+
+    let signer = pubky.signer(Keypair::random());
+    signer.signup(&server.public_key(), None).await.unwrap();
+    let session = signer.signin_cookie().await.unwrap();
+    let user = signer.public_key();
+
+    session
+        .storage()
+        .put("/priv/app/signin-cookie.txt", vec![42])
+        .await
+        .unwrap();
+
+    let mut stream = pubky
+        .event_stream_for(&server.public_key())
+        .add_users([(&user, None)])
+        .unwrap()
+        .session(&session)
+        .path("/priv/app/")
+        .limit(1)
+        .subscribe()
+        .await
+        .unwrap();
+
+    let event = stream
+        .next()
+        .await
+        .expect("signin-cookie session should receive its private event")
+        .unwrap();
+    assert_eq!(event.resource.owner.z32(), user.z32());
+    assert!(
+        event
+            .resource
+            .path
+            .as_str()
+            .contains("/priv/app/signin-cookie.txt"),
+        "expected the signin-cookie private event, got: {}",
         event.resource.path
     );
 }

--- a/e2e/src/tests/events/stream_sdk.rs
+++ b/e2e/src/tests/events/stream_sdk.rs
@@ -326,10 +326,6 @@ async fn events_stream_sdk_builder_api() {
     );
 }
 
-/// An authenticated owner receives their own private events through the SDK
-/// builder: a single `/priv/app/` filter yields only the in-scope event, and a
-/// mixed `/pub/` + `/priv/app/` subscription returns the union without leaking
-/// an unrequested private scope.
 #[tokio::test]
 #[pubky_testnet::test]
 async fn events_stream_sdk_private_authorized_scoping() {
@@ -350,7 +346,6 @@ async fn events_stream_sdk_private_authorized_scoping() {
         .await
         .unwrap();
 
-    // A single `/priv/app/` filter yields only the in-scope private event.
     let mut stream = pubky
         .event_stream_for(&server.public_key())
         .add_users([(&user, None)])
@@ -379,8 +374,6 @@ async fn events_stream_sdk_private_authorized_scoping() {
     );
     drop(stream);
 
-    // A mixed `/pub/` + `/priv/app/` subscription returns the union and never
-    // the unrequested `/priv/other/` scope.
     let mut stream = pubky
         .event_stream_for(&server.public_key())
         .add_users([(&user, None)])
@@ -410,104 +403,6 @@ async fn events_stream_sdk_private_authorized_scoping() {
     assert!(paths.iter().any(|p| p.contains("/priv/app/secret.txt")));
 }
 
-/// A private-path subscription with no session is rejected by the
-/// homeserver and surfaced as a typed `401 Unauthorized`.
-#[tokio::test]
-#[pubky_testnet::test]
-async fn events_stream_sdk_private_without_session_is_unauthorized() {
-    let testnet = build_full_testnet().await;
-    let server = testnet.homeserver_app();
-    let pubky = testnet.sdk().unwrap();
-    let (user, _session) = signed_in_user(&testnet, "sdk-401.test").await;
-
-    // No `.session()` → the homeserver rejects the private path.
-    let result = pubky
-        .event_stream_for(&server.public_key())
-        .add_users([(&user, None)])
-        .unwrap()
-        .path("/priv/app/")
-        .subscribe()
-        .await;
-
-    let err = result
-        .err()
-        .expect("private path without a session must be rejected");
-    assert_eq!(
-        server_status(&err),
-        Some(StatusCode::UNAUTHORIZED),
-        "expected a typed 401 Server error, got: {err}"
-    );
-}
-
-/// A session must not read another user's private events. The SDK scopes a
-/// private subscription to the credential's own user, so A's session is *not*
-/// attached to B's private stream.
-#[tokio::test]
-#[pubky_testnet::test]
-async fn events_stream_sdk_wrong_user_private_stream_is_not_attached() {
-    let testnet = build_full_testnet().await;
-    let server = testnet.homeserver_app();
-    let pubky = testnet.sdk().unwrap();
-
-    let (_a, session_a) = signed_in_user(&testnet, "sdk-401-a.test").await;
-    let (b, _session_b) = signed_in_user(&testnet, "sdk-401-b.test").await;
-
-    // A's session requesting B's private events: the SDK refuses to attach A's
-    // credential to a private stream scoped to B, so the request is anonymous.
-    let result = pubky
-        .event_stream_for(&server.public_key())
-        .add_users([(&b, None)])
-        .unwrap()
-        .session(&session_a)
-        .path("/priv/app/")
-        .subscribe()
-        .await;
-
-    let err = result
-        .err()
-        .expect("a session may not read another user's private events");
-    assert_eq!(
-        server_status(&err),
-        Some(StatusCode::UNAUTHORIZED),
-        "expected a typed 401 Server error (credential not attached), got: {err}"
-    );
-}
-
-/// A session must not be attached to a multi-user private subscription
-#[tokio::test]
-#[pubky_testnet::test]
-async fn events_stream_sdk_multi_user_private_stream_is_not_attached() {
-    let testnet = build_full_testnet().await;
-    let server = testnet.homeserver_app();
-    let pubky = testnet.sdk().unwrap();
-
-    let (a, session_a) = signed_in_user(&testnet, "sdk-multi-a.test").await;
-    let (b, _session_b) = signed_in_user(&testnet, "sdk-multi-b.test").await;
-
-    // A's session on a subscription naming both A and B with a private path: the
-    // SDK won't attach a credential to a multi-user private stream.
-    let result = pubky
-        .event_stream_for(&server.public_key())
-        .add_users([(&a, None), (&b, None)])
-        .unwrap()
-        .session(&session_a)
-        .path("/priv/app/")
-        .subscribe()
-        .await;
-
-    let err = result
-        .err()
-        .expect("a multi-user private subscription must not be authenticated");
-    assert_eq!(
-        server_status(&err),
-        Some(StatusCode::UNAUTHORIZED),
-        "expected a typed 401 Server error (credential not attached), got: {err}"
-    );
-}
-
-/// Attaching a session must not hijack the subscription's target.
-/// With two homeservers, subscribing to a user on HS2 while holding a session on
-/// HS1 still targets HS2 — the session is simply not attached (owner ≠ target).
 #[tokio::test]
 #[pubky_testnet::test]
 async fn events_stream_sdk_session_does_not_override_target_homeserver() {
@@ -522,7 +417,6 @@ async fn events_stream_sdk_session_does_not_override_target_homeserver() {
 
     let pubky = testnet.sdk().unwrap();
 
-    // `me` holds a session on HS1.
     let me = pubky.signer(Keypair::random());
     me.signup(&hs1, None).await.unwrap();
     let my_session = me
@@ -530,7 +424,6 @@ async fn events_stream_sdk_session_does_not_override_target_homeserver() {
         .await
         .unwrap();
 
-    // `other` lives on HS2 and writes a public event there.
     let other_signer = pubky.signer(Keypair::random());
     other_signer.signup(&hs2, None).await.unwrap();
     let other = other_signer.public_key();
@@ -544,9 +437,6 @@ async fn events_stream_sdk_session_does_not_override_target_homeserver() {
         .await
         .unwrap();
 
-    // Subscribe to `other`'s public events with MY (HS1) session attached. The
-    // builder must resolve `other`'s homeserver (HS2), not mine (HS1), and stream
-    // `other`'s event; the mismatched session is silently not attached.
     let mut stream = pubky
         .event_stream_for_user(&other, None)
         .session(&my_session)
@@ -569,70 +459,6 @@ async fn events_stream_sdk_session_does_not_override_target_homeserver() {
     );
 }
 
-/// A cookie-backed session authenticates its own single-user private stream
-/// (bound to its homeserver at signup); the path filter still excludes an
-/// out-of-scope private event.
-#[tokio::test]
-#[pubky_testnet::test]
-async fn events_stream_sdk_cookie_backed_private_authorized() {
-    let testnet = build_full_testnet().await;
-    let server = testnet.homeserver_app();
-    let pubky = testnet.sdk().unwrap();
-
-    let signer = pubky.signer(Keypair::random());
-    let session = signer
-        .signup_cookie(&server.public_key(), None)
-        .await
-        .unwrap();
-    let user = signer.public_key();
-
-    session
-        .storage()
-        .put("/priv/app/secret.txt", vec![42])
-        .await
-        .unwrap();
-    // An out-of-scope private write that the `/priv/app/` filter must exclude.
-    session
-        .storage()
-        .put("/priv/other/z.txt", vec![7])
-        .await
-        .unwrap();
-
-    let mut stream = pubky
-        .event_stream_for(&server.public_key())
-        .add_users([(&user, None)])
-        .unwrap()
-        .session(&session)
-        .path("/priv/app/")
-        .limit(1)
-        .subscribe()
-        .await
-        .unwrap();
-
-    let event = stream
-        .next()
-        .await
-        .expect("cookie-backed session should receive its in-scope private event")
-        .unwrap();
-    assert_eq!(event.resource.owner.z32(), user.z32());
-    assert!(
-        event
-            .resource
-            .path
-            .as_str()
-            .contains("/priv/app/secret.txt"),
-        "expected the in-scope private event, got: {}",
-        event.resource.path
-    );
-    assert!(
-        !event.resource.path.as_str().contains("/priv/other/"),
-        "out-of-scope private event leaked: {}",
-        event.resource.path
-    );
-}
-
-/// A locally signed cookie signin binds to the homeserver used for `/session`,
-/// so its private stream can authenticate immediately.
 #[tokio::test]
 #[pubky_testnet::test]
 async fn events_stream_sdk_signin_cookie_private_authorized() {
@@ -679,10 +505,6 @@ async fn events_stream_sdk_signin_cookie_private_authorized() {
     );
 }
 
-/// A cookie bound to HS1 must not grant private access when targeting HS2: the
-/// subscribe fails `401`. Outcome-only — HS2 returns `401` whether or not the
-/// cookie was sent (it holds no matching session); non-attachment itself is
-/// proven by the `can_attach_to` unit tests in the cookie credential.
 #[tokio::test]
 #[pubky_testnet::test]
 async fn events_stream_sdk_cookie_bound_homeserver_is_enforced() {
@@ -720,96 +542,6 @@ async fn events_stream_sdk_cookie_bound_homeserver_is_enforced() {
     );
 }
 
-/// A cookie session for A must not grant private access to a stream scoped to B:
-/// the subscribe fails `401`. Outcome-only — B's stream returns `401` whether or
-/// not A's cookie was sent; the gate's non-attachment (B ≠ credential user) is
-/// proven by the `should_attach_credential` unit tests in the event stream.
-#[tokio::test]
-#[pubky_testnet::test]
-async fn events_stream_sdk_cookie_wrong_user_private_is_not_attached() {
-    let testnet = build_full_testnet().await;
-    let server = testnet.homeserver_app();
-    let pubky = testnet.sdk().unwrap();
-
-    let signer_a = pubky.signer(Keypair::random());
-    let session_a = signer_a
-        .signup_cookie(&server.public_key(), None)
-        .await
-        .unwrap();
-
-    let signer_b = pubky.signer(Keypair::random());
-    signer_b
-        .signup_cookie(&server.public_key(), None)
-        .await
-        .unwrap();
-    let b = signer_b.public_key();
-
-    let result = pubky
-        .event_stream_for(&server.public_key())
-        .add_users([(&b, None)])
-        .unwrap()
-        .session(&session_a)
-        .path("/priv/app/")
-        .subscribe()
-        .await;
-
-    let err = result
-        .err()
-        .expect("A's cookie must not authenticate a private stream scoped to B");
-    assert_eq!(
-        server_status(&err),
-        Some(StatusCode::UNAUTHORIZED),
-        "expected a typed 401 Server error, got: {err}"
-    );
-}
-
-/// A public event stream works normally with a cookie session attached
-#[tokio::test]
-#[pubky_testnet::test]
-async fn events_stream_sdk_public_stream_with_cookie_session_works() {
-    let testnet = build_full_testnet().await;
-    let server = testnet.homeserver_app();
-    let pubky = testnet.sdk().unwrap();
-
-    let signer = pubky.signer(Keypair::random());
-    let session = signer
-        .signup_cookie(&server.public_key(), None)
-        .await
-        .unwrap();
-    let user = signer.public_key();
-
-    session
-        .storage()
-        .put("/pub/hello.txt", vec![1])
-        .await
-        .unwrap();
-
-    let mut stream = pubky
-        .event_stream_for(&server.public_key())
-        .add_users([(&user, None)])
-        .unwrap()
-        .session(&session)
-        .path("/pub/")
-        .limit(1)
-        .subscribe()
-        .await
-        .unwrap();
-
-    let event = stream
-        .next()
-        .await
-        .expect("public stream should deliver the public event")
-        .unwrap();
-    assert_eq!(event.resource.owner.z32(), user.z32());
-    assert!(
-        event.resource.path.as_str().contains("/pub/hello.txt"),
-        "expected the public event, got: {}",
-        event.resource.path
-    );
-}
-
-/// A cookie-backed live private stream receives in-scope private events and the
-/// path filter excludes out-of-scope ones.
 #[tokio::test]
 #[pubky_testnet::test]
 async fn events_stream_sdk_cookie_live_private_receives_in_scope() {
@@ -835,7 +567,6 @@ async fn events_stream_sdk_cookie_live_private_receives_in_scope() {
         .await
         .unwrap();
 
-    // After subscribing, write an out-of-scope then an in-scope private event.
     let writer = session.clone();
     tokio::spawn(async move {
         tokio::time::sleep(Duration::from_millis(100)).await;

--- a/e2e/src/tests/events/stream_sdk.rs
+++ b/e2e/src/tests/events/stream_sdk.rs
@@ -439,19 +439,21 @@ async fn events_stream_sdk_private_without_session_is_unauthorized() {
     );
 }
 
-/// A session may not read another user's private events; the homeserver
-/// rejection surfaces as a typed `403 Forbidden`.
+/// A session must not read another user's private events. The SDK scopes a
+/// private subscription to the credential's own user, so A's session is *not*
+/// attached to B's private stream.
 #[tokio::test]
 #[pubky_testnet::test]
-async fn events_stream_sdk_private_wrong_user_is_forbidden() {
+async fn events_stream_sdk_wrong_user_private_stream_is_not_attached() {
     let testnet = build_full_testnet().await;
     let server = testnet.homeserver_app();
     let pubky = testnet.sdk().unwrap();
 
-    let (_a, session_a) = signed_in_user(&testnet, "sdk-403-a.test").await;
-    let (b, _session_b) = signed_in_user(&testnet, "sdk-403-b.test").await;
+    let (_a, session_a) = signed_in_user(&testnet, "sdk-401-a.test").await;
+    let (b, _session_b) = signed_in_user(&testnet, "sdk-401-b.test").await;
 
-    // A's session requesting B's private events → 403 (server-enforced).
+    // A's session requesting B's private events: the SDK refuses to attach A's
+    // credential to a private stream scoped to B, so the request is anonymous.
     let result = pubky
         .event_stream_for(&server.public_key())
         .add_users([(&b, None)])
@@ -466,8 +468,40 @@ async fn events_stream_sdk_private_wrong_user_is_forbidden() {
         .expect("a session may not read another user's private events");
     assert_eq!(
         server_status(&err),
-        Some(StatusCode::FORBIDDEN),
-        "expected a typed 403 Server error, got: {err}"
+        Some(StatusCode::UNAUTHORIZED),
+        "expected a typed 401 Server error (credential not attached), got: {err}"
+    );
+}
+
+/// A session must not be attached to a multi-user private subscription
+#[tokio::test]
+#[pubky_testnet::test]
+async fn events_stream_sdk_multi_user_private_stream_is_not_attached() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+
+    let (a, session_a) = signed_in_user(&testnet, "sdk-multi-a.test").await;
+    let (b, _session_b) = signed_in_user(&testnet, "sdk-multi-b.test").await;
+
+    // A's session on a subscription naming both A and B with a private path: the
+    // SDK won't attach a credential to a multi-user private stream.
+    let result = pubky
+        .event_stream_for(&server.public_key())
+        .add_users([(&a, None), (&b, None)])
+        .unwrap()
+        .session(&session_a)
+        .path("/priv/app/")
+        .subscribe()
+        .await;
+
+    let err = result
+        .err()
+        .expect("a multi-user private subscription must not be authenticated");
+    assert_eq!(
+        server_status(&err),
+        Some(StatusCode::UNAUTHORIZED),
+        "expected a typed 401 Server error (credential not attached), got: {err}"
     );
 }
 
@@ -531,6 +565,94 @@ async fn events_stream_sdk_session_does_not_override_target_homeserver() {
     assert!(
         event.resource.path.as_str().contains("/pub/hello.txt"),
         "expected other's public event, got: {}",
+        event.resource.path
+    );
+}
+
+/// A cookie-backed session cannot authenticate a private event stream
+#[tokio::test]
+#[pubky_testnet::test]
+async fn events_stream_sdk_cookie_session_private_is_unauthorized() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+
+    let signer = pubky.signer(Keypair::random());
+    let session = signer
+        .signup_cookie(&server.public_key(), None)
+        .await
+        .unwrap();
+    let user = signer.public_key();
+
+    // The cookie write to a private path still works (regular file I/O).
+    session
+        .storage()
+        .put("/priv/app/secret.txt", vec![42])
+        .await
+        .unwrap();
+
+    // But a cookie-backed private *event stream* is not authenticated: the SDK
+    // won't attach a cookie credential to a `/priv/...` subscription.
+    let result = pubky
+        .event_stream_for(&server.public_key())
+        .add_users([(&user, None)])
+        .unwrap()
+        .session(&session)
+        .path("/priv/app/")
+        .subscribe()
+        .await;
+
+    let err = result
+        .err()
+        .expect("a cookie session must not authenticate a private event stream");
+    assert_eq!(
+        server_status(&err),
+        Some(StatusCode::UNAUTHORIZED),
+        "expected a typed 401 Server error, got: {err}"
+    );
+}
+
+/// A public event stream works normally with a cookie session attached
+#[tokio::test]
+#[pubky_testnet::test]
+async fn events_stream_sdk_public_stream_with_cookie_session_works() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+
+    let signer = pubky.signer(Keypair::random());
+    let session = signer
+        .signup_cookie(&server.public_key(), None)
+        .await
+        .unwrap();
+    let user = signer.public_key();
+
+    session
+        .storage()
+        .put("/pub/hello.txt", vec![1])
+        .await
+        .unwrap();
+
+    let mut stream = pubky
+        .event_stream_for(&server.public_key())
+        .add_users([(&user, None)])
+        .unwrap()
+        .session(&session)
+        .path("/pub/")
+        .limit(1)
+        .subscribe()
+        .await
+        .unwrap();
+
+    let event = stream
+        .next()
+        .await
+        .expect("public stream should deliver the public event")
+        .unwrap();
+    assert_eq!(event.resource.owner.z32(), user.z32());
+    assert!(
+        event.resource.path.as_str().contains("/pub/hello.txt"),
+        "expected the public event, got: {}",
         event.resource.path
     );
 }

--- a/e2e/src/tests/events/stream_sdk.rs
+++ b/e2e/src/tests/events/stream_sdk.rs
@@ -497,3 +497,40 @@ async fn events_stream_sdk_private_wrong_user_is_forbidden() {
         "expected a typed 403 Server error, got: {err}"
     );
 }
+
+/// The session credential must never be sent to a homeserver that
+/// isn't the session owner's. Pointing the builder at a foreign homeserver
+/// fails early, client-side, before any request is issued.
+#[tokio::test]
+#[pubky_testnet::test]
+async fn events_stream_sdk_session_rejects_foreign_homeserver() {
+    let testnet = build_full_testnet().await;
+    let pubky = testnet.sdk().unwrap();
+    let (user, session) = signed_in_user(&testnet, "sdk-leak.test").await;
+
+    // A homeserver pubkey that is NOT the session owner's.
+    let foreign_homeserver = Keypair::random().public_key();
+
+    let result = pubky
+        .event_stream_for(&foreign_homeserver)
+        .add_users([(&user, None)])
+        .unwrap()
+        .session(&session)
+        .path("/priv/app/")
+        .subscribe()
+        .await;
+
+    let err = match result {
+        Ok(_) => panic!("must refuse to send the session credential to a foreign homeserver"),
+        Err(e) => e,
+    };
+    // Rejected client-side (no server was contacted), so there is no HTTP status.
+    assert!(
+        server_status(&err).is_none(),
+        "should fail before contacting any server, got: {err}"
+    );
+    assert!(
+        err.to_string().contains("homeserver"),
+        "error should explain the homeserver mismatch, got: {err}"
+    );
+}

--- a/e2e/src/tests/events/stream_sdk.rs
+++ b/e2e/src/tests/events/stream_sdk.rs
@@ -569,10 +569,12 @@ async fn events_stream_sdk_session_does_not_override_target_homeserver() {
     );
 }
 
-/// A cookie-backed session cannot authenticate a private event stream
+/// A cookie-backed session authenticates its own single-user private stream
+/// (bound to its homeserver at signup); the path filter still excludes an
+/// out-of-scope private event.
 #[tokio::test]
 #[pubky_testnet::test]
-async fn events_stream_sdk_cookie_session_private_is_unauthorized() {
+async fn events_stream_sdk_cookie_backed_private_authorized() {
     let testnet = build_full_testnet().await;
     let server = testnet.homeserver_app();
     let pubky = testnet.sdk().unwrap();
@@ -584,27 +586,128 @@ async fn events_stream_sdk_cookie_session_private_is_unauthorized() {
         .unwrap();
     let user = signer.public_key();
 
-    // The cookie write to a private path still works (regular file I/O).
     session
         .storage()
         .put("/priv/app/secret.txt", vec![42])
         .await
         .unwrap();
+    // An out-of-scope private write that the `/priv/app/` filter must exclude.
+    session
+        .storage()
+        .put("/priv/other/z.txt", vec![7])
+        .await
+        .unwrap();
 
-    // But a cookie-backed private *event stream* is not authenticated: the SDK
-    // won't attach a cookie credential to a `/priv/...` subscription.
-    let result = pubky
+    let mut stream = pubky
         .event_stream_for(&server.public_key())
         .add_users([(&user, None)])
         .unwrap()
         .session(&session)
+        .path("/priv/app/")
+        .limit(1)
+        .subscribe()
+        .await
+        .unwrap();
+
+    let event = stream
+        .next()
+        .await
+        .expect("cookie-backed session should receive its in-scope private event")
+        .unwrap();
+    assert_eq!(event.resource.owner.z32(), user.z32());
+    assert!(
+        event
+            .resource
+            .path
+            .as_str()
+            .contains("/priv/app/secret.txt"),
+        "expected the in-scope private event, got: {}",
+        event.resource.path
+    );
+    assert!(
+        !event.resource.path.as_str().contains("/priv/other/"),
+        "out-of-scope private event leaked: {}",
+        event.resource.path
+    );
+}
+
+/// A cookie bound to HS1 must not grant private access when targeting HS2: the
+/// subscribe fails `401`. Outcome-only — HS2 returns `401` whether or not the
+/// cookie was sent (it holds no matching session); non-attachment itself is
+/// proven by the `can_attach_to` unit tests in the cookie credential.
+#[tokio::test]
+#[pubky_testnet::test]
+async fn events_stream_sdk_cookie_bound_homeserver_is_enforced() {
+    let mut testnet = build_full_testnet().await;
+    let hs1 = testnet.homeserver_app().public_key();
+    let hs2 = testnet
+        .create_random_homeserver()
+        .await
+        .unwrap()
+        .public_key();
+    assert_ne!(hs1, hs2, "test needs two distinct homeservers");
+
+    let pubky = testnet.sdk().unwrap();
+
+    let me = pubky.signer(Keypair::random());
+    let my_session = me.signup_cookie(&hs1, None).await.unwrap();
+    let my_user = me.public_key();
+
+    let result = pubky
+        .event_stream_for(&hs2)
+        .add_users([(&my_user, None)])
+        .unwrap()
+        .session(&my_session)
         .path("/priv/app/")
         .subscribe()
         .await;
 
     let err = result
         .err()
-        .expect("a cookie session must not authenticate a private event stream");
+        .expect("a cookie bound to HS1 must not authenticate a private stream on HS2");
+    assert_eq!(
+        server_status(&err),
+        Some(StatusCode::UNAUTHORIZED),
+        "expected a typed 401 Server error, got: {err}"
+    );
+}
+
+/// A cookie session for A must not grant private access to a stream scoped to B:
+/// the subscribe fails `401`. Outcome-only — B's stream returns `401` whether or
+/// not A's cookie was sent; the gate's non-attachment (B ≠ credential user) is
+/// proven by the `should_attach_credential` unit tests in the event stream.
+#[tokio::test]
+#[pubky_testnet::test]
+async fn events_stream_sdk_cookie_wrong_user_private_is_not_attached() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+
+    let signer_a = pubky.signer(Keypair::random());
+    let session_a = signer_a
+        .signup_cookie(&server.public_key(), None)
+        .await
+        .unwrap();
+
+    let signer_b = pubky.signer(Keypair::random());
+    signer_b
+        .signup_cookie(&server.public_key(), None)
+        .await
+        .unwrap();
+    let b = signer_b.public_key();
+
+    let result = pubky
+        .event_stream_for(&server.public_key())
+        .add_users([(&b, None)])
+        .unwrap()
+        .session(&session_a)
+        .path("/priv/app/")
+        .subscribe()
+        .await;
+
+    let err = result
+        .err()
+        .expect("A's cookie must not authenticate a private stream scoped to B");
     assert_eq!(
         server_status(&err),
         Some(StatusCode::UNAUTHORIZED),
@@ -653,6 +756,61 @@ async fn events_stream_sdk_public_stream_with_cookie_session_works() {
     assert!(
         event.resource.path.as_str().contains("/pub/hello.txt"),
         "expected the public event, got: {}",
+        event.resource.path
+    );
+}
+
+/// A cookie-backed live private stream receives in-scope private events and the
+/// path filter excludes out-of-scope ones.
+#[tokio::test]
+#[pubky_testnet::test]
+async fn events_stream_sdk_cookie_live_private_receives_in_scope() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+
+    let signer = pubky.signer(Keypair::random());
+    let session = signer
+        .signup_cookie(&server.public_key(), None)
+        .await
+        .unwrap();
+    let user = signer.public_key();
+
+    let mut stream = pubky
+        .event_stream_for(&server.public_key())
+        .add_users([(&user, None)])
+        .unwrap()
+        .session(&session)
+        .path("/priv/app/")
+        .live()
+        .subscribe()
+        .await
+        .unwrap();
+
+    // After subscribing, write an out-of-scope then an in-scope private event.
+    let writer = session.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        writer
+            .storage()
+            .put("/priv/other/skip.txt", vec![9])
+            .await
+            .unwrap();
+        writer
+            .storage()
+            .put("/priv/app/live.txt", vec![1])
+            .await
+            .unwrap();
+    });
+
+    let event = timeout(Duration::from_secs(5), stream.next())
+        .await
+        .expect("should receive a live event within the timeout")
+        .expect("stream should yield an event")
+        .unwrap();
+    assert!(
+        event.resource.path.as_str().contains("/priv/app/live.txt"),
+        "expected the in-scope live private event (out-of-scope excluded), got: {}",
         event.resource.path
     );
 }

--- a/e2e/src/tests/events/stream_sdk.rs
+++ b/e2e/src/tests/events/stream_sdk.rs
@@ -21,15 +21,6 @@ async fn signed_in_user(
     (signer.public_key(), session)
 }
 
-/// Extract the HTTP status from a typed server-rejection error, so tests assert
-/// against `RequestError::Server { status, .. }` rather than a raw string.
-fn server_status(err: &Error) -> Option<StatusCode> {
-    match err {
-        Error::Request(RequestError::Server { status, .. }) => Some(*status),
-        _ => None,
-    }
-}
-
 /// Test the SDK builder API: `event_stream_for()` and `add_users()`
 /// This tests the high-level SDK interface rather than raw HTTP requests.
 #[tokio::test]
@@ -535,10 +526,12 @@ async fn events_stream_sdk_cookie_bound_homeserver_is_enforced() {
     let err = result
         .err()
         .expect("a cookie bound to HS1 must not authenticate a private stream on HS2");
-    assert_eq!(
-        server_status(&err),
-        Some(StatusCode::UNAUTHORIZED),
-        "expected a typed 401 Server error, got: {err}"
+    let Error::Request(RequestError::Validation { message }) = err else {
+        panic!("expected local validation error, got: {err}");
+    };
+    assert!(
+        message.contains("cannot attach session credential"),
+        "got: {message}"
     );
 }
 

--- a/pubky-common/src/lib.rs
+++ b/pubky-common/src/lib.rs
@@ -15,6 +15,7 @@ mod keys;
 pub mod namespaces;
 pub mod recovery_file;
 pub mod session;
+pub mod storage;
 
 pub mod timestamp {
     //! Timestamp used across Pubky crates.

--- a/pubky-common/src/storage.rs
+++ b/pubky-common/src/storage.rs
@@ -1,0 +1,66 @@
+//! Shared Pubky storage path helpers.
+
+/// Storage root for public, world-readable data.
+pub const PUBLIC_ROOT: &str = "/pub/";
+
+/// Storage root for private data.
+pub const PRIVATE_ROOT: &str = "/priv/";
+
+/// Returns whether a normalized storage path is under [`PRIVATE_ROOT`].
+pub fn is_private_path(path: &str) -> bool {
+    path.starts_with(PRIVATE_ROOT)
+}
+
+/// Classifies a user-supplied path filter after WebDAV-style normalization.
+pub fn is_private_path_filter(path: &str) -> bool {
+    let Some(path) = normalize_path_filter(path) else {
+        return false;
+    };
+    is_private_path(&path)
+}
+
+fn normalize_path_filter(path: &str) -> Option<String> {
+    let mut segments = Vec::new();
+    for segment in path.split('/') {
+        match segment {
+            "" | "." => {}
+            ".." => {
+                segments.pop()?;
+            }
+            segment => segments.push(segment),
+        }
+    }
+
+    if segments.is_empty() {
+        return None;
+    }
+
+    let mut normalized = format!("/{}", segments.join("/"));
+    if (path.ends_with('/') || path.ends_with("..")) && !normalized.ends_with('/') {
+        normalized.push('/');
+    }
+    Some(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_private_path_filter;
+
+    #[test]
+    fn private_path_filter_matches_normalized_priv_directory() {
+        let cases = [
+            ("", false),
+            ("/pub/", false),
+            ("/priv", false),
+            ("/privstuff/x", false),
+            ("/priv/", true),
+            ("priv/x", true),
+            ("/pub/../priv/secret/", true),
+            ("/../../priv/secret/", false),
+        ];
+
+        for (path, expected) in cases {
+            assert_eq!(is_private_path_filter(path), expected, "{path}");
+        }
+    }
+}

--- a/pubky-homeserver/src/client_server/auth/grant/bearer.rs
+++ b/pubky-homeserver/src/client_server/auth/grant/bearer.rs
@@ -1,0 +1,93 @@
+use axum::http::{header, HeaderMap};
+
+use crate::client_server::auth::grant::crypto::session_token::SessionBearer;
+
+pub(crate) enum BearerTokenExtraction {
+    Present(SessionBearer),
+    InvalidBearer,
+    NonBearer,
+    Missing,
+}
+
+impl BearerTokenExtraction {
+    pub(crate) fn has_bearer_scheme(&self) -> bool {
+        matches!(self, Self::Present(_) | Self::InvalidBearer)
+    }
+}
+
+pub(crate) fn extract_bearer_token(headers: &HeaderMap) -> BearerTokenExtraction {
+    let Some(value) = headers.get(header::AUTHORIZATION) else {
+        return BearerTokenExtraction::Missing;
+    };
+
+    let Some(raw_token) = value.as_bytes().strip_prefix(b"Bearer ") else {
+        return BearerTokenExtraction::NonBearer;
+    };
+    let Ok(raw_token) = std::str::from_utf8(raw_token) else {
+        return BearerTokenExtraction::InvalidBearer;
+    };
+
+    match SessionBearer::parse(raw_token) {
+        Ok(bearer) => BearerTokenExtraction::Present(bearer),
+        Err(_) => BearerTokenExtraction::InvalidBearer,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    const UNKNOWN_WELL_FORMED_BEARER: &str = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG";
+
+    fn headers(value: HeaderValue) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::AUTHORIZATION, value);
+        headers
+    }
+
+    fn extraction_name(actual: &BearerTokenExtraction) -> &'static str {
+        match actual {
+            BearerTokenExtraction::Present(_) => "present",
+            BearerTokenExtraction::InvalidBearer => "invalid_bearer",
+            BearerTokenExtraction::NonBearer => "non_bearer",
+            BearerTokenExtraction::Missing => "missing",
+        }
+    }
+
+    #[test]
+    fn extract_bearer_token_classifies_authorization_header() {
+        let cases = [
+            (HeaderMap::new(), "missing", false),
+            (
+                headers(HeaderValue::from_static("Basic dXNlcjpwYXNz")),
+                "non_bearer",
+                false,
+            ),
+            (
+                headers(HeaderValue::from_static("Bearer ")),
+                "invalid_bearer",
+                true,
+            ),
+            (
+                headers(HeaderValue::from_bytes(b"Bearer \xff").expect("valid header bytes")),
+                "invalid_bearer",
+                true,
+            ),
+            (
+                headers(
+                    HeaderValue::from_str(&format!("Bearer {UNKNOWN_WELL_FORMED_BEARER}"))
+                        .expect("valid header"),
+                ),
+                "present",
+                true,
+            ),
+        ];
+
+        for (headers, expected, has_bearer_scheme) in cases {
+            let actual = extract_bearer_token(&headers);
+            assert_eq!(extraction_name(&actual), expected);
+            assert_eq!(actual.has_bearer_scheme(), has_bearer_scheme);
+        }
+    }
+}

--- a/pubky-homeserver/src/client_server/auth/grant/middleware.rs
+++ b/pubky-homeserver/src/client_server/auth/grant/middleware.rs
@@ -13,39 +13,12 @@
 //! - **No Authorization header** → forwards without an identity.
 //! - **Non-Bearer / malformed Authorization header** → forwards without an identity.
 
-use crate::client_server::auth::grant::crypto::session_token::SessionBearer;
+use crate::client_server::auth::grant::bearer::{extract_bearer_token, BearerTokenExtraction};
 use crate::client_server::auth::{AuthSession, AuthState};
-use axum::http::header;
 use axum::{body::Body, http::Request};
 use futures_util::future::BoxFuture;
 use std::{convert::Infallible, task::Poll};
 use tower::{Layer, Service};
-
-// ── Bearer token extraction ────────────────────────────────────────────────
-
-enum BearerTokenExtraction {
-    Present(SessionBearer),
-    Missing,
-    Invalid,
-}
-
-fn extract_bearer_token(req: &Request<Body>) -> BearerTokenExtraction {
-    let Some(value) = req.headers().get(header::AUTHORIZATION) else {
-        return BearerTokenExtraction::Missing;
-    };
-    let Ok(value) = value.to_str() else {
-        return BearerTokenExtraction::Invalid;
-    };
-
-    let Some(raw_token) = value.strip_prefix("Bearer ") else {
-        return BearerTokenExtraction::Invalid;
-    };
-
-    match SessionBearer::parse(raw_token) {
-        Ok(bearer) => BearerTokenExtraction::Present(bearer),
-        Err(_) => BearerTokenExtraction::Invalid,
-    }
-}
 
 // ── Layer ───────────────────────────────────────────────────────────────────
 
@@ -100,12 +73,12 @@ where
         let mut inner = self.inner.clone();
 
         Box::pin(async move {
-            let bearer = match extract_bearer_token(&req) {
+            let bearer = match extract_bearer_token(req.headers()) {
                 BearerTokenExtraction::Present(bearer) => bearer,
                 BearerTokenExtraction::Missing => {
                     return inner.call(req).await.map_err(|e| match e {});
                 }
-                BearerTokenExtraction::Invalid => {
+                BearerTokenExtraction::InvalidBearer | BearerTokenExtraction::NonBearer => {
                     tracing::debug!(
                         "Authorization header present but not a usable Bearer token; forwarding without auth"
                     );
@@ -247,68 +220,5 @@ mod tests {
 
         let resp = svc.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
-    }
-
-    // ── extract_bearer_token unit tests ────────────────────────────────
-
-    #[test]
-    fn extract_bearer_no_auth_header() {
-        let req = Request::builder().body(Body::empty()).unwrap();
-        assert!(matches!(
-            extract_bearer_token(&req),
-            BearerTokenExtraction::Missing
-        ));
-    }
-
-    #[test]
-    fn extract_bearer_basic_auth_rejected() {
-        let req = Request::builder()
-            .header("Authorization", "Basic dXNlcjpwYXNz")
-            .body(Body::empty())
-            .unwrap();
-        assert!(matches!(
-            extract_bearer_token(&req),
-            BearerTokenExtraction::Invalid
-        ));
-    }
-
-    #[test]
-    fn extract_bearer_empty_token() {
-        let req = Request::builder()
-            .header("Authorization", "Bearer ")
-            .body(Body::empty())
-            .unwrap();
-        assert!(matches!(
-            extract_bearer_token(&req),
-            BearerTokenExtraction::Invalid
-        ));
-    }
-
-    #[test]
-    fn extract_bearer_wrong_length_token() {
-        let huge = "a".repeat(WRONG_LENGTH_BEARER_LEN);
-        let req = Request::builder()
-            .header("Authorization", format!("Bearer {huge}"))
-            .body(Body::empty())
-            .unwrap();
-        assert!(matches!(
-            extract_bearer_token(&req),
-            BearerTokenExtraction::Invalid
-        ));
-    }
-
-    #[test]
-    fn extract_bearer_valid_token() {
-        let req = Request::builder()
-            .header(
-                "Authorization",
-                format!("Bearer {UNKNOWN_WELL_FORMED_BEARER}"),
-            )
-            .body(Body::empty())
-            .unwrap();
-        let BearerTokenExtraction::Present(bearer) = extract_bearer_token(&req) else {
-            panic!("expected bearer token to be present");
-        };
-        assert_eq!(bearer.as_str(), UNKNOWN_WELL_FORMED_BEARER);
     }
 }

--- a/pubky-homeserver/src/client_server/auth/grant/mod.rs
+++ b/pubky-homeserver/src/client_server/auth/grant/mod.rs
@@ -57,6 +57,7 @@
 //! - **Nonce**: each PoP nonce is tracked in `pop_nonces` (unique constraint, GC after 360 s).
 //! - **Audience**: PoP `aud` must match this homeserver's public key.
 
+pub(crate) mod bearer;
 pub mod crypto;
 mod error_mapping;
 pub mod middleware;

--- a/pubky-homeserver/src/client_server/auth/middleware/authentication.rs
+++ b/pubky-homeserver/src/client_server/auth/middleware/authentication.rs
@@ -56,15 +56,19 @@ impl<S> Layer<S> for AuthenticationLayer {
 mod tests {
     use super::*;
     use crate::app_context::AppContext;
+    use crate::client_server::auth::cookie::persistence::SessionRepository;
     use crate::client_server::auth::AuthSession;
     use crate::client_server::middleware::pubky_host::PubkyHost;
+    use crate::persistence::sql::user::UserRepository;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use axum::response::IntoResponse;
+    use pubky_common::capabilities::{Capabilities, Capability};
     use pubky_common::crypto::Keypair;
     use std::convert::Infallible;
     use std::sync::Arc;
     use tower::{Service, ServiceExt};
+    use tower_cookies::{Cookie, Cookies};
 
     async fn test_state() -> (AuthState, Keypair) {
         let context = AppContext::test().await;
@@ -93,6 +97,20 @@ mod tests {
                 Ok::<_, Infallible>(StatusCode::OK.into_response())
             }
         })
+    }
+
+    async fn cookie_for_user(context: &AppContext, keypair: &Keypair) -> Cookie<'static> {
+        let user = UserRepository::create(&keypair.public_key(), &mut context.sql_db.pool().into())
+            .await
+            .unwrap();
+        let secret = SessionRepository::create(
+            user.id,
+            &Capabilities::from(vec![Capability::root()]),
+            &mut context.sql_db.pool().into(),
+        )
+        .await
+        .unwrap();
+        Cookie::new(keypair.public_key().z32(), secret.to_string())
     }
 
     #[tokio::test]
@@ -124,6 +142,28 @@ mod tests {
             .body(Body::empty())
             .unwrap();
         req.extensions_mut().insert(PubkyHost(pk));
+
+        let resp = svc.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn invalid_bearer_falls_through_to_user_addressed_cookie() {
+        let context = AppContext::test().await;
+        let keypair = Keypair::random();
+        let state = AuthState::new(&context);
+        let svc = AuthenticationLayer::new(state).layer(assert_handler(true));
+
+        let mut req = Request::builder()
+            .uri("/pub/file.txt")
+            .header("Authorization", "Bearer not-a-valid-jws")
+            .body(Body::empty())
+            .unwrap();
+        req.extensions_mut().insert(PubkyHost(keypair.public_key()));
+        let cookies = Cookies::default();
+        cookies.add(cookie_for_user(&context, &keypair).await);
+        req.extensions_mut().insert(cookies);
 
         let resp = svc.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -331,8 +331,8 @@ pub async fn feed_stream(
         parse_query_params(raw_query.0.as_deref().unwrap_or("")).map_err(HttpError::from)?;
 
     // Authorize the requested path filters before doing any work. Public paths
-    // need no session; any `/priv/` path requires a session whose single user
-    // matches and that holds a covering read capability.
+    // need no session; any `/priv/` path requires a GRANT session whose single
+    // user matches and that holds a covering read capability.
     let allowed_paths = authorized_paths(&params.paths, &params.user_cursors, session.as_ref())?;
 
     let mut user_cursor_map =
@@ -507,12 +507,12 @@ async fn resolve_user_cursors(
 ///
 /// - No requested path → implicit public-only (`/pub/`), no session needed.
 /// - Public (`/pub/...`) paths need no capability.
-/// - Any private (`/priv/...`) path requires a session (else 401), exactly one
-///   `user=` equal to the session user (else 403), and a read capability
+/// - Any private (`/priv/...`) path requires a GRANT session (else 401), exactly
+///   one `user=` equal to the session user (else 403), and a read capability
 ///   covering each private path (else 403).
 ///
-/// If any requested private path is unauthorized the whole subscription is
-/// rejected.
+/// Private event streams are grant-only: a cookie session is ignored here, so a
+/// private path falls through to 401.
 fn authorized_paths(
     paths: &[WebDavPath],
     user_cursors: &[(PublicKey, Option<String>)],
@@ -524,6 +524,9 @@ fn authorized_paths(
             WebDavPath::new_unchecked(PUBLIC_ROOT.to_string()).into()
         ]);
     }
+
+    // Grant-only: drop any cookie session so private paths fall through to 401.
+    let session = session.filter(|s| matches!(s, AuthSession::Grant(_)));
 
     // The tenant to authorize each path against. A private read is single-tenant,
     // so a tenant only exists when the subscription names exactly one user.
@@ -614,6 +617,20 @@ mod tests {
             capabilities,
             grant_id: GrantId::generate(),
             token_expires_at: 9999999999,
+        })
+    }
+
+    fn cookie_session(user_key: PublicKey, capabilities: Capabilities) -> AuthSession {
+        use crate::client_server::auth::cookie::persistence::{SessionEntity, SessionSecret};
+        AuthSession::Cookie(SessionEntity {
+            id: 1,
+            secret: SessionSecret::random(),
+            user_id: 1,
+            user_pubkey: user_key,
+            capabilities,
+            created_at: sqlx::types::chrono::DateTime::from_timestamp(0, 0)
+                .expect("valid timestamp")
+                .naive_utc(),
         })
     }
 
@@ -750,6 +767,30 @@ mod tests {
         let u = pk();
         let status = reject_status(authorized_paths(&[wd("/priv/app/")], &cursors(&[&u]), None));
         assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn cookie_session_is_rejected_for_private_path() {
+        // Private event streams are grant-only: a cookie session (even with root
+        // caps for the requested user) is ignored, so a private path is 401.
+        let owner = pk();
+        let session = cookie_session(owner.clone(), Capabilities::from(vec![Capability::root()]));
+        let status = reject_status(authorized_paths(
+            &[wd("/priv/app/")],
+            &cursors(&[&owner]),
+            Some(&session),
+        ));
+        assert_eq!(status, StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn cookie_session_allows_public_path() {
+        // Public paths need no auth, so a cookie session doesn't change the outcome.
+        let owner = pk();
+        let session = cookie_session(owner.clone(), Capabilities::from(vec![Capability::root()]));
+        let filters =
+            authorized_paths(&[wd("/pub/")], &cursors(&[&owner]), Some(&session)).unwrap();
+        assert_eq!(filters, vec![pf("/pub/")]);
     }
 
     #[test]

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -9,7 +9,7 @@
 use axum::{
     body::Body,
     extract::{RawQuery, State},
-    http::{header, Response, StatusCode},
+    http::{header, HeaderMap, Response, StatusCode},
     response::{
         sse::{Event, KeepAlive, Sse},
         IntoResponse,
@@ -19,6 +19,7 @@ use futures_util::stream::Stream;
 use pubky_common::crypto::PublicKey;
 use serde::Deserialize;
 use std::{collections::HashMap, convert::Infallible, time::Instant};
+use tower_cookies::Cookies;
 use url::form_urlencoded;
 
 use crate::{
@@ -27,7 +28,7 @@ use crate::{
         query_params::ListQueryParams,
         AppState,
     },
-    constants::PUBLIC_ROOT,
+    constants::{PRIVATE_ROOT, PUBLIC_ROOT},
     metrics_server::routes::metrics::Metrics,
     persistence::{
         files::events::{
@@ -325,14 +326,27 @@ pub async fn feed(
 pub async fn feed_stream(
     State(state): State<AppState>,
     session: Option<AuthSession>,
+    headers: HeaderMap,
+    cookies: Cookies,
     raw_query: RawQuery,
 ) -> HttpResult<Sse<impl Stream<Item = Result<Event, Infallible>>>> {
     let params =
         parse_query_params(raw_query.0.as_deref().unwrap_or("")).map_err(HttpError::from)?;
 
+    // Grant sessions are set by middleware and take
+    // priority. When no session was extracted AND no bearer was presented, fall
+    // back to a same-tenant cookie for a single-user private subscription.
+    let session = match session {
+        Some(session) => Some(session),
+        None if !has_bearer_auth(&headers) => {
+            resolve_tenant_cookie_session(&state, &cookies, &params).await
+        }
+        None => None,
+    };
+
     // Authorize the requested path filters before doing any work. Public paths
-    // need no session; any `/priv/` path requires a GRANT session whose single
-    // user matches and that holds a covering read capability.
+    // need no session; any `/priv/` path requires a session (grant or same-tenant
+    // cookie) whose single user matches and that holds a covering read capability.
     let allowed_paths = authorized_paths(&params.paths, &params.user_cursors, session.as_ref())?;
 
     let mut user_cursor_map =
@@ -502,17 +516,58 @@ async fn resolve_user_cursors(
     Ok(user_cursor_map)
 }
 
+/// Whether the request presented a `Bearer` Authorization header (valid or not).
+/// Mirrors the grant middleware's `strip_prefix("Bearer ")`, so a presented
+/// bearer is never silently downgraded to cookie auth.
+fn has_bearer_auth(headers: &HeaderMap) -> bool {
+    headers
+        .get(header::AUTHORIZATION)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| value.starts_with("Bearer "))
+}
+
+/// Resolve a same-tenant cookie session for a single-user private subscription.
+///
+/// The cookie middleware keys cookies by `pubky-host` (the homeserver here), so a
+/// user's cookie never matches on this endpoint. A private subscription names
+/// exactly one user, so we look the cookie up by that tenant instead. Returns
+/// `None` unless a `/priv/` path is requested AND exactly one `user=` is named;
+/// [`resolve_session_from_cookie`](crate::client_server::auth::AuthState) then
+/// verifies the cookie's session belongs to that user, so this grants no
+/// authority the caller didn't already hold.
+async fn resolve_tenant_cookie_session(
+    state: &AppState,
+    cookies: &Cookies,
+    params: &EventStreamQueryParams,
+) -> Option<AuthSession> {
+    let requests_private = params
+        .paths
+        .iter()
+        .any(|path| path.as_str().starts_with(PRIVATE_ROOT));
+    if !requests_private {
+        return None;
+    }
+    let [(tenant, _)] = params.user_cursors.as_slice() else {
+        return None;
+    };
+    let cookie_value = cookies.get(&tenant.z32()).map(|c| c.value().to_string());
+    state
+        .auth_state
+        .cookie_auth_service
+        .resolve_session_from_cookie(cookie_value, tenant)
+        .await
+}
+
 /// Authorize the requested `path`s and return the allow-list to apply to both
 /// the historical replay and the live phase.
 ///
 /// - No requested path → implicit public-only (`/pub/`), no session needed.
 /// - Public (`/pub/...`) paths need no capability.
-/// - Any private (`/priv/...`) path requires a GRANT session (else 401), exactly
-///   one `user=` equal to the session user (else 403), and a read capability
+/// - Any private (`/priv/...`) path requires a session (else 401), exactly one
+///   `user=` equal to the session user (else 403), and a read capability
 ///   covering each private path (else 403).
 ///
-/// Private event streams are grant-only: a cookie session is ignored here, so a
-/// private path falls through to 401.
+/// The session may be grant- or (same-tenant) cookie-backed; both are accepted.
 fn authorized_paths(
     paths: &[WebDavPath],
     user_cursors: &[(PublicKey, Option<String>)],
@@ -524,9 +579,6 @@ fn authorized_paths(
             WebDavPath::new_unchecked(PUBLIC_ROOT.to_string()).into()
         ]);
     }
-
-    // Grant-only: drop any cookie session so private paths fall through to 401.
-    let session = session.filter(|s| matches!(s, AuthSession::Grant(_)));
 
     // The tenant to authorize each path against. A private read is single-tenant,
     // so a tenant only exists when the subscription names exactly one user.
@@ -770,17 +822,43 @@ mod tests {
     }
 
     #[test]
-    fn cookie_session_is_rejected_for_private_path() {
-        // Private event streams are grant-only: a cookie session (even with root
-        // caps for the requested user) is ignored, so a private path is 401.
+    fn cookie_session_authorizes_own_private_path() {
+        // A same-tenant cookie session authorizes its own single-user private path.
         let owner = pk();
         let session = cookie_session(owner.clone(), Capabilities::from(vec![Capability::root()]));
+        let filters =
+            authorized_paths(&[wd("/priv/app/")], &cursors(&[&owner]), Some(&session)).unwrap();
+        assert_eq!(filters, vec![pf("/priv/app/")]);
+    }
+
+    #[test]
+    fn cookie_session_wrong_tenant_is_forbidden() {
+        // A cookie session for A requesting B's private events is 403 (session user
+        // ≠ tenant). (Resolution can't reach here with a mismatched cookie anyway.)
+        let (a, b) = (pk(), pk());
+        let session = cookie_session(a, Capabilities::from(vec![Capability::root()]));
         let status = reject_status(authorized_paths(
             &[wd("/priv/app/")],
+            &cursors(&[&b]),
+            Some(&session),
+        ));
+        assert_eq!(status, StatusCode::FORBIDDEN);
+    }
+
+    #[test]
+    fn cookie_session_under_scoped_denies_sibling_private_path() {
+        // A cookie session scoped to `/priv/app/` may not read a sibling scope.
+        let owner = pk();
+        let session = cookie_session(
+            owner.clone(),
+            Capabilities::from(vec![Capability::read("/priv/app/")]),
+        );
+        let status = reject_status(authorized_paths(
+            &[wd("/priv/other/")],
             &cursors(&[&owner]),
             Some(&session),
         ));
-        assert_eq!(status, StatusCode::UNAUTHORIZED);
+        assert_eq!(status, StatusCode::FORBIDDEN);
     }
 
     #[test]

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -16,7 +16,7 @@ use axum::{
     },
 };
 use futures_util::stream::Stream;
-use pubky_common::crypto::PublicKey;
+use pubky_common::{crypto::PublicKey, storage};
 use serde::Deserialize;
 use std::{collections::HashMap, convert::Infallible, time::Instant};
 use tower_cookies::Cookies;
@@ -24,11 +24,10 @@ use url::form_urlencoded;
 
 use crate::{
     client_server::{
-        auth::{has_read_permission, AuthSession},
+        auth::{grant::bearer::extract_bearer_token, has_read_permission, AuthSession},
         query_params::ListQueryParams,
         AppState,
     },
-    constants::{PRIVATE_ROOT, PUBLIC_ROOT},
     metrics_server::routes::metrics::Metrics,
     persistence::{
         files::events::{
@@ -94,7 +93,7 @@ impl<'a> EventStreamTenantScope<'a> {
     fn from_query(paths: &[WebDavPath], user_cursors: &'a [(PublicKey, Option<String>)]) -> Self {
         if !paths
             .iter()
-            .any(|path| path.as_str().starts_with(PRIVATE_ROOT))
+            .any(|path| storage::is_private_path(path.as_str()))
         {
             return Self::PublicOnly;
         }
@@ -364,7 +363,7 @@ pub async fn feed_stream(
         parse_query_params(raw_query.0.as_deref().unwrap_or("")).map_err(HttpError::from)?;
     let tenant_scope = EventStreamTenantScope::from_query(&params.paths, &params.user_cursors);
 
-    // Bearer auth wins over cookie fallback, even when the bearer is invalid.
+    // Bearer auth disables the homeserver-addressed cookie fallback.
     let session = match session {
         Some(session) => Some(session),
         None if !has_bearer_auth(&headers) => {
@@ -542,13 +541,8 @@ async fn resolve_user_cursors(
     Ok(user_cursor_map)
 }
 
-/// Whether the request presented a `Bearer` Authorization header (valid or not).
-/// Mirrors the grant middleware's `strip_prefix("Bearer ")`, so a presented
-/// bearer is never silently downgraded to cookie auth.
 fn has_bearer_auth(headers: &HeaderMap) -> bool {
-    headers
-        .get(header::AUTHORIZATION)
-        .is_some_and(|value| value.as_bytes().starts_with(b"Bearer "))
+    extract_bearer_token(headers).has_bearer_scheme()
 }
 
 async fn resolve_tenant_cookie_session(
@@ -573,9 +567,10 @@ fn authorized_paths(
     session: Option<&AuthSession>,
 ) -> Result<Vec<PathFilter>, HttpError> {
     if paths.is_empty() {
-        return Ok(vec![
-            WebDavPath::new_unchecked(PUBLIC_ROOT.to_string()).into()
-        ]);
+        return Ok(vec![WebDavPath::new_unchecked(
+            storage::PUBLIC_ROOT.to_string(),
+        )
+        .into()]);
     }
 
     let mut allowed = Vec::with_capacity(paths.len());
@@ -707,7 +702,7 @@ mod tests {
     }
 
     #[test]
-    fn has_bearer_auth_checks_raw_bearer_prefix() {
+    fn has_bearer_auth_uses_bearer_scheme() {
         let cases = [
             (b"Bearer token".as_slice(), true),
             (b"Bearer \xff".as_slice(), true),

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -637,6 +637,7 @@ impl Drop for ConnectionGuard {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::client_server::auth::cookie::persistence::{SessionEntity, SessionSecret};
     use crate::client_server::auth::grant::session::GrantSession;
     use pubky_common::auth::jws::GrantId;
     use pubky_common::capabilities::{Capabilities, Capability};
@@ -664,7 +665,6 @@ mod tests {
     }
 
     fn cookie_session(user_key: PublicKey, capabilities: Capabilities) -> AuthSession {
-        use crate::client_server::auth::cookie::persistence::{SessionEntity, SessionSecret};
         AuthSession::Cookie(SessionEntity {
             id: 1,
             secret: SessionSecret::random(),

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -83,6 +83,36 @@ pub struct EventStreamQueryParams {
     pub paths: Vec<WebDavPath>,
 }
 
+#[derive(Clone, Copy)]
+enum EventStreamTenantScope<'a> {
+    PublicOnly,
+    PrivateSingleTenant(&'a PublicKey),
+    PrivateUnsupported,
+}
+
+impl<'a> EventStreamTenantScope<'a> {
+    fn from_query(paths: &[WebDavPath], user_cursors: &'a [(PublicKey, Option<String>)]) -> Self {
+        if !paths
+            .iter()
+            .any(|path| path.as_str().starts_with(PRIVATE_ROOT))
+        {
+            return Self::PublicOnly;
+        }
+
+        match user_cursors {
+            [(tenant, _)] => Self::PrivateSingleTenant(tenant),
+            _ => Self::PrivateUnsupported,
+        }
+    }
+
+    fn tenant(self) -> Option<&'a PublicKey> {
+        match self {
+            Self::PrivateSingleTenant(tenant) => Some(tenant),
+            Self::PublicOnly | Self::PrivateUnsupported => None,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct RawEventStreamQueryParams {
     #[serde(default)]
@@ -332,22 +362,18 @@ pub async fn feed_stream(
 ) -> HttpResult<Sse<impl Stream<Item = Result<Event, Infallible>>>> {
     let params =
         parse_query_params(raw_query.0.as_deref().unwrap_or("")).map_err(HttpError::from)?;
+    let tenant_scope = EventStreamTenantScope::from_query(&params.paths, &params.user_cursors);
 
-    // Grant sessions are set by middleware and take
-    // priority. When no session was extracted AND no bearer was presented, fall
-    // back to a same-tenant cookie for a single-user private subscription.
+    // Bearer auth wins over cookie fallback, even when the bearer is invalid.
     let session = match session {
         Some(session) => Some(session),
         None if !has_bearer_auth(&headers) => {
-            resolve_tenant_cookie_session(&state, &cookies, &params).await
+            resolve_tenant_cookie_session(&state, &cookies, tenant_scope).await
         }
         None => None,
     };
 
-    // Authorize the requested path filters before doing any work. Public paths
-    // need no session; any `/priv/` path requires a session (grant or same-tenant
-    // cookie) whose single user matches and that holds a covering read capability.
-    let allowed_paths = authorized_paths(&params.paths, &params.user_cursors, session.as_ref())?;
+    let allowed_paths = authorized_paths(&params.paths, tenant_scope, session.as_ref())?;
 
     let mut user_cursor_map =
         resolve_user_cursors(&params.user_cursors, &state.events_service, &state.sql_db)
@@ -525,28 +551,12 @@ fn has_bearer_auth(headers: &HeaderMap) -> bool {
         .is_some_and(|value| value.as_bytes().starts_with(b"Bearer "))
 }
 
-/// Resolve a same-tenant cookie session for a single-user private subscription.
-///
-/// The cookie middleware keys cookies by `pubky-host` (the homeserver here), so a
-/// user's cookie never matches on this endpoint. A private subscription names
-/// exactly one user, so we look the cookie up by that tenant instead. Returns
-/// `None` unless a `/priv/` path is requested AND exactly one `user=` is named;
-/// [`resolve_session_from_cookie`](crate::client_server::auth::AuthState) then
-/// verifies the cookie's session belongs to that user, so this grants no
-/// authority the caller didn't already hold.
 async fn resolve_tenant_cookie_session(
     state: &AppState,
     cookies: &Cookies,
-    params: &EventStreamQueryParams,
+    scope: EventStreamTenantScope<'_>,
 ) -> Option<AuthSession> {
-    let requests_private = params
-        .paths
-        .iter()
-        .any(|path| path.as_str().starts_with(PRIVATE_ROOT));
-    if !requests_private {
-        return None;
-    }
-    let [(tenant, _)] = params.user_cursors.as_slice() else {
+    let EventStreamTenantScope::PrivateSingleTenant(tenant) = scope else {
         return None;
     };
     let cookie_value = cookies.get(&tenant.z32()).map(|c| c.value().to_string());
@@ -557,38 +567,20 @@ async fn resolve_tenant_cookie_session(
         .await
 }
 
-/// Authorize the requested `path`s and return the allow-list to apply to both
-/// the historical replay and the live phase.
-///
-/// - No requested path → implicit public-only (`/pub/`), no session needed.
-/// - Public (`/pub/...`) paths need no capability.
-/// - Any private (`/priv/...`) path requires a session (else 401), exactly one
-///   `user=` equal to the session user (else 403), and a read capability
-///   covering each private path (else 403).
-///
-/// The session may be grant- or (same-tenant) cookie-backed; both are accepted.
 fn authorized_paths(
     paths: &[WebDavPath],
-    user_cursors: &[(PublicKey, Option<String>)],
+    scope: EventStreamTenantScope<'_>,
     session: Option<&AuthSession>,
 ) -> Result<Vec<PathFilter>, HttpError> {
-    // No path requested: default to public-only.
     if paths.is_empty() {
         return Ok(vec![
             WebDavPath::new_unchecked(PUBLIC_ROOT.to_string()).into()
         ]);
     }
 
-    // The tenant to authorize each path against. A private read is single-tenant,
-    // so a tenant only exists when the subscription names exactly one user.
-    let tenant = match user_cursors {
-        [(pubkey, _)] => Some(pubkey),
-        _ => None,
-    };
-
     let mut allowed = Vec::with_capacity(paths.len());
     for path in paths {
-        has_read_permission(session, tenant, path)?;
+        has_read_permission(session, scope.tenant(), path)?;
         allowed.push(path.clone().into());
     }
     Ok(allowed)
@@ -696,6 +688,18 @@ mod tests {
             .status()
     }
 
+    fn authorize(
+        paths: &[WebDavPath],
+        user_cursors: &[(PublicKey, Option<String>)],
+        session: Option<&AuthSession>,
+    ) -> Result<Vec<PathFilter>, HttpError> {
+        authorized_paths(
+            paths,
+            EventStreamTenantScope::from_query(paths, user_cursors),
+            session,
+        )
+    }
+
     fn authorization_headers(value: axum::http::HeaderValue) -> HeaderMap {
         let mut headers = HeaderMap::new();
         headers.insert(header::AUTHORIZATION, value);
@@ -703,28 +707,19 @@ mod tests {
     }
 
     #[test]
-    fn has_bearer_auth_detects_valid_bearer_prefix() {
-        let headers = authorization_headers(axum::http::HeaderValue::from_static("Bearer token"));
+    fn has_bearer_auth_checks_raw_bearer_prefix() {
+        let cases = [
+            (b"Bearer token".as_slice(), true),
+            (b"Bearer \xff".as_slice(), true),
+            (b"Basic \xff".as_slice(), false),
+        ];
 
-        assert!(has_bearer_auth(&headers));
-    }
-
-    #[test]
-    fn has_bearer_auth_detects_non_utf8_bearer_prefix() {
-        let headers = authorization_headers(
-            axum::http::HeaderValue::from_bytes(b"Bearer \xff").expect("valid header bytes"),
-        );
-
-        assert!(has_bearer_auth(&headers));
-    }
-
-    #[test]
-    fn has_bearer_auth_ignores_non_bearer_invalid_bytes() {
-        let headers = authorization_headers(
-            axum::http::HeaderValue::from_bytes(b"Basic \xff").expect("valid header bytes"),
-        );
-
-        assert!(!has_bearer_auth(&headers));
+        for (value, expected) in cases {
+            let headers = authorization_headers(
+                axum::http::HeaderValue::from_bytes(value).expect("valid header bytes"),
+            );
+            assert_eq!(has_bearer_auth(&headers), expected, "{value:?}");
+        }
     }
 
     #[test]
@@ -838,36 +833,32 @@ mod tests {
     }
 
     #[test]
-    fn no_path_defaults_to_public_dir_filter() {
+    fn authorized_paths_defaults_to_public_dir_filter() {
         let u = pk();
-        let filters = authorized_paths(&[], &cursors(&[&u]), None).unwrap();
+        let filters = authorize(&[], &cursors(&[&u]), None).unwrap();
         assert_eq!(filters, vec![pf("/pub/")]);
     }
 
     #[test]
-    fn anonymous_private_path_is_unauthorized() {
+    fn authorized_paths_rejects_anonymous_private_path() {
         let u = pk();
-        let status = reject_status(authorized_paths(&[wd("/priv/app/")], &cursors(&[&u]), None));
+        let status = reject_status(authorize(&[wd("/priv/app/")], &cursors(&[&u]), None));
         assert_eq!(status, StatusCode::UNAUTHORIZED);
     }
 
     #[test]
-    fn cookie_session_authorizes_own_private_path() {
-        // A same-tenant cookie session authorizes its own single-user private path.
+    fn authorized_paths_allows_cookie_session_own_private_path() {
         let owner = pk();
         let session = cookie_session(owner.clone(), Capabilities::from(vec![Capability::root()]));
-        let filters =
-            authorized_paths(&[wd("/priv/app/")], &cursors(&[&owner]), Some(&session)).unwrap();
+        let filters = authorize(&[wd("/priv/app/")], &cursors(&[&owner]), Some(&session)).unwrap();
         assert_eq!(filters, vec![pf("/priv/app/")]);
     }
 
     #[test]
-    fn cookie_session_wrong_tenant_is_forbidden() {
-        // A cookie session for A requesting B's private events is 403 (session user
-        // ≠ tenant). (Resolution can't reach here with a mismatched cookie anyway.)
+    fn authorized_paths_rejects_wrong_tenant() {
         let (a, b) = (pk(), pk());
         let session = cookie_session(a, Capabilities::from(vec![Capability::root()]));
-        let status = reject_status(authorized_paths(
+        let status = reject_status(authorize(
             &[wd("/priv/app/")],
             &cursors(&[&b]),
             Some(&session),
@@ -876,36 +867,10 @@ mod tests {
     }
 
     #[test]
-    fn cookie_session_under_scoped_denies_sibling_private_path() {
-        // A cookie session scoped to `/priv/app/` may not read a sibling scope.
-        let owner = pk();
-        let session = cookie_session(
-            owner.clone(),
-            Capabilities::from(vec![Capability::read("/priv/app/")]),
-        );
-        let status = reject_status(authorized_paths(
-            &[wd("/priv/other/")],
-            &cursors(&[&owner]),
-            Some(&session),
-        ));
-        assert_eq!(status, StatusCode::FORBIDDEN);
-    }
-
-    #[test]
-    fn cookie_session_allows_public_path() {
-        // Public paths need no auth, so a cookie session doesn't change the outcome.
-        let owner = pk();
-        let session = cookie_session(owner.clone(), Capabilities::from(vec![Capability::root()]));
-        let filters =
-            authorized_paths(&[wd("/pub/")], &cursors(&[&owner]), Some(&session)).unwrap();
-        assert_eq!(filters, vec![pf("/pub/")]);
-    }
-
-    #[test]
-    fn private_path_with_multiple_users_is_forbidden() {
+    fn authorized_paths_rejects_private_path_with_multiple_users() {
         let (a, b) = (pk(), pk());
         let session = grant_session(a.clone(), Capabilities::from(vec![Capability::root()]));
-        let status = reject_status(authorized_paths(
+        let status = reject_status(authorize(
             &[wd("/priv/app/")],
             &cursors(&[&a, &b]),
             Some(&session),
@@ -914,14 +879,13 @@ mod tests {
     }
 
     #[test]
-    fn private_path_under_scoped_session_is_forbidden() {
+    fn authorized_paths_rejects_under_scoped_private_path() {
         let owner = pk();
         let session = grant_session(
             owner.clone(),
             Capabilities::from(vec![Capability::read("/priv/app/")]),
         );
-        // A sibling scope not covered by the read cap.
-        let status = reject_status(authorized_paths(
+        let status = reject_status(authorize(
             &[wd("/priv/other/")],
             &cursors(&[&owner]),
             Some(&session),
@@ -930,13 +894,13 @@ mod tests {
     }
 
     #[test]
-    fn mixed_public_and_private_authorized_union() {
+    fn authorized_paths_allows_mixed_public_and_private_union() {
         let owner = pk();
         let session = grant_session(
             owner.clone(),
             Capabilities::from(vec![Capability::read("/priv/app/")]),
         );
-        let filters = authorized_paths(
+        let filters = authorize(
             &[wd("/pub/"), wd("/priv/app/")],
             &cursors(&[&owner]),
             Some(&session),
@@ -946,9 +910,9 @@ mod tests {
     }
 
     #[test]
-    fn public_paths_with_multiple_users_are_authorized() {
+    fn authorized_paths_allows_public_paths_with_multiple_users() {
         let (a, b) = (pk(), pk());
-        let filters = authorized_paths(&[wd("/pub/")], &cursors(&[&a, &b]), None).unwrap();
+        let filters = authorize(&[wd("/pub/")], &cursors(&[&a, &b]), None).unwrap();
         assert_eq!(filters, vec![pf("/pub/")]);
     }
 }

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -522,8 +522,7 @@ async fn resolve_user_cursors(
 fn has_bearer_auth(headers: &HeaderMap) -> bool {
     headers
         .get(header::AUTHORIZATION)
-        .and_then(|value| value.to_str().ok())
-        .is_some_and(|value| value.starts_with("Bearer "))
+        .is_some_and(|value| value.as_bytes().starts_with(b"Bearer "))
 }
 
 /// Resolve a same-tenant cookie session for a single-user private subscription.
@@ -695,6 +694,37 @@ mod tests {
             .expect_err("expected the subscription to be rejected")
             .into_response()
             .status()
+    }
+
+    fn authorization_headers(value: axum::http::HeaderValue) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(header::AUTHORIZATION, value);
+        headers
+    }
+
+    #[test]
+    fn has_bearer_auth_detects_valid_bearer_prefix() {
+        let headers = authorization_headers(axum::http::HeaderValue::from_static("Bearer token"));
+
+        assert!(has_bearer_auth(&headers));
+    }
+
+    #[test]
+    fn has_bearer_auth_detects_non_utf8_bearer_prefix() {
+        let headers = authorization_headers(
+            axum::http::HeaderValue::from_bytes(b"Bearer \xff").expect("valid header bytes"),
+        );
+
+        assert!(has_bearer_auth(&headers));
+    }
+
+    #[test]
+    fn has_bearer_auth_ignores_non_bearer_invalid_bytes() {
+        let headers = authorization_headers(
+            axum::http::HeaderValue::from_bytes(b"Basic \xff").expect("valid header bytes"),
+        );
+
+        assert!(!has_bearer_auth(&headers));
     }
 
     #[test]

--- a/pubky-homeserver/src/constants.rs
+++ b/pubky-homeserver/src/constants.rs
@@ -2,8 +2,8 @@
 pub const DEFAULT_LIST_LIMIT: u16 = 100;
 pub const DEFAULT_MAX_LIST_LIMIT: u16 = 1000;
 
-/// Storage root for public, world-readable data (`/pub/...`).
-pub const PUBLIC_ROOT: &str = "/pub/";
+/// Storage root for private data (`/priv/...`).
+pub use pubky_common::storage::PRIVATE_ROOT;
 
-/// Storage root for private data (`/priv/...`), reads and writes require auth.
-pub const PRIVATE_ROOT: &str = "/priv/";
+/// Storage root for public data (`/pub/...`).
+pub use pubky_common::storage::PUBLIC_ROOT;

--- a/pubky-sdk/bindings/js/src/actors/event_stream.rs
+++ b/pubky-sdk/bindings/js/src/actors/event_stream.rs
@@ -2,6 +2,7 @@ use futures_util::StreamExt;
 use wasm_bindgen::prelude::*;
 use web_sys::ReadableStream;
 
+use crate::actors::session::Session;
 use crate::wrappers::event_stream::Event;
 
 /// Builder for creating an event stream subscription.
@@ -19,6 +20,15 @@ use crate::wrappers::event_stream::Event;
 /// for await (const event of stream) {
 ///   console.log(event.eventType, event.resource.path);
 /// }
+/// ```
+///
+/// @example
+/// ```typescript
+/// // Private events: attach a session and request a `/priv/...` path.
+/// const stream = await pubky.eventStreamForUser(userPubkey, null)
+///   .session(session)
+///   .path("/priv/app/")
+///   .subscribe();
 /// ```
 #[wasm_bindgen]
 pub struct EventStreamBuilder(pub(crate) pubky::EventStreamBuilder);
@@ -150,16 +160,37 @@ impl EventStreamBuilder {
         EventStreamBuilder(self.0.reverse())
     }
 
-    /// Filter events by path prefix.
+    /// Filter events by path. Call once per path to receive the
+    /// union of several scopes (e.g. `/pub/` plus a private `/priv/app/`).
     ///
-    /// Format: Path WITHOUT `pubky://` scheme or user pubkey (e.g., "/pub/files/" or "/pub/").
-    /// Only events whose path starts with this prefix are returned.
+    /// Format: a path WITHOUT the `pubky://` scheme or user pubkey. A trailing
+    /// slash matches a directory and all its descendants (`/pub/files/`); no
+    /// trailing slash matches an exact file (`/pub/notes.txt`).
     ///
-    /// @param {string} path - Path prefix to filter by
+    /// Private (`/priv/...`) paths require a session attached via `session()`;
+    /// without one the homeserver rejects the subscription with 401.
+    ///
+    /// @param {string} path - Path filter (repeatable)
     /// @returns {EventStreamBuilder} - Builder for chaining
     #[wasm_bindgen]
     pub fn path(self, path: String) -> Self {
         EventStreamBuilder(self.0.path(path))
+    }
+
+    /// Authenticate the subscription with a user `Session`.
+    ///
+    /// Required to receive private (`/priv/...`) events: the session credential
+    /// is attached so the homeserver can authorize each private `path()` against
+    /// the session's read capabilities. Public subscriptions don't need this.
+    ///
+    /// The homeserver only authorizes private paths when the subscription names
+    /// exactly the session's own user; otherwise it responds with 403.
+    ///
+    /// @param {Session} session - The authenticated session
+    /// @returns {EventStreamBuilder} - Builder for chaining
+    #[wasm_bindgen]
+    pub fn session(self, session: &Session) -> Self {
+        EventStreamBuilder(self.0.session(&session.0))
     }
 
     /// Subscribe to the event stream.

--- a/pubky-sdk/bindings/js/src/actors/event_stream.rs
+++ b/pubky-sdk/bindings/js/src/actors/event_stream.rs
@@ -180,11 +180,10 @@ impl EventStreamBuilder {
     /// Authenticate the subscription with a user `Session`.
     ///
     /// Required to receive private (`/priv/...`) events: the session credential
-    /// is attached so the homeserver can authorize each private `path()` against
-    /// the session's read capabilities. Public subscriptions don't need this.
+    /// (grant or cookie) is attached so the homeserver can authorize each private
+    /// `path()` against the session's read capabilities. Public subscriptions
+    /// don't need this.
     ///
-    /// The homeserver only authorizes private paths when the subscription names
-    /// exactly the session's own user; otherwise it responds with 403.
     ///
     /// @param {Session} session - The authenticated session
     /// @returns {EventStreamBuilder} - Builder for chaining

--- a/pubky-sdk/src/actors/auth/cookie/credential.rs
+++ b/pubky-sdk/src/actors/auth/cookie/credential.rs
@@ -32,12 +32,8 @@ use reqwest::{Method, RequestBuilder, Response};
 use crate::actors::session::core::PubkySession;
 use crate::actors::session::credential::{SessionCredential, credential_session_missing};
 use crate::{
-    PubkyHttpClient,
-    actors::session::SessionInfo,
-    actors::storage::resource::resolve_pubky,
-    cross_log,
-    errors::{RequestError, Result},
-    util::check_http_status,
+    PubkyHttpClient, actors::session::SessionInfo, actors::storage::resource::resolve_pubky,
+    cross_log, errors::Result, util::check_http_status,
 };
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -159,7 +155,7 @@ impl CookieCredential {
                 )
                 .await?
         } else {
-            let url = format!("pubky{}/session", token.public_key().z32());
+            let url = format!("pubky{}{}", token.public_key().z32(), SESSION_PATH);
             let resolved = resolve_pubky(&url)?;
             client.cross_request(Method::POST, resolved).await?
         };
@@ -225,7 +221,11 @@ impl SessionCredential for CookieCredential {
     async fn signout(&self, client: &PubkyHttpClient) -> Result<()> {
         let homeserver = match self.bound_homeserver() {
             Some(homeserver) => homeserver,
-            None => resolve_cookie_homeserver(client, &self.user).await?,
+            None => {
+                crate::Pkdns::with_client(client.clone())
+                    .require_homeserver_of(&self.user)
+                    .await?
+            }
         };
         let rb = client
             .cross_request_via_homeserver(Method::DELETE, &homeserver, &self.user, SESSION_PATH)
@@ -248,10 +248,7 @@ impl SessionCredential for CookieCredential {
                 Ok(rb.header(reqwest::header::COOKIE, format!("{cookie_name}={cookie}")))
             }
             None => {
-                // Browser WASM: the secret lives only in the cookie jar. Opt this
-                // request into credentialed fetch so the jar is sent (event streams
-                // default to `credentials: omit`). Only reached once `can_attach_to`
-                // confirmed the target is this cookie's bound homeserver.
+                // Browser WASM keeps the secret in the cookie jar.
                 #[cfg(target_arch = "wasm32")]
                 {
                     Ok(rb.fetch_credentials_include())
@@ -277,7 +274,12 @@ impl SessionCredential for CookieCredential {
     ) -> Result<Option<SessionInfo>> {
         let (homeserver, bind_on_success) = match self.bound_homeserver() {
             Some(homeserver) => (homeserver, false),
-            None => (resolve_cookie_homeserver(client, user).await?, true),
+            None => (
+                crate::Pkdns::with_client(client.clone())
+                    .require_homeserver_of(user)
+                    .await?,
+                true,
+            ),
         };
         let rb = client
             .cross_request_via_homeserver(Method::GET, &homeserver, user, SESSION_PATH)
@@ -303,21 +305,6 @@ impl SessionCredential for CookieCredential {
     fn as_any(&self) -> &dyn Any {
         self
     }
-}
-
-async fn resolve_cookie_homeserver(
-    client: &PubkyHttpClient,
-    user: &PublicKey,
-) -> Result<PublicKey> {
-    crate::Pkdns::with_client(client.clone())
-        .get_homeserver_of(user)
-        .await
-        .ok_or_else(|| {
-            RequestError::Validation {
-                message: format!("could not resolve homeserver for {}", user.z32()),
-            }
-            .into()
-        })
 }
 
 impl PubkySession {

--- a/pubky-sdk/src/actors/auth/cookie/credential.rs
+++ b/pubky-sdk/src/actors/auth/cookie/credential.rs
@@ -213,6 +213,13 @@ impl SessionCredential for CookieCredential {
         }
     }
 
+    async fn can_attach_to(&self, _homeserver: &PublicKey) -> bool {
+        // Private event streams are grant-only, so a cookie is never attached to
+        // one. (`can_attach_to` is only consulted by the event stream; regular
+        // cookie file I/O is unaffected.)
+        false
+    }
+
     async fn revalidate(
         &self,
         client: &PubkyHttpClient,
@@ -250,5 +257,38 @@ impl PubkySession {
     #[must_use]
     pub fn from_cookie_credential(client: PubkyHttpClient, credential: CookieCredential) -> Self {
         Self::from_credential(client, Arc::new(credential))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pubky_common::{
+        capabilities::{Capabilities, Capability},
+        crypto::Keypair,
+    };
+
+    fn cookie_credential(user: &PublicKey) -> CookieCredential {
+        let record =
+            CookieSessionRecord::new(user, Capabilities::from(vec![Capability::root()]), None);
+        CookieCredential::new(user.clone(), Some("cookie-secret".to_string()), record)
+    }
+
+    /// Cookie credentials never authenticate event streams
+    #[tokio::test]
+    async fn can_attach_to_is_always_false() {
+        let user = Keypair::random().public_key();
+        let credential = cookie_credential(&user);
+
+        assert!(
+            !credential
+                .can_attach_to(&Keypair::random().public_key())
+                .await
+        );
+        assert!(
+            !credential
+                .can_attach_to(&Keypair::random().public_key())
+                .await
+        );
     }
 }

--- a/pubky-sdk/src/actors/auth/cookie/credential.rs
+++ b/pubky-sdk/src/actors/auth/cookie/credential.rs
@@ -136,20 +136,13 @@ impl CookieCredential {
             "Establishing new session exchange for {}",
             token.public_key()
         );
-        let request = if let Some(homeserver) = homeserver.as_ref() {
-            client
-                .cross_request_via_homeserver(
-                    Method::POST,
-                    homeserver,
-                    token.public_key(),
-                    SESSION_PATH,
-                )
-                .await?
-        } else {
-            let url = format!("pubky{}{}", token.public_key().z32(), SESSION_PATH);
-            let resolved = resolve_pubky(&url)?;
-            client.cross_request(Method::POST, resolved).await?
-        };
+        let request = session_request(
+            client,
+            Method::POST,
+            token.public_key(),
+            homeserver.as_ref(),
+        )
+        .await?;
         let response = request.body(token.serialize()).send().await?;
 
         let response = check_http_status(response).await?;
@@ -183,6 +176,26 @@ impl CookieCredential {
     }
 }
 
+fn session_resource(user: &PublicKey) -> String {
+    format!("pubky{}{}", user.z32(), SESSION_PATH)
+}
+
+async fn session_request(
+    client: &PubkyHttpClient,
+    method: Method,
+    user: &PublicKey,
+    homeserver: Option<&PublicKey>,
+) -> Result<RequestBuilder> {
+    if let Some(homeserver) = homeserver {
+        return client
+            .cross_request_via_homeserver(method, homeserver, user, SESSION_PATH)
+            .await;
+    }
+
+    let resolved = resolve_pubky(session_resource(user))?;
+    client.cross_request(method, resolved).await
+}
+
 /// Cross-target reader for `Set-Cookie` response header values.
 fn collect_set_cookies(response: &Response) -> Vec<String> {
     let mut out = Vec::new();
@@ -211,16 +224,14 @@ impl SessionCredential for CookieCredential {
 
     async fn signout(&self, client: &PubkyHttpClient) -> Result<()> {
         let homeserver = match self.bound_homeserver() {
-            Some(homeserver) => homeserver,
+            Some(homeserver) => Some(homeserver),
             None => {
                 crate::Pkdns::with_client(client.clone())
-                    .require_homeserver_of(&self.user)
-                    .await?
+                    .get_homeserver_of(&self.user)
+                    .await
             }
         };
-        let rb = client
-            .cross_request_via_homeserver(Method::DELETE, &homeserver, &self.user, SESSION_PATH)
-            .await?;
+        let rb = session_request(client, Method::DELETE, &self.user, homeserver.as_ref()).await?;
         let rb = self.attach(rb, client).await?;
         let response = rb.send().await.map_err(crate::Error::from)?;
         check_http_status(response).await?;
@@ -261,18 +272,17 @@ impl SessionCredential for CookieCredential {
         client: &PubkyHttpClient,
         user: &PublicKey,
     ) -> Result<Option<SessionInfo>> {
-        let (homeserver, bind_on_success) = match self.bound_homeserver() {
-            Some(homeserver) => (homeserver, false),
-            None => (
+        let bound_homeserver = self.bound_homeserver();
+        let bind_on_success = bound_homeserver.is_none();
+        let homeserver = match bound_homeserver {
+            Some(homeserver) => Some(homeserver),
+            None => {
                 crate::Pkdns::with_client(client.clone())
-                    .require_homeserver_of(user)
-                    .await?,
-                true,
-            ),
+                    .get_homeserver_of(user)
+                    .await
+            }
         };
-        let rb = client
-            .cross_request_via_homeserver(Method::GET, &homeserver, user, SESSION_PATH)
-            .await?;
+        let rb = session_request(client, Method::GET, user, homeserver.as_ref()).await?;
         let rb = self.attach(rb, client).await?;
         let response = rb.send().await.map_err(crate::Error::from)?;
         if credential_session_missing(&response) {
@@ -285,7 +295,7 @@ impl SessionCredential for CookieCredential {
         let info = SessionInfo::new(record.public_key().clone(), record.capabilities().to_vec());
         self.replace_record(record);
 
-        if bind_on_success {
+        if bind_on_success && let Some(homeserver) = homeserver {
             self.set_homeserver(homeserver);
         }
         Ok(Some(info))

--- a/pubky-sdk/src/actors/auth/cookie/credential.rs
+++ b/pubky-sdk/src/actors/auth/cookie/credential.rs
@@ -54,6 +54,10 @@ pub struct CookieCredential {
     /// Cookie secret captured from `Set-Cookie`. `None` only on browser
     /// WASM where the value is hidden by the fetch spec.
     cookie: Option<String>,
+    /// Homeserver this cookie was established against, once known. Gates
+    /// [`SessionCredential::can_attach_to`] so the cookie is only ever attached
+    /// to a request targeting that homeserver.
+    homeserver: Arc<RwLock<Option<PublicKey>>>,
 }
 
 impl CookieCredential {
@@ -62,17 +66,34 @@ impl CookieCredential {
         user: PublicKey,
         cookie: Option<String>,
         record: CookieSessionRecord,
+        homeserver: Option<PublicKey>,
     ) -> Self {
         Self {
             user,
             record: Arc::new(RwLock::new(record)),
             cookie,
+            homeserver: Arc::new(RwLock::new(homeserver)),
         }
     }
 
+    /// Record the homeserver this cookie is bound to. Idempotent.
+    pub(crate) fn set_homeserver(&self, homeserver: PublicKey) {
+        if let Ok(mut hs) = self.homeserver.write() {
+            *hs = Some(homeserver);
+        }
+    }
+
+    /// The homeserver this cookie is currently bound to, if any.
+    fn bound_homeserver(&self) -> Option<PublicKey> {
+        self.homeserver.read().ok().and_then(|hs| hs.clone())
+    }
+
     /// Build a cookie credential from a successful `/session` or `/signup`
-    /// response.
-    pub(crate) async fn from_response(response: Response) -> Result<Self> {
+    /// response. `homeserver` is the homeserver that served it, when known.
+    pub(crate) async fn from_response(
+        response: Response,
+        homeserver: Option<PublicKey>,
+    ) -> Result<Self> {
         let raw_set_cookies = collect_set_cookies(&response);
 
         let bytes = response.bytes().await?;
@@ -103,17 +124,19 @@ impl CookieCredential {
         }
 
         cross_log!(info, "Hydrated cookie credential for {}", user);
-        Ok(Self::new(user, cookie, record))
+        Ok(Self::new(user, cookie, record, homeserver))
     }
 
     /// Establish a cookie credential from a signed [`AuthToken`] (legacy flow).
     ///
     /// POSTs the token to the homeserver's `/session` endpoint and constructs
     /// a [`CookieCredential`] ready to be lifted into a [`PubkySession`] via
-    /// [`PubkySession::from_cookie_credential`].
+    /// [`PubkySession::from_cookie_credential`]. `homeserver` is the homeserver
+    /// the session is established against, when the caller knows it.
     pub(crate) async fn from_auth_token(
         token: &AuthToken,
         client: &PubkyHttpClient,
+        homeserver: Option<PublicKey>,
     ) -> Result<Self> {
         let url = format!("pubky{}/session", token.public_key().z32());
         cross_log!(
@@ -135,7 +158,7 @@ impl CookieCredential {
             "Session exchange for {} succeeded; constructing credential",
             token.public_key()
         );
-        Self::from_response(response).await
+        Self::from_response(response, homeserver).await
     }
 
     /// Cookie secret accessor — used by [`super::view::CookieSessionView`]
@@ -201,23 +224,33 @@ impl SessionCredential for CookieCredential {
         rb: RequestBuilder,
         _client: &PubkyHttpClient,
     ) -> Result<RequestBuilder> {
-        // When we own the secret (native, Node.js WASM) we attach it
-        // manually. When we don't (browser WASM) the runtime cookie jar
-        // is the source of truth and we leave the request alone.
+        // When we own the secret (native, Node.js WASM) we attach it manually.
         match &self.cookie {
             Some(cookie) => {
                 let cookie_name = self.user.z32();
                 Ok(rb.header(reqwest::header::COOKIE, format!("{cookie_name}={cookie}")))
             }
-            None => Ok(rb),
+            None => {
+                // Browser WASM: the secret lives only in the cookie jar. Opt this
+                // request into credentialed fetch so the jar is sent (event streams
+                // default to `credentials: omit`). Only reached once `can_attach_to`
+                // confirmed the target is this cookie's bound homeserver.
+                #[cfg(target_arch = "wasm32")]
+                {
+                    Ok(rb.fetch_credentials_include())
+                }
+                #[cfg(not(target_arch = "wasm32"))]
+                {
+                    Ok(rb)
+                }
+            }
         }
     }
 
-    async fn can_attach_to(&self, _homeserver: &PublicKey) -> bool {
-        // Private event streams are grant-only, so a cookie is never attached to
-        // one. (`can_attach_to` is only consulted by the event stream; regular
-        // cookie file I/O is unaffected.)
-        false
+    async fn can_attach_to(&self, homeserver: &PublicKey) -> bool {
+        // Attach only to the homeserver this cookie was established against. An
+        // unbound cookie (restored, not yet revalidated) fails closed.
+        self.bound_homeserver().as_ref() == Some(homeserver)
     }
 
     async fn revalidate(
@@ -239,6 +272,20 @@ impl SessionCredential for CookieCredential {
         let record = CookieSessionRecord::deserialize(&bytes)?;
         let info = SessionInfo::new(record.public_key().clone(), record.capabilities().to_vec());
         self.replace_record(record);
+
+        // Best-effort hydration for restored/imported cookies that were created
+        // without a homeserver binding. Normal signup/signin paths bind at
+        // construction. This can theoretically race with concurrent PKDNS
+        // re-homing between the request resolution and this lookup; if resolution
+        // fails, keep the credential unbound so private event streams stay
+        // anonymous.
+        if self.bound_homeserver().is_none()
+            && let Some(hs) = crate::Pkdns::with_client(client.clone())
+                .get_homeserver_of(user)
+                .await
+        {
+            self.set_homeserver(hs);
+        }
         Ok(Some(info))
     }
 
@@ -268,23 +315,41 @@ mod tests {
         crypto::Keypair,
     };
 
-    fn cookie_credential(user: &PublicKey) -> CookieCredential {
+    fn cookie_credential(user: &PublicKey, homeserver: Option<PublicKey>) -> CookieCredential {
         let record =
             CookieSessionRecord::new(user, Capabilities::from(vec![Capability::root()]), None);
-        CookieCredential::new(user.clone(), Some("cookie-secret".to_string()), record)
+        CookieCredential::new(
+            user.clone(),
+            Some("cookie-secret".to_string()),
+            record,
+            homeserver,
+        )
     }
 
-    /// Cookie credentials never authenticate event streams
+    /// A bound cookie attaches only to the homeserver it was established against.
     #[tokio::test]
-    async fn can_attach_to_is_always_false() {
+    async fn can_attach_to_only_matches_bound_homeserver() {
         let user = Keypair::random().public_key();
-        let credential = cookie_credential(&user);
+        let bound = Keypair::random().public_key();
+        let other = Keypair::random().public_key();
+        let credential = cookie_credential(&user, Some(bound.clone()));
 
-        assert!(
-            !credential
-                .can_attach_to(&Keypair::random().public_key())
-                .await
-        );
+        assert!(credential.can_attach_to(&bound).await);
+        assert!(!credential.can_attach_to(&other).await);
+    }
+
+    /// An unbound cookie (restored, not yet revalidated) fails closed, then
+    /// attaches to its homeserver once bound.
+    #[tokio::test]
+    async fn can_attach_to_is_false_until_bound() {
+        let user = Keypair::random().public_key();
+        let credential = cookie_credential(&user, None);
+        let homeserver = Keypair::random().public_key();
+
+        assert!(!credential.can_attach_to(&homeserver).await);
+
+        credential.set_homeserver(homeserver.clone());
+        assert!(credential.can_attach_to(&homeserver).await);
         assert!(
             !credential
                 .can_attach_to(&Keypair::random().public_key())

--- a/pubky-sdk/src/actors/auth/cookie/credential.rs
+++ b/pubky-sdk/src/actors/auth/cookie/credential.rs
@@ -32,12 +32,18 @@ use reqwest::{Method, RequestBuilder, Response};
 use crate::actors::session::core::PubkySession;
 use crate::actors::session::credential::{SessionCredential, credential_session_missing};
 use crate::{
-    PubkyHttpClient, actors::session::SessionInfo, actors::storage::resource::resolve_pubky,
-    cross_log, errors::Result, util::check_http_status,
+    PubkyHttpClient,
+    actors::session::SessionInfo,
+    actors::storage::resource::resolve_pubky,
+    cross_log,
+    errors::{RequestError, Result},
+    util::check_http_status,
 };
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::errors::AuthError;
+
+const SESSION_PATH: &str = "/session";
 
 /// Cookie-based session credential (legacy).
 ///
@@ -138,19 +144,26 @@ impl CookieCredential {
         client: &PubkyHttpClient,
         homeserver: Option<PublicKey>,
     ) -> Result<Self> {
-        let url = format!("pubky{}/session", token.public_key().z32());
         cross_log!(
             info,
             "Establishing new session exchange for {}",
             token.public_key()
         );
-        let resolved = resolve_pubky(&url)?;
-        let response = client
-            .cross_request(Method::POST, resolved)
-            .await?
-            .body(token.serialize())
-            .send()
-            .await?;
+        let request = if let Some(homeserver) = homeserver.as_ref() {
+            client
+                .cross_request_via_homeserver(
+                    Method::POST,
+                    homeserver,
+                    token.public_key(),
+                    SESSION_PATH,
+                )
+                .await?
+        } else {
+            let url = format!("pubky{}/session", token.public_key().z32());
+            let resolved = resolve_pubky(&url)?;
+            client.cross_request(Method::POST, resolved).await?
+        };
+        let response = request.body(token.serialize()).send().await?;
 
         let response = check_http_status(response).await?;
         cross_log!(
@@ -210,9 +223,13 @@ impl SessionCredential for CookieCredential {
     }
 
     async fn signout(&self, client: &PubkyHttpClient) -> Result<()> {
-        let url = format!("pubky{}/session", self.user.z32());
-        let resolved = resolve_pubky(&url)?;
-        let rb = client.cross_request(Method::DELETE, resolved).await?;
+        let homeserver = match self.bound_homeserver() {
+            Some(homeserver) => homeserver,
+            None => resolve_cookie_homeserver(client, &self.user).await?,
+        };
+        let rb = client
+            .cross_request_via_homeserver(Method::DELETE, &homeserver, &self.user, SESSION_PATH)
+            .await?;
         let rb = self.attach(rb, client).await?;
         let response = rb.send().await.map_err(crate::Error::from)?;
         check_http_status(response).await?;
@@ -258,9 +275,13 @@ impl SessionCredential for CookieCredential {
         client: &PubkyHttpClient,
         user: &PublicKey,
     ) -> Result<Option<SessionInfo>> {
-        let url = format!("pubky{}/session", user.z32());
-        let resolved = resolve_pubky(&url)?;
-        let rb = client.cross_request(Method::GET, resolved).await?;
+        let (homeserver, bind_on_success) = match self.bound_homeserver() {
+            Some(homeserver) => (homeserver, false),
+            None => (resolve_cookie_homeserver(client, user).await?, true),
+        };
+        let rb = client
+            .cross_request_via_homeserver(Method::GET, &homeserver, user, SESSION_PATH)
+            .await?;
         let rb = self.attach(rb, client).await?;
         let response = rb.send().await.map_err(crate::Error::from)?;
         if credential_session_missing(&response) {
@@ -273,18 +294,8 @@ impl SessionCredential for CookieCredential {
         let info = SessionInfo::new(record.public_key().clone(), record.capabilities().to_vec());
         self.replace_record(record);
 
-        // Best-effort hydration for restored/imported cookies that were created
-        // without a homeserver binding. Normal signup/signin paths bind at
-        // construction. This can theoretically race with concurrent PKDNS
-        // re-homing between the request resolution and this lookup; if resolution
-        // fails, keep the credential unbound so private event streams stay
-        // anonymous.
-        if self.bound_homeserver().is_none()
-            && let Some(hs) = crate::Pkdns::with_client(client.clone())
-                .get_homeserver_of(user)
-                .await
-        {
-            self.set_homeserver(hs);
+        if bind_on_success {
+            self.set_homeserver(homeserver);
         }
         Ok(Some(info))
     }
@@ -292,6 +303,21 @@ impl SessionCredential for CookieCredential {
     fn as_any(&self) -> &dyn Any {
         self
     }
+}
+
+async fn resolve_cookie_homeserver(
+    client: &PubkyHttpClient,
+    user: &PublicKey,
+) -> Result<PublicKey> {
+    crate::Pkdns::with_client(client.clone())
+        .get_homeserver_of(user)
+        .await
+        .ok_or_else(|| {
+            RequestError::Validation {
+                message: format!("could not resolve homeserver for {}", user.z32()),
+            }
+            .into()
+        })
 }
 
 impl PubkySession {

--- a/pubky-sdk/src/actors/auth/cookie/credential.rs
+++ b/pubky-sdk/src/actors/auth/cookie/credential.rs
@@ -56,9 +56,7 @@ pub struct CookieCredential {
     /// Cookie secret captured from `Set-Cookie`. `None` only on browser
     /// WASM where the value is hidden by the fetch spec.
     cookie: Option<String>,
-    /// Homeserver this cookie was established against, once known. Gates
-    /// [`SessionCredential::can_attach_to`] so the cookie is only ever attached
-    /// to a request targeting that homeserver.
+    /// Homeserver this cookie may attach to.
     homeserver: Arc<RwLock<Option<PublicKey>>>,
 }
 
@@ -78,14 +76,12 @@ impl CookieCredential {
         }
     }
 
-    /// Record the homeserver this cookie is bound to. Idempotent.
     pub(crate) fn set_homeserver(&self, homeserver: PublicKey) {
         if let Ok(mut hs) = self.homeserver.write() {
             *hs = Some(homeserver);
         }
     }
 
-    /// The homeserver this cookie is currently bound to, if any.
     fn bound_homeserver(&self) -> Option<PublicKey> {
         self.homeserver.read().ok().and_then(|hs| hs.clone())
     }
@@ -130,11 +126,6 @@ impl CookieCredential {
     }
 
     /// Establish a cookie credential from a signed [`AuthToken`] (legacy flow).
-    ///
-    /// POSTs the token to the homeserver's `/session` endpoint and constructs
-    /// a [`CookieCredential`] ready to be lifted into a [`PubkySession`] via
-    /// [`PubkySession::from_cookie_credential`]. `homeserver` is the homeserver
-    /// the session is established against, when the caller knows it.
     pub(crate) async fn from_auth_token(
         token: &AuthToken,
         client: &PubkyHttpClient,
@@ -262,8 +253,6 @@ impl SessionCredential for CookieCredential {
     }
 
     async fn can_attach_to(&self, homeserver: &PublicKey) -> bool {
-        // Attach only to the homeserver this cookie was established against. An
-        // unbound cookie (restored, not yet revalidated) fails closed.
         self.bound_homeserver().as_ref() == Some(homeserver)
     }
 
@@ -339,7 +328,6 @@ mod tests {
         )
     }
 
-    /// A bound cookie attaches only to the homeserver it was established against.
     #[tokio::test]
     async fn can_attach_to_only_matches_bound_homeserver() {
         let user = Keypair::random().public_key();
@@ -351,8 +339,6 @@ mod tests {
         assert!(!credential.can_attach_to(&other).await);
     }
 
-    /// An unbound cookie (restored, not yet revalidated) fails closed, then
-    /// attaches to its homeserver once bound.
     #[tokio::test]
     async fn can_attach_to_is_false_until_bound() {
         let user = Keypair::random().public_key();

--- a/pubky-sdk/src/actors/auth/cookie/flow.rs
+++ b/pubky-sdk/src/actors/auth/cookie/flow.rs
@@ -131,6 +131,13 @@ impl PubkyCookieAuthFlow {
     /// [`await_credential`](Self::await_credential) directly if you need to
     /// inspect or persist the credential before building a session.
     ///
+    /// Signup flows bind the cookie credential to the homeserver named in the
+    /// signup deep link. Signin flows do not name a homeserver, so their cookie
+    /// credential remains unbound until a successful
+    /// [`PubkySession::revalidate`](PubkySession::revalidate). Until then, the
+    /// session can still use normal cookie storage APIs, but it will not
+    /// authenticate private event streams.
+    ///
     /// # Errors
     /// - Returns [`crate::errors::Error::Authentication`] if the relay channel
     ///   expires before approval.
@@ -148,16 +155,23 @@ impl PubkyCookieAuthFlow {
     /// The credential can be inspected, persisted, or lifted into a full
     /// [`PubkySession`] via [`PubkySession::from_cookie_credential`].
     ///
+    /// Signup credentials are bound immediately to the deep link homeserver.
+    /// Signin credentials are unbound because the signin deep link carries no
+    /// homeserver; call [`PubkySession::revalidate`](PubkySession::revalidate)
+    /// after constructing a session if it needs to authenticate private event
+    /// streams.
+    ///
     /// # Errors
     /// - See [`await_approval`](Self::await_approval).
     pub async fn await_credential(self) -> Result<CookieCredential> {
+        let homeserver = self.target_homeserver();
         let Self {
             relay_listener,
             client,
             ..
         } = self;
         let approval = Self::await_decoded_approval(relay_listener).await?;
-        CookieCredential::from_auth_token(&approval.0, &client).await
+        CookieCredential::from_auth_token(&approval.0, &client, homeserver).await
     }
 
     /// Block until the signer approves and we receive an [`AuthToken`].
@@ -203,7 +217,8 @@ impl PubkyCookieAuthFlow {
             return Ok(None);
         };
         Ok(Some(
-            CookieCredential::from_auth_token(&approval.0, &self.client).await?,
+            CookieCredential::from_auth_token(&approval.0, &self.client, self.target_homeserver())
+                .await?,
         ))
     }
 
@@ -219,6 +234,18 @@ impl PubkyCookieAuthFlow {
             Ok(Some(approval)) => Some(Ok(approval.0)),
             Ok(None) => None,
             Err(error) => Some(Err(error)),
+        }
+    }
+
+    /// Homeserver this flow targets, when the deep link names one.
+    ///
+    /// Only signup links carry it. Signin links intentionally return `None`; a
+    /// signin cookie stays unbound and private event streams remain anonymous
+    /// until the resulting session successfully revalidates.
+    fn target_homeserver(&self) -> Option<crate::PublicKey> {
+        match &self.auth_url {
+            DeepLink::Signup(link) => Some(link.params().homeserver.clone()),
+            _ => None,
         }
     }
 
@@ -332,5 +359,46 @@ mod tests {
         let url = "pubkyauth://secret_export?secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8";
         let result = pubky.resume_cookie_auth_flow(url);
         assert!(result.is_err(), "seed export URL should fail to resume");
+    }
+
+    async fn build_flow(auth_kind: AuthFlowKind) -> PubkyCookieAuthFlow {
+        let relay = http_relay::HttpRelay::builder()
+            .http_port(0)
+            .run()
+            .await
+            .unwrap();
+        let inbox_base = relay.local_url().join("inbox").unwrap();
+        PubkyCookieAuthFlow::builder(&Capabilities::default(), auth_kind)
+            .client(PubkyHttpClient::new().unwrap())
+            .relay(inbox_base)
+            .start()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn signup_flow_binds_cookie_to_deep_link_homeserver() {
+        let homeserver = Keypair::random().public_key();
+        let flow = build_flow(AuthFlowKind::signup(
+            homeserver.clone(),
+            Some("token".to_string()),
+        ))
+        .await;
+
+        assert_eq!(
+            flow.target_homeserver(),
+            Some(homeserver),
+            "signup deep link binds the cookie to its homeserver"
+        );
+    }
+
+    #[tokio::test]
+    async fn signin_flow_leaves_cookie_unbound() {
+        let flow = build_flow(AuthFlowKind::signin()).await;
+
+        assert_eq!(
+            flow.target_homeserver(),
+            None,
+            "signin deep link names no homeserver; the cookie binds on revalidate"
+        );
     }
 }

--- a/pubky-sdk/src/actors/auth/cookie/flow.rs
+++ b/pubky-sdk/src/actors/auth/cookie/flow.rs
@@ -273,6 +273,20 @@ mod tests {
     use crate::{Keypair, Pubky};
     use std::str::FromStr;
 
+    async fn build_flow(auth_kind: AuthFlowKind) -> PubkyCookieAuthFlow {
+        let relay = http_relay::HttpRelay::builder()
+            .http_port(0)
+            .run()
+            .await
+            .unwrap();
+        let inbox_base = relay.local_url().join("inbox").unwrap();
+        PubkyCookieAuthFlow::builder(&Capabilities::default(), auth_kind)
+            .client(PubkyHttpClient::new().unwrap())
+            .relay(inbox_base)
+            .start()
+            .unwrap()
+    }
+
     async fn assert_resume_reconnects(auth_kind: AuthFlowKind) {
         let relay = http_relay::HttpRelay::builder()
             .http_port(0)
@@ -359,20 +373,6 @@ mod tests {
         let url = "pubkyauth://secret_export?secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8";
         let result = pubky.resume_cookie_auth_flow(url);
         assert!(result.is_err(), "seed export URL should fail to resume");
-    }
-
-    async fn build_flow(auth_kind: AuthFlowKind) -> PubkyCookieAuthFlow {
-        let relay = http_relay::HttpRelay::builder()
-            .http_port(0)
-            .run()
-            .await
-            .unwrap();
-        let inbox_base = relay.local_url().join("inbox").unwrap();
-        PubkyCookieAuthFlow::builder(&Capabilities::default(), auth_kind)
-            .client(PubkyHttpClient::new().unwrap())
-            .relay(inbox_base)
-            .start()
-            .unwrap()
     }
 
     #[tokio::test]

--- a/pubky-sdk/src/actors/auth/cookie/secret.rs
+++ b/pubky-sdk/src/actors/auth/cookie/secret.rs
@@ -49,7 +49,7 @@ pub(crate) async fn import_session(
     // Browser WASM cannot read Set-Cookie, so the secret is None and
     // attachment is delegated to the runtime cookie jar.
     let credential: Arc<dyn SessionCredential> =
-        Arc::new(CookieCredential::new(user, None, record));
+        Arc::new(CookieCredential::new(user, None, record, None));
     let session = PubkySession::from_credential(client, Arc::clone(&credential));
     // Revalidate updates the credential's internal state automatically.
     session
@@ -120,8 +120,12 @@ pub(crate) async fn import_session_secret(
     // Build minimal session; placeholder record will be replaced
     // after validation.
     let placeholder = CookieSessionRecord::new(&public_key, Capabilities::default(), None);
-    let cookie_credential =
-        CookieCredential::new(public_key.clone(), Some(cookie.to_string()), placeholder);
+    let cookie_credential = CookieCredential::new(
+        public_key.clone(),
+        Some(cookie.to_string()),
+        placeholder,
+        None,
+    );
     let credential: Arc<dyn SessionCredential> = Arc::new(cookie_credential);
     let session = PubkySession::from_credential(client, Arc::clone(&credential));
 

--- a/pubky-sdk/src/actors/auth/grant/credential.rs
+++ b/pubky-sdk/src/actors/auth/grant/credential.rs
@@ -382,8 +382,6 @@ impl SessionCredential for GrantCredential {
     }
 
     async fn signout(&self, client: &PubkyHttpClient) -> Result<()> {
-        // Hit the auth endpoint directly and attach the bearer ourselves —
-        // `/auth/grant/session` is not a storage URL.
         let bearer = self.current_bearer().await;
         let response = self
             .grant_session_request(client, Method::DELETE)
@@ -411,8 +409,6 @@ impl SessionCredential for GrantCredential {
     }
 
     async fn can_attach_to(&self, homeserver: &PublicKey) -> bool {
-        // Attach only to the homeserver that minted the bearer (the `PoP`
-        // audience), so a rotated/poisoned Pkarr record can't divert it.
         &self.state.lock().await.homeserver_pk == homeserver
     }
 
@@ -421,9 +417,6 @@ impl SessionCredential for GrantCredential {
         client: &PubkyHttpClient,
         _user: &PublicKey,
     ) -> Result<Option<SessionInfo>> {
-        // We hit the auth endpoint directly (not the storage path) and
-        // attach the bearer ourselves — `/auth/grant/session` is not a
-        // storage URL.
         let bearer = self.current_bearer().await;
         let response = self
             .grant_session_request(client, Method::GET)
@@ -718,9 +711,6 @@ mod tests {
         super::super::pop_signer::delegated_sign_callback(|_| async { Ok(vec![0; 64]) })
     }
 
-    /// A grant credential attaches only to the homeserver it was minted for,
-    /// regardless of what a live PKDNS lookup might resolve to. This is the
-    /// core of the event-stream credential-attachment guard.
     #[tokio::test]
     async fn can_attach_to_only_matches_bound_homeserver() {
         let bound = Keypair::random().public_key();

--- a/pubky-sdk/src/actors/auth/grant/credential.rs
+++ b/pubky-sdk/src/actors/auth/grant/credential.rs
@@ -331,6 +331,12 @@ impl SessionCredential for GrantCredential {
         Ok(rb.bearer_auth(bearer))
     }
 
+    async fn can_attach_to(&self, homeserver: &PublicKey) -> bool {
+        // Attach only to the homeserver that minted the bearer (the `PoP`
+        // audience), so a rotated/poisoned Pkarr record can't divert it.
+        &self.state.lock().await.homeserver_pk == homeserver
+    }
+
     async fn revalidate(
         &self,
         client: &PubkyHttpClient,
@@ -523,5 +529,54 @@ mod tests {
             homeserver_pk: homeserver_keypair.public_key(),
         };
         (stored, claims)
+    }
+
+    /// Build a live [`GrantCredential`] bound to `homeserver`.
+    fn grant_credential_bound_to(homeserver: PublicKey) -> GrantCredential {
+        let user_keypair = Keypair::random();
+        let client_keypair = Keypair::random();
+        let claims = GrantClaims {
+            iss: user_keypair.public_key(),
+            client_id: ClientId::new("can-attach.test").unwrap(),
+            caps: vec![Capability::root()],
+            cnf: client_keypair.public_key(),
+            jti: GrantId::generate(),
+            iat: now_unix(),
+            exp: now_unix() + 3600,
+        };
+        let grant_jws = claims.sign(&user_keypair, GRANT_JWS_TYP);
+        let response = GrantSessionResponse {
+            token: "test-bearer".to_string(),
+            session: GrantSessionInfo {
+                homeserver: homeserver.clone(),
+                pubky: user_keypair.public_key(),
+                client_id: ClientId::new("can-attach.test").unwrap(),
+                capabilities: vec![Capability::root()],
+                grant_id: claims.jti.clone(),
+                token_expires_at: now_unix() + 3600,
+                grant_expires_at: now_unix() + 7200,
+                created_at: now_unix(),
+            },
+        };
+        GrantCredential::from_response(response, grant_jws, claims, client_keypair, homeserver)
+    }
+
+    /// A grant credential attaches only to the homeserver it was minted for,
+    /// regardless of what a live PKDNS lookup might resolve to. This is the
+    /// core of the event-stream credential-attachment guard.
+    #[tokio::test]
+    async fn can_attach_to_only_matches_bound_homeserver() {
+        let bound = Keypair::random().public_key();
+        let other = Keypair::random().public_key();
+        let credential = grant_credential_bound_to(bound.clone());
+
+        assert!(
+            credential.can_attach_to(&bound).await,
+            "grant credential must attach to the homeserver it was minted for"
+        );
+        assert!(
+            !credential.can_attach_to(&other).await,
+            "grant credential must NOT attach to a homeserver it was not minted for"
+        );
     }
 }

--- a/pubky-sdk/src/actors/auth/grant/credential.rs
+++ b/pubky-sdk/src/actors/auth/grant/credential.rs
@@ -33,7 +33,6 @@ use crate::actors::session::credential::{SessionCredential, credential_session_m
 use crate::{
     PubkyHttpClient,
     actors::session::SessionInfo,
-    actors::storage::resource::resolve_pubky,
     cross_log,
     errors::{AuthError, RequestError, Result},
     util::check_http_status,
@@ -42,6 +41,7 @@ use crate::{
 /// Refresh the bearer proactively when it has less than this many seconds left.
 pub(crate) const REFRESH_SLACK_SECS: u64 = 300;
 
+const GRANT_SESSION_PATH: &str = "/auth/grant/session";
 const STORED_GRANT_CREDENTIAL_PREFIX: &str = "pubky-grant-credential-v1";
 const STORED_GRANT_CREDENTIAL_PREFIX_FAMILY: &str = "pubky-grant-credential-";
 
@@ -332,10 +332,13 @@ impl GrantCredential {
         .await?;
         let body = serde_json::json!({ "grant": &state.grant_jws, "pop": pop_jws });
 
-        let url = format!("pubky{}/auth/grant/session", state.grant_claims.iss.z32());
-        let resolved = resolve_pubky(&url)?;
         let resp = client
-            .cross_request(Method::POST, resolved)
+            .cross_request_via_homeserver(
+                Method::POST,
+                &state.homeserver_pk,
+                &state.grant_claims.iss,
+                GRANT_SESSION_PATH,
+            )
             .await?
             .json(&body)
             .send()
@@ -350,6 +353,20 @@ impl GrantCredential {
         state.token_expires_at = parsed.session.token_expires_at;
         state.session = parsed.session;
         Ok(())
+    }
+
+    async fn grant_session_request(
+        &self,
+        client: &PubkyHttpClient,
+        method: Method,
+    ) -> Result<RequestBuilder> {
+        let (homeserver, user) = {
+            let state = self.state.lock().await;
+            (state.homeserver_pk.clone(), state.grant_claims.iss.clone())
+        };
+        client
+            .cross_request_via_homeserver(method, &homeserver, &user, GRANT_SESSION_PATH)
+            .await
     }
 }
 
@@ -367,12 +384,9 @@ impl SessionCredential for GrantCredential {
     async fn signout(&self, client: &PubkyHttpClient) -> Result<()> {
         // Hit the auth endpoint directly and attach the bearer ourselves —
         // `/auth/grant/session` is not a storage URL.
-        let user_pk = self.state.lock().await.grant_claims.iss.clone();
-        let url = format!("pubky{}/auth/grant/session", user_pk.z32());
-        let resolved = resolve_pubky(&url)?;
         let bearer = self.current_bearer().await;
-        let response = client
-            .cross_request(Method::DELETE, resolved)
+        let response = self
+            .grant_session_request(client, Method::DELETE)
             .await?
             .bearer_auth(&bearer)
             .send()
@@ -410,12 +424,9 @@ impl SessionCredential for GrantCredential {
         // We hit the auth endpoint directly (not the storage path) and
         // attach the bearer ourselves — `/auth/grant/session` is not a
         // storage URL.
-        let user_pk = self.state.lock().await.grant_claims.iss.clone();
-        let url = format!("pubky{}/auth/grant/session", user_pk.z32());
-        let resolved = resolve_pubky(&url)?;
         let bearer = self.current_bearer().await;
-        let response = client
-            .cross_request(Method::GET, resolved)
+        let response = self
+            .grant_session_request(client, Method::GET)
             .await?
             .bearer_auth(&bearer)
             .send()
@@ -726,6 +737,46 @@ mod tests {
         assert!(
             !credential.can_attach_to(&other).await,
             "grant credential must NOT attach to a homeserver it was not minted for"
+        );
+    }
+
+    #[tokio::test]
+    async fn grant_session_request_routes_through_bound_homeserver() {
+        use pkarr::{SignedPacket, dns::rdata::SVCB};
+
+        let (mut stored, claims) = stored_credential(now_unix() + 3600);
+        let homeserver_keypair = pkarr::Keypair::random();
+        stored.homeserver_pk =
+            PublicKey::try_from_z32(&homeserver_keypair.public_key().to_string()).unwrap();
+        let icann = SVCB::new(10, "example.com".try_into().unwrap());
+        let homeserver_packet = SignedPacket::builder()
+            .https(".".try_into().unwrap(), icann, 3600)
+            .sign(&homeserver_keypair)
+            .unwrap();
+        let client_signer = GrantPopSigner::local(Keypair::from_secret(&stored.client_key_secret));
+        let credential = test_credential(stored, claims.clone(), client_signer);
+
+        let mut builder = PubkyHttpClient::builder();
+        builder.pkarr(|b| b.no_default_network().bootstrap(&["127.0.0.1:1"]));
+        let client = builder.build().unwrap();
+        client
+            .pkarr
+            .cache()
+            .unwrap()
+            .put(&homeserver_keypair.public_key().into(), &homeserver_packet);
+
+        let request = credential
+            .grant_session_request(&client, Method::POST)
+            .await
+            .unwrap()
+            .build()
+            .unwrap();
+
+        assert_eq!(request.url().host_str(), Some("example.com"));
+        assert_eq!(request.url().path(), "/auth/grant/session");
+        assert_eq!(
+            request.headers().get("pubky-host").unwrap(),
+            &claims.iss.z32()
         );
     }
 }

--- a/pubky-sdk/src/actors/auth/grant/flow.rs
+++ b/pubky-sdk/src/actors/auth/grant/flow.rs
@@ -381,12 +381,7 @@ impl PubkyGrantAuthFlow {
         let GrantApproval { jws, claims } = approval;
 
         let pkdns = Pkdns::with_client(client.clone());
-        let hs_pk = pkdns.get_homeserver_of(&claims.iss).await.ok_or_else(|| {
-            AuthError::Validation(format!(
-                "could not resolve homeserver for {}",
-                claims.iss.z32()
-            ))
-        })?;
+        let hs_pk = pkdns.require_homeserver_of(&claims.iss).await?;
         credential_from_grant_exchange(client, jws, claims, client_signer, hs_pk).await
     }
 

--- a/pubky-sdk/src/actors/event_stream.rs
+++ b/pubky-sdk/src/actors/event_stream.rs
@@ -131,6 +131,12 @@ pub struct EventStreamBuilder {
     credential: Option<Arc<dyn SessionCredential>>,
 }
 
+enum EventStreamAuthScope<'a> {
+    PublicOnly,
+    PrivateSingleUser(&'a PublicKey),
+    PrivateUnsupported,
+}
+
 impl EventStreamBuilder {
     /// Create an event stream builder for a single user.
     ///
@@ -338,14 +344,7 @@ impl EventStreamBuilder {
 
     /// Authenticate the subscription with a user session.
     ///
-    /// Required to receive private (`/priv/...`) events: the session credential
-    /// is attached so the homeserver can authorize each private [`path`](Self::path)
-    /// against the session's read capabilities. Public subscriptions need no session.
-    ///
-    /// The credential is attached only for a private stream naming exactly the
-    /// session's own user AND bound to the target homeserver. Otherwise the request stays anonymous, so a
-    /// credential is never sent to the wrong user, the wrong homeserver, or on a
-    /// public stream. A cookie is only attachable once bound.
+    /// Required for private (`/priv/...`) events. Public streams stay anonymous.
     #[must_use]
     pub fn session(mut self, session: &PubkySession) -> Self {
         self.credential = Some(Arc::clone(session.credential()));
@@ -385,8 +384,6 @@ impl EventStreamBuilder {
         Ok(url)
     }
 
-    /// Whether any requested [`path`](Self::path) targets a private (`/priv/...`)
-    /// scope. Only private paths require authentication; `/pub/` is world-readable.
     fn has_private_path_filter(&self) -> bool {
         self.paths
             .iter()
@@ -418,17 +415,22 @@ impl EventStreamBuilder {
         normalized.starts_with("/priv/")
     }
 
-    /// Whether `credential` should be attached to this subscription.
-    fn should_attach_credential(&self, credential: &dyn SessionCredential) -> bool {
+    fn auth_scope(&self) -> EventStreamAuthScope<'_> {
         if !self.has_private_path_filter() {
-            return false;
+            return EventStreamAuthScope::PublicOnly;
         }
 
-        let [(user, _)] = self.users.as_slice() else {
-            return false;
-        };
+        match self.users.as_slice() {
+            [(user, _)] => EventStreamAuthScope::PrivateSingleUser(user),
+            _ => EventStreamAuthScope::PrivateUnsupported,
+        }
+    }
 
-        user == credential.info().public_key()
+    fn should_attach_credential(&self, credential: &dyn SessionCredential) -> bool {
+        match self.auth_scope() {
+            EventStreamAuthScope::PrivateSingleUser(user) => user == credential.info().public_key(),
+            EventStreamAuthScope::PublicOnly | EventStreamAuthScope::PrivateUnsupported => false,
+        }
     }
 
     /// Internal helper that contains the shared subscription logic.
@@ -469,14 +471,10 @@ impl EventStreamBuilder {
         );
 
         let url = self.build_request_url(&homeserver)?;
-        // Anonymous by default so an ambient browser cookie can't authenticate a
-        // private stream; a credential is attached below only when intended.
         let mut request = self
             .client
             .cross_request_anonymous(Method::GET, url)
             .await?;
-        // Attach only for a private stream scoped to thecredentials own single user and bound to the target homeserver. A
-        // cookie that isn't bound (or bound elsewhere) reports `can_attach_to == false` and stays off.
         if let Some(credential) = &self.credential
             && self.should_attach_credential(credential.as_ref())
             && credential.can_attach_to(&homeserver).await
@@ -1016,8 +1014,6 @@ mod tests {
         );
     }
 
-    /// Build a real (cookie) credential for `user`, to exercise the private-scope
-    /// gate without a homeserver.
     fn cookie_credential_for(
         user: &PublicKey,
     ) -> crate::actors::auth::cookie::credential::CookieCredential {
@@ -1041,63 +1037,25 @@ mod tests {
         let keys = test_pubkeys(1);
         let user = &keys[0];
 
-        // Public-only and empty subscriptions are not private.
-        assert!(
-            !EventStreamBuilder::for_user(client.clone(), user, None)
-                .path("/pub/")
-                .has_private_path_filter()
-        );
-        assert!(
-            !EventStreamBuilder::for_user(client.clone(), user, None).has_private_path_filter()
-        );
+        let cases = [
+            (vec![], false),
+            (vec!["/pub/"], false),
+            (vec!["/privstuff/x"], false),
+            (vec!["/priv"], false),
+            (vec!["/priv/app/"], true),
+            (vec!["/priv/"], true),
+            (vec!["priv/x"], true),
+            (vec!["/pub/", "/priv/app/"], true),
+            (vec!["/pub/../priv/secret/"], true),
+        ];
 
-        // `/privstuff` is a distinct root, not `/priv/`.
-        assert!(
-            !EventStreamBuilder::for_user(client.clone(), user, None)
-                .path("/privstuff/x")
-                .has_private_path_filter()
-        );
-
-        // `/priv/...`, a leading-slash-less `priv/...`, and any mix count.
-        assert!(
-            EventStreamBuilder::for_user(client.clone(), user, None)
-                .path("/priv/app/")
-                .has_private_path_filter()
-        );
-        assert!(
-            EventStreamBuilder::for_user(client.clone(), user, None)
-                .path("/priv/")
-                .has_private_path_filter()
-        );
-        assert!(
-            EventStreamBuilder::for_user(client.clone(), user, None)
-                .path("priv/x")
-                .has_private_path_filter()
-        );
-        assert!(
-            EventStreamBuilder::for_user(client, user, None)
-                .path("/pub/")
-                .path("/priv/app/")
-                .has_private_path_filter()
-        );
-    }
-
-    #[test]
-    fn has_private_path_filter_normalizes_before_classifying() {
-        let client = crate::PubkyHttpClient::testnet().unwrap();
-        let keys = test_pubkeys(1);
-        let user = &keys[0];
-
-        assert!(
-            EventStreamBuilder::for_user(client.clone(), user, None)
-                .path("/pub/../priv/secret/")
-                .has_private_path_filter()
-        );
-        assert!(
-            !EventStreamBuilder::for_user(client, user, None)
-                .path("/priv")
-                .has_private_path_filter()
-        );
+        for (paths, expected) in cases {
+            let builder = paths.iter().fold(
+                EventStreamBuilder::for_user(client.clone(), user, None),
+                |b, p| b.path(*p),
+            );
+            assert_eq!(builder.has_private_path_filter(), expected, "{paths:?}");
+        }
     }
 
     #[test]
@@ -1108,47 +1066,50 @@ mod tests {
         let bob = &keys[1];
         let alice_cred = cookie_credential_for(alice);
 
-        // Public-only subscription: never attach — public streams are anonymous.
-        assert!(
-            !EventStreamBuilder::for_user(client.clone(), alice, None)
-                .path("/pub/")
-                .should_attach_credential(&alice_cred)
-        );
-        // Even with no path (public-only default): never attach.
-        assert!(
-            !EventStreamBuilder::for_user(client.clone(), alice, None)
-                .should_attach_credential(&alice_cred)
-        );
+        let cases = [
+            (
+                "no path",
+                EventStreamBuilder::for_user(client.clone(), alice, None),
+                false,
+            ),
+            (
+                "public path",
+                EventStreamBuilder::for_user(client.clone(), alice, None).path("/pub/"),
+                false,
+            ),
+            (
+                "same-user private path",
+                EventStreamBuilder::for_user(client.clone(), alice, None).path("/priv/app/"),
+                true,
+            ),
+            (
+                "normalized private path",
+                EventStreamBuilder::for_user(client.clone(), alice, None)
+                    .path("/pub/../priv/secret/"),
+                true,
+            ),
+            (
+                "wrong-user private path",
+                EventStreamBuilder::for_user(client.clone(), bob, None).path("/priv/app/"),
+                false,
+            ),
+            (
+                "multi-user private path",
+                EventStreamBuilder::for_homeserver(client, &keys[0])
+                    .add_users([(alice, None), (bob, None)])
+                    .unwrap()
+                    .path("/priv/app/"),
+                false,
+            ),
+        ];
 
-        // Private, single user == credential's user → attach.
-        assert!(
-            EventStreamBuilder::for_user(client.clone(), alice, None)
-                .path("/priv/app/")
-                .should_attach_credential(&alice_cred)
-        );
-
-        assert!(
-            EventStreamBuilder::for_user(client.clone(), alice, None)
-                .path("/pub/../priv/secret/")
-                .should_attach_credential(&alice_cred)
-        );
-
-        // Private, single user != credential's user → do not attach.
-        assert!(
-            !EventStreamBuilder::for_user(client.clone(), bob, None)
-                .path("/priv/app/")
-                .should_attach_credential(&alice_cred)
-        );
-
-        // Private, multi-user → do not attach even though the credential's user is
-        // among them.
-        assert!(
-            !EventStreamBuilder::for_homeserver(client, &keys[0])
-                .add_users([(alice, None), (bob, None)])
-                .unwrap()
-                .path("/priv/app/")
-                .should_attach_credential(&alice_cred)
-        );
+        for (name, builder, expected) in cases {
+            assert_eq!(
+                builder.should_attach_credential(&alice_cred),
+                expected,
+                "{name}"
+            );
+        }
     }
 
     #[test]

--- a/pubky-sdk/src/actors/event_stream.rs
+++ b/pubky-sdk/src/actors/event_stream.rs
@@ -91,7 +91,7 @@ use crate::PublicKey;
 use base64::Engine;
 use eventsource_stream::Eventsource;
 use futures_util::{Stream, StreamExt};
-use pubky_common::crypto::Hash;
+use pubky_common::{crypto::Hash, storage};
 use reqwest::Method;
 use url::Url;
 
@@ -387,32 +387,7 @@ impl EventStreamBuilder {
     fn has_private_path_filter(&self) -> bool {
         self.paths
             .iter()
-            .any(|path| Self::is_private_path_filter(path))
-    }
-
-    fn is_private_path_filter(path: &str) -> bool {
-        let mut segments = Vec::new();
-        for segment in path.split('/') {
-            match segment {
-                "" | "." => {}
-                ".." => {
-                    if segments.pop().is_none() {
-                        return false;
-                    }
-                }
-                segment => segments.push(segment),
-            }
-        }
-
-        if segments.is_empty() {
-            return false;
-        }
-
-        let mut normalized = format!("/{}", segments.join("/"));
-        if (path.ends_with('/') || path.ends_with("..")) && !normalized.ends_with('/') {
-            normalized.push('/');
-        }
-        normalized.starts_with("/priv/")
+            .any(|path| storage::is_private_path_filter(path))
     }
 
     fn auth_scope(&self) -> EventStreamAuthScope<'_> {
@@ -657,6 +632,11 @@ fn decode_content_hash(content_hash_base64: Option<&str>) -> Result<Hash> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::actors::auth::cookie::credential::CookieCredential;
+    use pubky_common::{
+        capabilities::{Capabilities, Capability},
+        session::CookieSessionRecord,
+    };
 
     /// Helper to create an SSE event for testing
     fn make_sse(event: &str, data: &str) -> eventsource_stream::Event {
@@ -1014,21 +994,10 @@ mod tests {
         );
     }
 
-    fn cookie_credential_for(
-        user: &PublicKey,
-    ) -> crate::actors::auth::cookie::credential::CookieCredential {
-        use pubky_common::{
-            capabilities::{Capabilities, Capability},
-            session::CookieSessionRecord,
-        };
+    fn cookie_credential_for(user: &PublicKey) -> CookieCredential {
         let record =
             CookieSessionRecord::new(user, Capabilities::from(vec![Capability::root()]), None);
-        crate::actors::auth::cookie::credential::CookieCredential::new(
-            user.clone(),
-            Some("test-cookie".to_string()),
-            record,
-            None,
-        )
+        CookieCredential::new(user.clone(), Some("test-cookie".to_string()), record, None)
     }
 
     #[test]

--- a/pubky-sdk/src/actors/event_stream.rs
+++ b/pubky-sdk/src/actors/event_stream.rs
@@ -339,7 +339,7 @@ impl EventStreamBuilder {
     /// Authenticate the subscription with a user session.
     ///
     /// Required to receive private (`/priv/...`) events: the session credential
-    /// is attached so the homeserver can authorize each private [`path`](Self::path) 
+    /// is attached so the homeserver can authorize each private [`path`](Self::path)
     /// against the session's read capabilities. Public subscriptions need no session.
     ///
     /// The credential is attached only for a private stream naming exactly the

--- a/pubky-sdk/src/actors/event_stream.rs
+++ b/pubky-sdk/src/actors/event_stream.rs
@@ -56,10 +56,11 @@
 //!
 //! # Example: Private events (authenticated)
 //!
-//! Attach a **grant** session with [`EventStreamBuilder::session`] and request a
+//! Attach a session with [`EventStreamBuilder::session`] and request a
 //! `/priv/...` [`path`](EventStreamBuilder::path). The homeserver authorizes the
-//! private scope against the session's read capabilities. Private event streams
-//! require a grant-backed session; public subscriptions need no session.
+//! private scope against the session's read capabilities. The session may be
+//! grant- or cookie-backed, but it must name the session's own user and be bound
+//! to the target homeserver; public subscriptions need no session.
 //! ```no_run
 //! use pubky::{Pubky, PubkySession};
 //! use futures_util::StreamExt;
@@ -326,7 +327,7 @@ impl EventStreamBuilder {
     /// slash matches a directory and all its descendants (`/pub/files/`); no
     /// trailing slash matches an exact file (`/pub/notes.txt`).
     ///
-    /// Private (`/priv/...`) paths require a grant-backed session attached via
+    /// Private (`/priv/...`) paths require a session attached via
     /// [`Self::session`]; without one the homeserver rejects the subscription
     /// with `401 Unauthorized`.
     #[must_use]
@@ -335,16 +336,16 @@ impl EventStreamBuilder {
         self
     }
 
-    /// Authenticate the subscription with a **grant** session.
+    /// Authenticate the subscription with a user session.
     ///
-    /// Required to receive private (`/priv/...`) events: the session's grant
-    /// bearer is attached so the homeserver can authorize each private
-    /// [`path`](Self::path) against the session's read capabilities. Public
-    /// subscriptions need no session.
+    /// Required to receive private (`/priv/...`) events: the session credential
+    /// is attached so the homeserver can authorize each private [`path`](Self::path) 
+    /// against the session's read capabilities. Public subscriptions need no session.
     ///
-    /// Private event streams are grant-only. A legacy cookie session is never
-    /// attached here, so a cookie-backed `/priv/...` subscription stays anonymous
-    /// and the homeserver rejects it with `401`.
+    /// The credential is attached only for a private stream naming exactly the
+    /// session's own user AND bound to the target homeserver. Otherwise the request stays anonymous, so a
+    /// credential is never sent to the wrong user, the wrong homeserver, or on a
+    /// public stream. A cookie is only attachable once bound.
     #[must_use]
     pub fn session(mut self, session: &PubkySession) -> Self {
         self.credential = Some(Arc::clone(session.credential()));
@@ -461,9 +462,8 @@ impl EventStreamBuilder {
             .client
             .cross_request_anonymous(Method::GET, url)
             .await?;
-        // Attach only for a private stream scoped to the credential's own single
-        // user and bound to the target homeserver. Cookies return
-        // `can_attach_to == false`, so private streams are grant-only.
+        // Attach only for a private stream scoped to thecredentials own single user and bound to the target homeserver. A
+        // cookie that isn't bound (or bound elsewhere) reports `can_attach_to == false` and stays off.
         if let Some(credential) = &self.credential
             && self.should_attach_credential(credential.as_ref())
             && credential.can_attach_to(&homeserver).await
@@ -1018,6 +1018,7 @@ mod tests {
             user.clone(),
             Some("test-cookie".to_string()),
             record,
+            None,
         )
     }
 

--- a/pubky-sdk/src/actors/event_stream.rs
+++ b/pubky-sdk/src/actors/event_stream.rs
@@ -417,29 +417,11 @@ impl EventStreamBuilder {
         }
 
         // The session owner (the user the credential authenticates as), if any.
-        let session_owner = self
-            .credential
-            .as_ref()
-            .map(|credential| credential.info().public_key().clone());
-
-        // Resolve the homeserver we will send the request to.
-        //
-        // When a session credential is attached it must ONLY ever be transmitted
-        // to its owner's homeserver. We resolve the owner's homeserver and, if the
-        // caller also pinned one explicitly, require the two to match.
-        let homeserver = if let Some(owner) = &session_owner {
-            let owner_homeserver = self.resolve_homeserver(owner).await?;
-            if let Some(pinned) = &self.homeserver
-                && *pinned != owner_homeserver
-            {
-                return Err(Error::from(RequestError::Validation {
-                    message: format!(
-                        "refusing to attach the session credential: target homeserver {pinned} is not the session owner's homeserver {owner_homeserver}"
-                    ),
-                }));
-            }
-            owner_homeserver
-        } else if let Some(hs) = &self.homeserver {
+        // Resolve the homeserver from the subscription itself: an explicit
+        // homeserver if given, otherwise the first user's. An attached session
+        // must never change WHERE the request goes, only WHETHER a credential is
+        // attached (below).
+        let homeserver = if let Some(hs) = &self.homeserver {
             hs.clone()
         } else {
             self.resolve_homeserver(&self.users[0].0).await?
@@ -454,10 +436,16 @@ impl EventStreamBuilder {
 
         let url = self.build_request_url(&homeserver)?;
         let mut request = self.client.cross_request(Method::GET, url).await?;
-        // Attach the session credential (cookie or bearer) when present so the
-        // homeserver can authorize any private `/priv/...` path filters.
+        // Attach the session credential (cookie or bearer) only when the target
+        // is the session owners own homeserver, so a session token is never sent
+        // to a homeserver that isn't its owners. On a mismatch the request stays
+        // unauthenticated and the homeserver rejects any private `/priv/...` path
+        // with 401.
         if let Some(credential) = &self.credential {
-            request = credential.attach(request, &self.client).await?;
+            let owner = credential.info().public_key().clone();
+            if self.resolve_homeserver(&owner).await? == homeserver {
+                request = credential.attach(request, &self.client).await?;
+            }
         }
         let response = request.send().await?;
 

--- a/pubky-sdk/src/actors/event_stream.rs
+++ b/pubky-sdk/src/actors/event_stream.rs
@@ -445,15 +445,26 @@ impl EventStreamBuilder {
             homeserver
         );
 
+        let credential = self
+            .credential
+            .as_ref()
+            .filter(|credential| self.should_attach_credential(credential.as_ref()));
+        let can_attach_credential = match credential {
+            Some(credential) => credential.can_attach_to(&homeserver).await,
+            None => false,
+        };
+        if credential.is_some() && !can_attach_credential {
+            return Err(Error::from(RequestError::Validation {
+                message: "cannot attach session credential to target homeserver".into(),
+            }));
+        }
+
         let url = self.build_request_url(&homeserver)?;
         let mut request = self
             .client
             .cross_request_anonymous(Method::GET, url)
             .await?;
-        if let Some(credential) = &self.credential
-            && self.should_attach_credential(credential.as_ref())
-            && credential.can_attach_to(&homeserver).await
-        {
+        if let Some(credential) = credential {
             request = credential.attach(request, &self.client).await?;
         }
         let response = request.send().await?;
@@ -1079,6 +1090,35 @@ mod tests {
                 "{name}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn private_stream_with_unbound_cookie_returns_validation_error() {
+        let client = crate::PubkyHttpClient::testnet().unwrap();
+        let keys = test_pubkeys(2);
+        let user = &keys[0];
+        let homeserver = &keys[1];
+        let session =
+            PubkySession::from_cookie_credential(client.clone(), cookie_credential_for(user));
+
+        let result = EventStreamBuilder::for_homeserver(client, homeserver)
+            .add_users([(user, None)])
+            .unwrap()
+            .path("/priv/app/")
+            .session(&session)
+            .subscribe_internal()
+            .await;
+
+        let Err(err) = result else {
+            panic!("private stream should fail before request");
+        };
+        let Error::Request(RequestError::Validation { message }) = err else {
+            panic!("expected validation error");
+        };
+        assert!(
+            message.contains("cannot attach session credential"),
+            "got: {message}"
+        );
     }
 
     #[test]

--- a/pubky-sdk/src/actors/event_stream.rs
+++ b/pubky-sdk/src/actors/event_stream.rs
@@ -53,8 +53,38 @@
 //! # Ok(())
 //! # }
 //! ```
+//!
+//! # Example: Private events (authenticated)
+//!
+//! Attach a session with [`EventStreamBuilder::session`] and request a
+//! `/priv/...` [`path`](EventStreamBuilder::path). The homeserver authorizes the
+//! private scope against the session's read capabilities; public subscriptions
+//! need no session.
+//! ```no_run
+//! use pubky::{Pubky, PubkySession};
+//! use futures_util::StreamExt;
+//!
+//! # async fn example(session: PubkySession) -> pubky::Result<()> {
+//! let pubky = Pubky::new()?;
+//! let user = session.public_key();
+//!
+//! let mut stream = pubky.event_stream_for_user(&user, None)
+//!     .session(&session)
+//!     .path("/priv/app/")
+//!     .live()
+//!     .subscribe()
+//!     .await?;
+//!
+//! while let Some(result) = stream.next().await {
+//!     let event = result?;
+//!     println!("Private event: {:?} at {}", event.event_type, event.resource);
+//! }
+//! # Ok(())
+//! # }
+//! ```
 
 use std::pin::Pin;
+use std::sync::Arc;
 
 use crate::PublicKey;
 use base64::Engine;
@@ -67,8 +97,11 @@ use url::Url;
 pub use pubky_common::events::{EventCursor, EventType};
 
 use crate::{
-    Pkdns, PubkyHttpClient, PubkyResource, cross_log,
+    Pkdns, PubkyHttpClient, PubkyResource, PubkySession,
+    actors::session::credential::SessionCredential,
+    cross_log,
     errors::{Error, RequestError, Result},
+    util::check_http_status,
 };
 
 /// A single event from the event stream.
@@ -93,7 +126,8 @@ pub struct EventStreamBuilder {
     limit: Option<u16>,
     live: bool,
     reverse: bool,
-    path: Option<String>,
+    paths: Vec<String>,
+    credential: Option<Arc<dyn SessionCredential>>,
 }
 
 impl EventStreamBuilder {
@@ -136,7 +170,8 @@ impl EventStreamBuilder {
             limit: None,
             live: false,
             reverse: false,
-            path: None,
+            paths: Vec::new(),
+            credential: None,
         }
     }
 
@@ -181,7 +216,8 @@ impl EventStreamBuilder {
             limit: None,
             live: false,
             reverse: false,
-            path: None,
+            paths: Vec::new(),
+            credential: None,
         }
     }
 
@@ -283,12 +319,35 @@ impl EventStreamBuilder {
         self
     }
 
-    /// Filter events by path prefix.
+    /// Filter events by path. Repeatable: call once per path to receive the
+    /// union of several scopes (e.g. `/pub/` plus a private `/priv/app/`).
     ///
-    /// Format: Path WITHOUT `pubky://` scheme or user pubkey (e.g., "/pub/files/" or "/pub/").
+    /// Format: a path WITHOUT the `pubky://` scheme or user pubkey. A trailing
+    /// slash matches a directory and all its descendants (`/pub/files/`); no
+    /// trailing slash matches an exact file (`/pub/notes.txt`).
+    ///
+    /// Private (`/priv/...`) paths require a session attached via
+    /// [`Self::session`]; without one the homeserver rejects the subscription
+    /// with `401 Unauthorized`.
     #[must_use]
     pub fn path<S: Into<String>>(mut self, path: S) -> Self {
-        self.path = Some(path.into());
+        self.paths.push(path.into());
+        self
+    }
+
+    /// Authenticate the subscription with a user session.
+    ///
+    /// Required to receive private (`/priv/...`) events: the session credential
+    /// (cookie or bearer token) is attached to the request so the homeserver can
+    /// authorize each private [`path`](Self::path) against the session's read
+    /// capabilities. Public subscriptions don't need this.
+    ///
+    /// The homeserver only authorizes private paths when the subscription names
+    /// exactly the session's own user (a single `user=`); otherwise it responds
+    /// with `403 Forbidden`.
+    #[must_use]
+    pub fn session(mut self, session: &PubkySession) -> Self {
+        self.credential = Some(Arc::clone(session.credential()));
         self
     }
 
@@ -317,7 +376,7 @@ impl EventStreamBuilder {
             if self.reverse {
                 query.append_pair("reverse", "true");
             }
-            if let Some(path) = &self.path {
+            for path in &self.paths {
                 query.append_pair("path", path);
             }
         }
@@ -367,18 +426,18 @@ impl EventStreamBuilder {
         );
 
         let url = self.build_request_url(&homeserver)?;
-        let response = self
-            .client
-            .cross_request(Method::GET, url)
-            .await?
-            .send()
-            .await?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let message = format!("Event stream request failed with status {status}");
-            return Err(Error::from(RequestError::Server { status, message }));
+        let mut request = self.client.cross_request(Method::GET, url).await?;
+        // Attach the session credential (cookie or bearer) when present so the
+        // homeserver can authorize any private `/priv/...` path filters.
+        if let Some(credential) = &self.credential {
+            request = credential.attach(request, &self.client).await?;
         }
+        let response = request.send().await?;
+
+        // Surface homeserver rejections (e.g. 401/403/400 for private-path
+        // authorization) as a typed `RequestError::Server` carrying the status
+        // and the server's message, rather than a hand-rolled string.
+        let response = check_http_status(response).await?;
 
         let sse_stream = response.bytes_stream().eventsource();
         let event_stream = sse_stream.filter_map(|result| async move {
@@ -871,7 +930,8 @@ mod tests {
         assert_eq!(builder.limit, Some(100));
         assert!(builder.live);
         assert!(!builder.reverse);
-        assert_eq!(builder.path, Some("/pub/posts/".to_string()));
+        assert_eq!(builder.paths, vec!["/pub/posts/".to_string()]);
+        assert!(builder.credential.is_none());
 
         // Builder chaining with reverse mode
         let builder = EventStreamBuilder::for_user(client, &keys[0], None)
@@ -881,7 +941,28 @@ mod tests {
         assert_eq!(builder.limit, Some(50));
         assert!(!builder.live);
         assert!(builder.reverse);
-        assert_eq!(builder.path, Some("/pub/files/".to_string()));
+        assert_eq!(builder.paths, vec!["/pub/files/".to_string()]);
+    }
+
+    #[test]
+    fn path_is_repeatable_and_accumulates() {
+        let client = crate::PubkyHttpClient::testnet().unwrap();
+        let keys = test_pubkeys(1);
+
+        // No path by default.
+        let builder = EventStreamBuilder::for_user(client.clone(), &keys[0], None);
+        assert!(builder.paths.is_empty());
+
+        // Each `.path()` call appends, preserving order (union of scopes).
+        let builder = builder.path("/pub/").path("/priv/app/").path("/priv/file");
+        assert_eq!(
+            builder.paths,
+            vec![
+                "/pub/".to_string(),
+                "/priv/app/".to_string(),
+                "/priv/file".to_string(),
+            ]
+        );
     }
 
     #[test]
@@ -969,6 +1050,34 @@ mod tests {
         assert!(
             !query_reverse.iter().any(|(k, _)| k == "live"),
             "Should not have live param when reverse is set"
+        );
+    }
+
+    #[test]
+    fn build_request_url_emits_repeated_path_params() {
+        let client = crate::PubkyHttpClient::testnet().unwrap();
+        let keys = test_pubkeys(2);
+        let homeserver = &keys[0];
+        let user = &keys[1];
+
+        // A mixed public + private subscription emits one `path=` per filter,
+        // matching the server's repeatable `path` query from #429.
+        let builder = EventStreamBuilder::for_homeserver(client, homeserver)
+            .add_users([(user, None)])
+            .unwrap()
+            .path("/pub/")
+            .path("/priv/app/");
+
+        let url = builder.build_request_url(homeserver).unwrap();
+        let path_params: Vec<String> = url
+            .query_pairs()
+            .filter(|(k, _)| k == "path")
+            .map(|(_, v)| v.to_string())
+            .collect();
+
+        assert_eq!(
+            path_params,
+            vec!["/pub/".to_string(), "/priv/app/".to_string()]
         );
     }
 

--- a/pubky-sdk/src/actors/event_stream.rs
+++ b/pubky-sdk/src/actors/event_stream.rs
@@ -385,26 +385,37 @@ impl EventStreamBuilder {
         Ok(url)
     }
 
-    /// Resolve a user's homeserver via Pkarr, mapping a resolution failure to a
-    /// typed validation error.
-    async fn resolve_homeserver(&self, user: &PublicKey) -> Result<PublicKey> {
-        Pkdns::with_client(self.client.clone())
-            .get_homeserver_of(user)
-            .await
-            .ok_or_else(|| {
-                Error::from(RequestError::Validation {
-                    message: format!("Could not resolve homeserver for user {user}"),
-                })
-            })
-    }
-
     /// Whether any requested [`path`](Self::path) targets a private (`/priv/...`)
     /// scope. Only private paths require authentication; `/pub/` is world-readable.
     fn has_private_path_filter(&self) -> bool {
-        self.paths.iter().any(|path| {
-            let path = path.trim_start_matches('/');
-            path == "priv" || path.starts_with("priv/")
-        })
+        self.paths
+            .iter()
+            .any(|path| Self::is_private_path_filter(path))
+    }
+
+    fn is_private_path_filter(path: &str) -> bool {
+        let mut segments = Vec::new();
+        for segment in path.split('/') {
+            match segment {
+                "" | "." => {}
+                ".." => {
+                    if segments.pop().is_none() {
+                        return false;
+                    }
+                }
+                segment => segments.push(segment),
+            }
+        }
+
+        if segments.is_empty() {
+            return false;
+        }
+
+        let mut normalized = format!("/{}", segments.join("/"));
+        if (path.ends_with('/') || path.ends_with("..")) && !normalized.ends_with('/') {
+            normalized.push('/');
+        }
+        normalized.starts_with("/priv/")
     }
 
     /// Whether `credential` should be attached to this subscription.
@@ -445,7 +456,9 @@ impl EventStreamBuilder {
         let homeserver = if let Some(hs) = &self.homeserver {
             hs.clone()
         } else {
-            self.resolve_homeserver(&self.users[0].0).await?
+            Pkdns::with_client(self.client.clone())
+                .require_homeserver_of(&self.users[0].0)
+                .await?
         };
 
         cross_log!(
@@ -1053,6 +1066,11 @@ mod tests {
         );
         assert!(
             EventStreamBuilder::for_user(client.clone(), user, None)
+                .path("/priv/")
+                .has_private_path_filter()
+        );
+        assert!(
+            EventStreamBuilder::for_user(client.clone(), user, None)
                 .path("priv/x")
                 .has_private_path_filter()
         );
@@ -1060,6 +1078,24 @@ mod tests {
             EventStreamBuilder::for_user(client, user, None)
                 .path("/pub/")
                 .path("/priv/app/")
+                .has_private_path_filter()
+        );
+    }
+
+    #[test]
+    fn has_private_path_filter_normalizes_before_classifying() {
+        let client = crate::PubkyHttpClient::testnet().unwrap();
+        let keys = test_pubkeys(1);
+        let user = &keys[0];
+
+        assert!(
+            EventStreamBuilder::for_user(client.clone(), user, None)
+                .path("/pub/../priv/secret/")
+                .has_private_path_filter()
+        );
+        assert!(
+            !EventStreamBuilder::for_user(client, user, None)
+                .path("/priv")
                 .has_private_path_filter()
         );
     }
@@ -1088,6 +1124,12 @@ mod tests {
         assert!(
             EventStreamBuilder::for_user(client.clone(), alice, None)
                 .path("/priv/app/")
+                .should_attach_credential(&alice_cred)
+        );
+
+        assert!(
+            EventStreamBuilder::for_user(client.clone(), alice, None)
+                .path("/pub/../priv/secret/")
                 .should_attach_credential(&alice_cred)
         );
 

--- a/pubky-sdk/src/actors/event_stream.rs
+++ b/pubky-sdk/src/actors/event_stream.rs
@@ -384,6 +384,19 @@ impl EventStreamBuilder {
         Ok(url)
     }
 
+    /// Resolve a user's homeserver via Pkarr, mapping a resolution failure to a
+    /// typed validation error.
+    async fn resolve_homeserver(&self, user: &PublicKey) -> Result<PublicKey> {
+        Pkdns::with_client(self.client.clone())
+            .get_homeserver_of(user)
+            .await
+            .ok_or_else(|| {
+                Error::from(RequestError::Validation {
+                    message: format!("Could not resolve homeserver for user {user}"),
+                })
+            })
+    }
+
     /// Internal helper that contains the shared subscription logic.
     async fn subscribe_internal(self) -> Result<impl Stream<Item = Result<Event>>> {
         if self.live && self.reverse {
@@ -403,19 +416,33 @@ impl EventStreamBuilder {
             }));
         }
 
-        // Use pre-set homeserver or resolve from first user
-        let homeserver = if let Some(hs) = &self.homeserver {
+        // The session owner (the user the credential authenticates as), if any.
+        let session_owner = self
+            .credential
+            .as_ref()
+            .map(|credential| credential.info().public_key().clone());
+
+        // Resolve the homeserver we will send the request to.
+        //
+        // When a session credential is attached it must ONLY ever be transmitted
+        // to its owner's homeserver. We resolve the owner's homeserver and, if the
+        // caller also pinned one explicitly, require the two to match.
+        let homeserver = if let Some(owner) = &session_owner {
+            let owner_homeserver = self.resolve_homeserver(owner).await?;
+            if let Some(pinned) = &self.homeserver
+                && *pinned != owner_homeserver
+            {
+                return Err(Error::from(RequestError::Validation {
+                    message: format!(
+                        "refusing to attach the session credential: target homeserver {pinned} is not the session owner's homeserver {owner_homeserver}"
+                    ),
+                }));
+            }
+            owner_homeserver
+        } else if let Some(hs) = &self.homeserver {
             hs.clone()
         } else {
-            let (first_user, _) = &self.users[0];
-            Pkdns::with_client(self.client.clone())
-                .get_homeserver_of(first_user)
-                .await
-                .ok_or_else(|| {
-                    Error::from(RequestError::Validation {
-                        message: format!("Could not resolve homeserver for user {first_user}"),
-                    })
-                })?
+            self.resolve_homeserver(&self.users[0].0).await?
         };
 
         cross_log!(

--- a/pubky-sdk/src/actors/event_stream.rs
+++ b/pubky-sdk/src/actors/event_stream.rs
@@ -56,10 +56,10 @@
 //!
 //! # Example: Private events (authenticated)
 //!
-//! Attach a session with [`EventStreamBuilder::session`] and request a
+//! Attach a **grant** session with [`EventStreamBuilder::session`] and request a
 //! `/priv/...` [`path`](EventStreamBuilder::path). The homeserver authorizes the
-//! private scope against the session's read capabilities; public subscriptions
-//! need no session.
+//! private scope against the session's read capabilities. Private event streams
+//! require a grant-backed session; public subscriptions need no session.
 //! ```no_run
 //! use pubky::{Pubky, PubkySession};
 //! use futures_util::StreamExt;
@@ -326,7 +326,7 @@ impl EventStreamBuilder {
     /// slash matches a directory and all its descendants (`/pub/files/`); no
     /// trailing slash matches an exact file (`/pub/notes.txt`).
     ///
-    /// Private (`/priv/...`) paths require a session attached via
+    /// Private (`/priv/...`) paths require a grant-backed session attached via
     /// [`Self::session`]; without one the homeserver rejects the subscription
     /// with `401 Unauthorized`.
     #[must_use]
@@ -335,16 +335,16 @@ impl EventStreamBuilder {
         self
     }
 
-    /// Authenticate the subscription with a user session.
+    /// Authenticate the subscription with a **grant** session.
     ///
-    /// Required to receive private (`/priv/...`) events: the session credential
-    /// (cookie or bearer token) is attached to the request so the homeserver can
-    /// authorize each private [`path`](Self::path) against the session's read
-    /// capabilities. Public subscriptions don't need this.
+    /// Required to receive private (`/priv/...`) events: the session's grant
+    /// bearer is attached so the homeserver can authorize each private
+    /// [`path`](Self::path) against the session's read capabilities. Public
+    /// subscriptions need no session.
     ///
-    /// The homeserver only authorizes private paths when the subscription names
-    /// exactly the session's own user (a single `user=`); otherwise it responds
-    /// with `403 Forbidden`.
+    /// Private event streams are grant-only. A legacy cookie session is never
+    /// attached here, so a cookie-backed `/priv/...` subscription stays anonymous
+    /// and the homeserver rejects it with `401`.
     #[must_use]
     pub fn session(mut self, session: &PubkySession) -> Self {
         self.credential = Some(Arc::clone(session.credential()));
@@ -397,6 +397,28 @@ impl EventStreamBuilder {
             })
     }
 
+    /// Whether any requested [`path`](Self::path) targets a private (`/priv/...`)
+    /// scope. Only private paths require authentication; `/pub/` is world-readable.
+    fn has_private_path_filter(&self) -> bool {
+        self.paths.iter().any(|path| {
+            let path = path.trim_start_matches('/');
+            path == "priv" || path.starts_with("priv/")
+        })
+    }
+
+    /// Whether `credential` should be attached to this subscription.
+    fn should_attach_credential(&self, credential: &dyn SessionCredential) -> bool {
+        if !self.has_private_path_filter() {
+            return false;
+        }
+
+        let [(user, _)] = self.users.as_slice() else {
+            return false;
+        };
+
+        user == credential.info().public_key()
+    }
+
     /// Internal helper that contains the shared subscription logic.
     async fn subscribe_internal(self) -> Result<impl Stream<Item = Result<Event>>> {
         if self.live && self.reverse {
@@ -416,11 +438,9 @@ impl EventStreamBuilder {
             }));
         }
 
-        // The session owner (the user the credential authenticates as), if any.
-        // Resolve the homeserver from the subscription itself: an explicit
-        // homeserver if given, otherwise the first user's. An attached session
-        // must never change WHERE the request goes, only WHETHER a credential is
-        // attached (below).
+        // Resolve the target homeserver from the subscription (explicit if given,
+        // else the first user's). A session only decides WHETHER a credential is
+        // attached, never WHERE the request goes.
         let homeserver = if let Some(hs) = &self.homeserver {
             hs.clone()
         } else {
@@ -435,17 +455,20 @@ impl EventStreamBuilder {
         );
 
         let url = self.build_request_url(&homeserver)?;
-        let mut request = self.client.cross_request(Method::GET, url).await?;
-        // Attach the session credential (cookie or bearer) only when the target
-        // is the session owners own homeserver, so a session token is never sent
-        // to a homeserver that isn't its owners. On a mismatch the request stays
-        // unauthenticated and the homeserver rejects any private `/priv/...` path
-        // with 401.
-        if let Some(credential) = &self.credential {
-            let owner = credential.info().public_key().clone();
-            if self.resolve_homeserver(&owner).await? == homeserver {
-                request = credential.attach(request, &self.client).await?;
-            }
+        // Anonymous by default so an ambient browser cookie can't authenticate a
+        // private stream; a credential is attached below only when intended.
+        let mut request = self
+            .client
+            .cross_request_anonymous(Method::GET, url)
+            .await?;
+        // Attach only for a private stream scoped to the credential's own single
+        // user and bound to the target homeserver. Cookies return
+        // `can_attach_to == false`, so private streams are grant-only.
+        if let Some(credential) = &self.credential
+            && self.should_attach_credential(credential.as_ref())
+            && credential.can_attach_to(&homeserver).await
+        {
+            request = credential.attach(request, &self.client).await?;
         }
         let response = request.send().await?;
 
@@ -977,6 +1000,111 @@ mod tests {
                 "/priv/app/".to_string(),
                 "/priv/file".to_string(),
             ]
+        );
+    }
+
+    /// Build a real (cookie) credential for `user`, to exercise the private-scope
+    /// gate without a homeserver.
+    fn cookie_credential_for(
+        user: &PublicKey,
+    ) -> crate::actors::auth::cookie::credential::CookieCredential {
+        use pubky_common::{
+            capabilities::{Capabilities, Capability},
+            session::CookieSessionRecord,
+        };
+        let record =
+            CookieSessionRecord::new(user, Capabilities::from(vec![Capability::root()]), None);
+        crate::actors::auth::cookie::credential::CookieCredential::new(
+            user.clone(),
+            Some("test-cookie".to_string()),
+            record,
+        )
+    }
+
+    #[test]
+    fn has_private_path_filter_detects_priv_scopes() {
+        let client = crate::PubkyHttpClient::testnet().unwrap();
+        let keys = test_pubkeys(1);
+        let user = &keys[0];
+
+        // Public-only and empty subscriptions are not private.
+        assert!(
+            !EventStreamBuilder::for_user(client.clone(), user, None)
+                .path("/pub/")
+                .has_private_path_filter()
+        );
+        assert!(
+            !EventStreamBuilder::for_user(client.clone(), user, None).has_private_path_filter()
+        );
+
+        // `/privstuff` is a distinct root, not `/priv/`.
+        assert!(
+            !EventStreamBuilder::for_user(client.clone(), user, None)
+                .path("/privstuff/x")
+                .has_private_path_filter()
+        );
+
+        // `/priv/...`, a leading-slash-less `priv/...`, and any mix count.
+        assert!(
+            EventStreamBuilder::for_user(client.clone(), user, None)
+                .path("/priv/app/")
+                .has_private_path_filter()
+        );
+        assert!(
+            EventStreamBuilder::for_user(client.clone(), user, None)
+                .path("priv/x")
+                .has_private_path_filter()
+        );
+        assert!(
+            EventStreamBuilder::for_user(client, user, None)
+                .path("/pub/")
+                .path("/priv/app/")
+                .has_private_path_filter()
+        );
+    }
+
+    #[test]
+    fn should_attach_credential_only_for_own_single_user_private_stream() {
+        let client = crate::PubkyHttpClient::testnet().unwrap();
+        let keys = test_pubkeys(2);
+        let alice = &keys[0];
+        let bob = &keys[1];
+        let alice_cred = cookie_credential_for(alice);
+
+        // Public-only subscription: never attach — public streams are anonymous.
+        assert!(
+            !EventStreamBuilder::for_user(client.clone(), alice, None)
+                .path("/pub/")
+                .should_attach_credential(&alice_cred)
+        );
+        // Even with no path (public-only default): never attach.
+        assert!(
+            !EventStreamBuilder::for_user(client.clone(), alice, None)
+                .should_attach_credential(&alice_cred)
+        );
+
+        // Private, single user == credential's user → attach.
+        assert!(
+            EventStreamBuilder::for_user(client.clone(), alice, None)
+                .path("/priv/app/")
+                .should_attach_credential(&alice_cred)
+        );
+
+        // Private, single user != credential's user → do not attach.
+        assert!(
+            !EventStreamBuilder::for_user(client.clone(), bob, None)
+                .path("/priv/app/")
+                .should_attach_credential(&alice_cred)
+        );
+
+        // Private, multi-user → do not attach even though the credential's user is
+        // among them.
+        assert!(
+            !EventStreamBuilder::for_homeserver(client, &keys[0])
+                .add_users([(alice, None), (bob, None)])
+                .unwrap()
+                .path("/priv/app/")
+                .should_attach_credential(&alice_cred)
         );
     }
 

--- a/pubky-sdk/src/actors/pkdns.rs
+++ b/pubky-sdk/src/actors/pkdns.rs
@@ -14,7 +14,7 @@ use pkarr::{
 
 use crate::{
     Keypair, PubkyHttpClient, PubkySigner, PublicKey, cross_log,
-    errors::{AuthError, Error, PkarrError, Result},
+    errors::{AuthError, Error, PkarrError, RequestError, Result},
 };
 
 /// Default staleness window for homeserver `_pubky` Pkarr records (1 hour).
@@ -139,10 +139,9 @@ impl Pkdns {
 
     // -------------------- Reads --------------------
 
-    /// Resolve current homeserver host for a user public key via Pkarr (no keypair required).
+    /// Resolve a user's homeserver public key via Pkarr.
     ///
-    /// Returns the `_pubky` SVCB/HTTPS target (domain or pubkey-as-host),
-    /// or `None` if the record is missing/unresolvable.
+    /// Returns `None` for missing records and for domain-only `_pubky` targets.
     pub async fn get_homeserver_of(&self, user_public_key: &PublicKey) -> Option<PublicKey> {
         cross_log!(
             info,
@@ -159,6 +158,20 @@ impl Pkdns {
             result
         );
         result
+    }
+
+    pub(crate) async fn require_homeserver_of(
+        &self,
+        user_public_key: &PublicKey,
+    ) -> Result<PublicKey> {
+        self.get_homeserver_of(user_public_key)
+            .await
+            .ok_or_else(|| {
+                RequestError::Validation {
+                    message: format!("could not resolve homeserver for {}", user_public_key.z32()),
+                }
+                .into()
+            })
     }
 
     /// Convenience: resolve the homeserver for **this** user (requires keypair on `Pkdns`).
@@ -436,6 +449,27 @@ pub fn extract_host_from_packet(packet: &SignedPacket) -> Option<String> {
 mod tests {
     use super::*;
     use pkarr::dns::rdata::TXT;
+
+    #[tokio::test]
+    async fn require_homeserver_of_returns_validation_when_unresolved() {
+        let client = PubkyHttpClient::builder()
+            .pkarr(|b| b.no_default_network().bootstrap(&["127.0.0.1:1"]))
+            .build()
+            .expect("client");
+        let pkdns = Pkdns::with_client(client);
+        let user = Keypair::random().public_key();
+
+        let err = pkdns
+            .require_homeserver_of(&user)
+            .await
+            .expect_err("missing homeserver should be a validation error");
+
+        assert!(matches!(
+            err,
+            Error::Request(crate::errors::RequestError::Validation { message })
+                if message == format!("could not resolve homeserver for {}", user.z32())
+        ));
+    }
 
     #[test]
     fn republish_preserves_non_pubky_records() {

--- a/pubky-sdk/src/actors/session/credential.rs
+++ b/pubky-sdk/src/actors/session/credential.rs
@@ -80,6 +80,10 @@ pub(crate) trait SessionCredential: Debug + Send + Sync {
     /// browser jar on WASM).
     async fn attach(&self, rb: RequestBuilder, client: &PubkyHttpClient) -> Result<RequestBuilder>;
 
+    /// Whether this credential may be attached to a request targeting
+    /// `homeserver`.
+    async fn can_attach_to(&self, homeserver: &PublicKey) -> bool;
+
     /// Round-trip the homeserver to verify this credential is still valid.
     ///
     /// Returns:

--- a/pubky-sdk/src/actors/signer/session.rs
+++ b/pubky-sdk/src/actors/signer/session.rs
@@ -101,12 +101,8 @@ impl PubkySigner {
         client_id: ClientId,
         mode: PublishMode,
     ) -> Result<PubkySession> {
-        let homeserver = self.pkdns().get_homeserver().await?.ok_or_else(|| {
-            crate::errors::AuthError::Validation(format!(
-                "could not resolve homeserver for {}",
-                self.keypair.public_key().z32()
-            ))
-        })?;
+        let user = self.keypair.public_key();
+        let homeserver = self.pkdns().require_homeserver_of(&user).await?;
         let client_keypair = Keypair::random();
         let (grant_jws, grant_claims) = self.session_grant(client_id, &client_keypair);
         let client_signer = GrantPopSigner::local(client_keypair);
@@ -178,12 +174,8 @@ impl PubkySigner {
 
     async fn signin_cookie_with_publish(&self, mode: PublishMode) -> Result<PubkySession> {
         let token = self.root_capability_token();
-        let homeserver = self.pkdns().get_homeserver().await?.ok_or_else(|| {
-            crate::errors::AuthError::Validation(format!(
-                "could not resolve homeserver for {}",
-                self.keypair.public_key().z32()
-            ))
-        })?;
+        let user = self.keypair.public_key();
+        let homeserver = self.pkdns().require_homeserver_of(&user).await?;
         let credential =
             CookieCredential::from_auth_token(&token, &self.client, Some(homeserver)).await?;
         let session = PubkySession::from_cookie_credential(self.client.clone(), credential);

--- a/pubky-sdk/src/actors/signer/session.rs
+++ b/pubky-sdk/src/actors/signer/session.rs
@@ -175,9 +175,9 @@ impl PubkySigner {
     async fn signin_cookie_with_publish(&self, mode: PublishMode) -> Result<PubkySession> {
         let token = self.root_capability_token();
         let user = self.keypair.public_key();
-        let homeserver = self.pkdns().require_homeserver_of(&user).await?;
+        let homeserver = self.pkdns().get_homeserver_of(&user).await;
         let credential =
-            CookieCredential::from_auth_token(&token, &self.client, Some(homeserver)).await?;
+            CookieCredential::from_auth_token(&token, &self.client, homeserver).await?;
         let session = PubkySession::from_cookie_credential(self.client.clone(), credential);
         self.publish_after_signin(mode).await?;
         Ok(session)

--- a/pubky-sdk/src/actors/signer/session.rs
+++ b/pubky-sdk/src/actors/signer/session.rs
@@ -146,7 +146,8 @@ impl PubkySigner {
             .await?;
 
         self.publish_signup_homeserver(homeserver).await?;
-        let cookie_credential = CookieCredential::from_response(response).await?;
+        let cookie_credential =
+            CookieCredential::from_response(response, Some(homeserver.clone())).await?;
         Ok(PubkySession::from_credential(
             self.client.clone(),
             Arc::new(cookie_credential),
@@ -174,7 +175,11 @@ impl PubkySigner {
 
     async fn signin_cookie_with_publish(&self, mode: PublishMode) -> Result<PubkySession> {
         let token = self.root_capability_token();
-        let credential = CookieCredential::from_auth_token(&token, &self.client).await?;
+        // Best-effort: if resolution is unavailable the cookie stays unbound and
+        // hydrates on its first successful revalidate.
+        let homeserver = self.pkdns().get_homeserver().await.ok().flatten();
+        let credential =
+            CookieCredential::from_auth_token(&token, &self.client, homeserver).await?;
         let session = PubkySession::from_cookie_credential(self.client.clone(), credential);
         self.publish_after_signin(mode).await?;
         Ok(session)

--- a/pubky-sdk/src/actors/signer/session.rs
+++ b/pubky-sdk/src/actors/signer/session.rs
@@ -178,11 +178,14 @@ impl PubkySigner {
 
     async fn signin_cookie_with_publish(&self, mode: PublishMode) -> Result<PubkySession> {
         let token = self.root_capability_token();
-        // Best-effort: if resolution is unavailable the cookie stays unbound and
-        // hydrates on its first successful revalidate.
-        let homeserver = self.pkdns().get_homeserver().await.ok().flatten();
+        let homeserver = self.pkdns().get_homeserver().await?.ok_or_else(|| {
+            crate::errors::AuthError::Validation(format!(
+                "could not resolve homeserver for {}",
+                self.keypair.public_key().z32()
+            ))
+        })?;
         let credential =
-            CookieCredential::from_auth_token(&token, &self.client, homeserver).await?;
+            CookieCredential::from_auth_token(&token, &self.client, Some(homeserver)).await?;
         let session = PubkySession::from_cookie_credential(self.client.clone(), credential);
         self.publish_after_signin(mode).await?;
         Ok(session)

--- a/pubky-sdk/src/client/http_targets/mod.rs
+++ b/pubky-sdk/src/client/http_targets/mod.rs
@@ -1,4 +1,20 @@
+use crate::{PublicKey, Result};
+use url::Url;
+
 #[cfg(not(target_arch = "wasm32"))]
 pub mod native;
 #[cfg(target_arch = "wasm32")]
 pub mod wasm;
+
+fn homeserver_url(homeserver: &PublicKey, path: &str) -> Result<Url> {
+    let path = if path.starts_with('/') {
+        path.to_string()
+    } else {
+        format!("/{path}")
+    };
+    Ok(Url::parse(&format!(
+        "https://{}{}",
+        homeserver.z32(),
+        path
+    ))?)
+}

--- a/pubky-sdk/src/client/http_targets/native.rs
+++ b/pubky-sdk/src/client/http_targets/native.rs
@@ -177,6 +177,18 @@ impl PubkyHttpClient {
         self.build_pubky_request(method, &url, &pk, &transport)
     }
 
+    /// Like [`Self::cross_request`]. Native has no ambient cookie jar (the cookie
+    /// credential attaches its secret via an explicit `Cookie` header), so this
+    /// is identical to `cross_request`; it exists to mirror the WASM API, which
+    /// drops `credentials: include` here.
+    pub(crate) async fn cross_request_anonymous(
+        &self,
+        method: Method,
+        url: Url,
+    ) -> Result<RequestBuilder> {
+        self.cross_request(method, url).await
+    }
+
     /// Build a [`RequestBuilder`] for a resolved pubky host transport.
     fn build_pubky_request(
         &self,

--- a/pubky-sdk/src/client/http_targets/native.rs
+++ b/pubky-sdk/src/client/http_targets/native.rs
@@ -2,6 +2,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 use std::time::{Duration, Instant};
 
+use super::homeserver_url;
 use futures_util::StreamExt;
 use tokio::net::TcpStream;
 
@@ -187,6 +188,31 @@ impl PubkyHttpClient {
         url: Url,
     ) -> Result<RequestBuilder> {
         self.cross_request(method, url).await
+    }
+
+    /// Build a request transported through `homeserver` while addressing
+    /// `pubky_host` as the logical tenant on that homeserver.
+    pub(crate) async fn cross_request_via_homeserver(
+        &self,
+        method: Method,
+        homeserver: &PublicKey,
+        pubky_host: &PublicKey,
+        path: &str,
+    ) -> Result<RequestBuilder> {
+        let url = homeserver_url(homeserver, path)?;
+        let homeserver_z32 = homeserver.z32();
+        let pubky_host_z32 = pubky_host.z32();
+        let transport = self.transport.resolve(&homeserver_z32, &self.pkarr).await;
+
+        match transport {
+            ResolvedTransport::PubkyTls => Ok(self
+                .http
+                .request(method, url.as_str())
+                .header("pubky-host", pubky_host_z32)),
+            ResolvedTransport::Icann { .. } => {
+                self.build_pubky_request(method, &url, &pubky_host_z32, &transport)
+            }
+        }
     }
 
     /// Build a [`RequestBuilder`] for a resolved pubky host transport.
@@ -440,6 +466,39 @@ mod tests {
             req.url()
         );
         assert_eq!(req.headers().get("pubky-host").unwrap(), &user_z32);
+    }
+
+    #[tokio::test]
+    async fn cross_request_via_homeserver_routes_to_homeserver_with_user_pubky_host() {
+        let homeserver = Keypair::random();
+        let user = Keypair::random();
+        let icann = SVCB::new(10, "example.com".try_into().unwrap());
+        let homeserver_packet = SignedPacket::builder()
+            .https(".".try_into().unwrap(), icann, 3600)
+            .sign(&homeserver)
+            .unwrap();
+
+        let mut builder = PubkyHttpClient::builder();
+        builder.pkarr(|b| b.no_default_network().bootstrap(&["127.0.0.1:1"]));
+        let client = builder.build().unwrap();
+        client
+            .pkarr
+            .cache()
+            .unwrap()
+            .put(&homeserver.public_key().into(), &homeserver_packet);
+        let homeserver_pk = PublicKey::try_from_z32(&homeserver.public_key().to_string()).unwrap();
+        let user_pk = PublicKey::try_from_z32(&user.public_key().to_string()).unwrap();
+
+        let req = client
+            .cross_request_via_homeserver(Method::POST, &homeserver_pk, &user_pk, "/session")
+            .await
+            .unwrap()
+            .build()
+            .unwrap();
+
+        assert_eq!(req.url().host_str(), Some("example.com"));
+        assert_eq!(req.url().path(), "/session");
+        assert_eq!(req.headers().get("pubky-host").unwrap(), &user_pk.z32());
     }
 
     #[tokio::test]

--- a/pubky-sdk/src/client/http_targets/native.rs
+++ b/pubky-sdk/src/client/http_targets/native.rs
@@ -178,10 +178,7 @@ impl PubkyHttpClient {
         self.build_pubky_request(method, &url, &pk, &transport)
     }
 
-    /// Like [`Self::cross_request`]. Native has no ambient cookie jar (the cookie
-    /// credential attaches its secret via an explicit `Cookie` header), so this
-    /// is identical to `cross_request`; it exists to mirror the WASM API, which
-    /// drops `credentials: include` here.
+    /// Native has no ambient browser cookie jar, so this is `cross_request`.
     pub(crate) async fn cross_request_anonymous(
         &self,
         method: Method,
@@ -190,8 +187,7 @@ impl PubkyHttpClient {
         self.cross_request(method, url).await
     }
 
-    /// Build a request transported through `homeserver` while addressing
-    /// `pubky_host` as the logical tenant on that homeserver.
+    /// Route through `homeserver` while addressing `pubky_host`.
     pub(crate) async fn cross_request_via_homeserver(
         &self,
         method: Method,

--- a/pubky-sdk/src/client/http_targets/wasm.rs
+++ b/pubky-sdk/src/client/http_targets/wasm.rs
@@ -1,5 +1,6 @@
 //! HTTP methods that support `https://` with Pkarr domains, including `_pubky.<pk>` URLs
 
+use super::homeserver_url;
 use crate::PublicKey;
 use crate::errors::{PkarrError, RequestError, Result};
 use crate::{PubkyHttpClient, cross_log};
@@ -43,6 +44,25 @@ impl PubkyHttpClient {
     ) -> Result<RequestBuilder> {
         self.cross_request_with_credentials(method, url, AmbientCredentials::Omit)
             .await
+    }
+
+    /// Build a credentialed request transported through `homeserver` while
+    /// addressing `pubky_host` as the logical tenant on that homeserver.
+    pub(crate) async fn cross_request_via_homeserver(
+        &self,
+        method: Method,
+        homeserver: &PublicKey,
+        pubky_host: &PublicKey,
+        path: &str,
+    ) -> Result<RequestBuilder> {
+        let mut url = homeserver_url(homeserver, path)?;
+        self.prepare_request(&mut url).await?;
+
+        Ok(self
+            .http
+            .request(method, url)
+            .fetch_credentials_include()
+            .header("pubky-host", pubky_host.z32()))
     }
 
     async fn cross_request_with_credentials<T: IntoUrl>(

--- a/pubky-sdk/src/client/http_targets/wasm.rs
+++ b/pubky-sdk/src/client/http_targets/wasm.rs
@@ -10,15 +10,9 @@ use pkarr::extra::endpoints::Endpoint;
 use reqwest::{IntoUrl, Method, RequestBuilder};
 use url::Url;
 
-/// Whether a WASM `fetch` should carry ambient browser credentials — i.e. the
-/// cookie jar for the target origin.
 #[derive(Clone, Copy)]
 enum AmbientCredentials {
-    /// `credentials: include` — send the origin's cookies. Required
-    /// by the legacy cookie auth flow, whose secret lives only in the browser jar.
     Include,
-    /// `credentials: omit` — never send ambient cookies. Used where a request
-    /// must be anonymous unless a credential is explicitly attached.
     Omit,
 }
 
@@ -33,10 +27,7 @@ impl PubkyHttpClient {
             .await
     }
 
-    /// Like [`Self::cross_request`], but never carries ambient browser
-    /// credentials. Use where a request must stay anonymous
-    /// unless a credential is intentionally attached — notably event-stream
-    /// subscriptions.
+    /// Like [`Self::cross_request`], but omits ambient browser cookies.
     pub(crate) async fn cross_request_anonymous<T: IntoUrl>(
         &self,
         method: Method,
@@ -46,8 +37,7 @@ impl PubkyHttpClient {
             .await
     }
 
-    /// Build a credentialed request transported through `homeserver` while
-    /// addressing `pubky_host` as the logical tenant on that homeserver.
+    /// Route through `homeserver` while addressing `pubky_host`.
     pub(crate) async fn cross_request_via_homeserver(
         &self,
         method: Method,

--- a/pubky-sdk/src/client/http_targets/wasm.rs
+++ b/pubky-sdk/src/client/http_targets/wasm.rs
@@ -9,6 +9,18 @@ use pkarr::extra::endpoints::Endpoint;
 use reqwest::{IntoUrl, Method, RequestBuilder};
 use url::Url;
 
+/// Whether a WASM `fetch` should carry ambient browser credentials — i.e. the
+/// cookie jar for the target origin.
+#[derive(Clone, Copy)]
+enum AmbientCredentials {
+    /// `credentials: include` — send the origin's cookies. Required
+    /// by the legacy cookie auth flow, whose secret lives only in the browser jar.
+    Include,
+    /// `credentials: omit` — never send ambient cookies. Used where a request
+    /// must be anonymous unless a credential is explicitly attached.
+    Omit,
+}
+
 impl PubkyHttpClient {
     /// A wrapper around [`PubkyHttpClient::request`], with the same signature between native and WASM.
     pub(crate) async fn cross_request<T: IntoUrl>(
@@ -16,15 +28,39 @@ impl PubkyHttpClient {
         method: Method,
         url: T,
     ) -> Result<RequestBuilder> {
+        self.cross_request_with_credentials(method, url, AmbientCredentials::Include)
+            .await
+    }
+
+    /// Like [`Self::cross_request`], but never carries ambient browser
+    /// credentials. Use where a request must stay anonymous
+    /// unless a credential is intentionally attached — notably event-stream
+    /// subscriptions.
+    pub(crate) async fn cross_request_anonymous<T: IntoUrl>(
+        &self,
+        method: Method,
+        url: T,
+    ) -> Result<RequestBuilder> {
+        self.cross_request_with_credentials(method, url, AmbientCredentials::Omit)
+            .await
+    }
+
+    async fn cross_request_with_credentials<T: IntoUrl>(
+        &self,
+        method: Method,
+        url: T,
+        credentials: AmbientCredentials,
+    ) -> Result<RequestBuilder> {
         let original_url = url.as_str();
         let mut url = Url::parse(original_url)?;
 
         let pubky_host = self.prepare_request(&mut url).await?;
 
-        let builder = self
-            .http
-            .request(method, url.clone())
-            .fetch_credentials_include();
+        let request = self.http.request(method, url.clone());
+        let builder = match credentials {
+            AmbientCredentials::Include => request.fetch_credentials_include(),
+            AmbientCredentials::Omit => request.fetch_credentials_omit(),
+        };
 
         let builder = if let Some(pubky_host) = pubky_host {
             builder.header("pubky-host", pubky_host)

--- a/pubky-sdk/src/pubky.rs
+++ b/pubky-sdk/src/pubky.rs
@@ -209,11 +209,9 @@ impl Pubky {
         Pkdns::with_client(self.client.clone())
     }
 
-    /// Resolve current homeserver host for a user public key via Pkarr.
+    /// Resolve a user's homeserver public key via Pkarr.
     ///
-    /// Returns the `_pubky` SVCB/HTTPS target (domain or pubkey-as-host),
-    /// or `None` if the record is missing/unresolvable. Uses an internal
-    /// read-only [`Pkdns`] actor.
+    /// Returns `None` for missing records and for domain-only `_pubky` targets.
     pub async fn get_homeserver_of(&self, user_public_key: &PublicKey) -> Option<PublicKey> {
         Pkdns::with_client(self.client.clone())
             .get_homeserver_of(user_public_key)


### PR DESCRIPTION
Closes #438.

### Summary

Extends the SDK's `EventStreamBuilder` so apps can subscribe to a user's private
(`/priv/...`) events, not just public ones. The homeserver side already landed in
#429 (repeatable `path=` params + per-path authorization), this PR is the SDK/bindings
half that lets callers actually drive it.

Two builder additions:
- **`.path()` is now repeatable** — call it once per scope to receive the union
  (e.g. `/pub/` plus a private `/priv/app/`). Previously it was a single overwrite-on-recall `Option<String>`.
- **`.session(&PubkySession)`** — attaches the session credential so the homeserver can authorize each private path against the session's read capabilities.

### API

```rust
let mut stream = pubky
    .event_stream_for_user(&user, None)
    .session(&session)        // new: authenticate the subscription
    .path("/pub/")            // repeatable
    .path("/priv/app/")       // private scope, authorized server-side
    .live()
    .subscribe()
    .await?;
```

### Auth behavior
- Public-only streams stay anonymous, even when a session is provided.
- Private streams attach a session credential only for a single-user subscription where the session belongs to that user.
- Session credentials are only attached to their bound target homeserver, so the SDK fails early instead of sending cookies or bearers to the wrong homeserver.
- On the homeserver, a valid bearer authenticates normally. If an `Authorization: Bearer ...` header is present, the event-stream cookie fallback is disabled, even when the bearer is invalid.
- Cookie auth is still supported for single-tenant private streams by resolving the cookie for the requested user= tenant.

### Acceptance criteria
- [x] A subscription with a `/priv/app/` path + session receives that user's private events.
- [x] The same subscription **without** a covering cap receives none (server-enforced).
- [x] Public subscriptions (no path / `/pub/`) behave as before.