### PR TITLE
test(homeserver): private storage user quotas tests

### DIFF
--- a/e2e/src/tests/storage/quotas.rs
+++ b/e2e/src/tests/storage/quotas.rs
@@ -22,7 +22,8 @@ async fn put_quota_applied() {
         .unwrap();
 
     let p1 = "/pub/data";
-    let p2 = "/pub/data2";
+    // `/priv/` draws from the same quota bucket as `/pub/`.
+    let p2 = "/priv/data2";
 
     // First 600 KB → OK (201)
     let data_600k: Vec<u8> = vec![0; 600_000];
@@ -77,61 +78,6 @@ async fn put_quota_applied() {
     assert_eq!(resp.status(), StatusCode::CREATED);
 }
 
-/// A `/priv/` write is rejected with 507 once the shared bucket
-/// is exhausted, and freeing `/pub/` space lets the same `/priv/` write succeed.
-#[tokio::test]
-#[pubky_testnet::test]
-async fn priv_writes_count_toward_quota() {
-    let mut testnet = Testnet::new().await.unwrap();
-    let pubky = testnet.sdk().unwrap();
-
-    let mut mock_dir = MockDataDir::test();
-    mock_dir.config_toml.storage.default_quota_mb = Some(1); // 1 MB
-    let server = testnet
-        .create_homeserver_app_with_mock(mock_dir)
-        .await
-        .unwrap();
-
-    let signer = pubky.signer(Keypair::random());
-    let session = signer
-        .signup_cookie(&server.public_key(), None)
-        .await
-        .unwrap();
-
-    let data_600k: Vec<u8> = vec![0; 600_000];
-
-    // 600 KB to /pub → OK (201).
-    let resp = session
-        .storage()
-        .put("/pub/data", data_600k.clone())
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::CREATED);
-
-    // 600 KB to /priv → combined 1.2 MB exceeds the shared 1 MB quota → 507.
-    let err = session
-        .storage()
-        .put("/priv/data", data_600k.clone())
-        .await
-        .unwrap_err();
-    assert!(matches!(
-        err,
-        Error::Request(RequestError::Server { status, .. })
-            if status == StatusCode::INSUFFICIENT_STORAGE
-    ));
-
-    // Free the /pub file → 204.
-    let resp = session.storage().delete("/pub/data").await.unwrap();
-    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
-
-    // Now the same /priv write fits in the freed quota → 201.
-    let resp = session
-        .storage()
-        .put("/priv/data", data_600k)
-        .await
-        .unwrap();
-    assert_eq!(resp.status(), StatusCode::CREATED);
-}
 /// Regression test: quota early-rejection still works when bandwidth throttling
 /// is active. The bandwidth middleware wraps the request body in a throttled
 /// stream that loses `body.size_hint()`. The fix reads Content-Length from

--- a/e2e/src/tests/storage/quotas.rs
+++ b/e2e/src/tests/storage/quotas.rs
@@ -76,6 +76,62 @@ async fn put_quota_applied() {
     let resp = session.storage().put(p1, data_1mb_minus_256).await.unwrap();
     assert_eq!(resp.status(), StatusCode::CREATED);
 }
+
+/// A `/priv/` write is rejected with 507 once the shared bucket
+/// is exhausted, and freeing `/pub/` space lets the same `/priv/` write succeed.
+#[tokio::test]
+#[pubky_testnet::test]
+async fn priv_writes_count_toward_quota() {
+    let mut testnet = Testnet::new().await.unwrap();
+    let pubky = testnet.sdk().unwrap();
+
+    let mut mock_dir = MockDataDir::test();
+    mock_dir.config_toml.storage.default_quota_mb = Some(1); // 1 MB
+    let server = testnet
+        .create_homeserver_app_with_mock(mock_dir)
+        .await
+        .unwrap();
+
+    let signer = pubky.signer(Keypair::random());
+    let session = signer
+        .signup_cookie(&server.public_key(), None)
+        .await
+        .unwrap();
+
+    let data_600k: Vec<u8> = vec![0; 600_000];
+
+    // 600 KB to /pub → OK (201).
+    let resp = session
+        .storage()
+        .put("/pub/data", data_600k.clone())
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+
+    // 600 KB to /priv → combined 1.2 MB exceeds the shared 1 MB quota → 507.
+    let err = session
+        .storage()
+        .put("/priv/data", data_600k.clone())
+        .await
+        .unwrap_err();
+    assert!(matches!(
+        err,
+        Error::Request(RequestError::Server { status, .. })
+            if status == StatusCode::INSUFFICIENT_STORAGE
+    ));
+
+    // Free the /pub file → 204.
+    let resp = session.storage().delete("/pub/data").await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    // Now the same /priv write fits in the freed quota → 201.
+    let resp = session
+        .storage()
+        .put("/priv/data", data_600k)
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+}
 /// Regression test: quota early-rejection still works when bandwidth throttling
 /// is active. The bandwidth middleware wraps the request body in a throttled
 /// stream that loses `body.size_hint()`. The fix reads Content-Length from

--- a/pubky-homeserver/src/client_server/routes/tenants/write.rs
+++ b/pubky-homeserver/src/client_server/routes/tenants/write.rs
@@ -201,6 +201,26 @@ mod tests {
             .expect_err("content + metadata should exceed 1 MB quota");
     }
 
+    /// The Content-Length pre-check is namespace-agnostic,
+    /// a `/priv/` path is checked against the storage quota exactly like `/pub/`.
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_priv_path_checked_like_pub() {
+        let db = SqlDb::test().await;
+        let pk = Keypair::random().public_key();
+        let user = UserRepository::create_with_quota_mb(&db, &pk, 1).await;
+
+        // Small /priv file → within quota.
+        check_hint(&db, &user, None, "/priv/app/small.txt", Some(100))
+            .await
+            .expect("small /priv file should be within 1 MB quota");
+
+        // 1 MB /priv content + FILE_METADATA_SIZE > 1 MB quota → rejected.
+        check_hint(&db, &user, None, "/priv/app/big.txt", Some(1024 * 1024))
+            .await
+            .expect_err("/priv content + metadata should exceed 1 MB quota");
+    }
+
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_new_file_accounts_for_metadata_overhead() {

--- a/pubky-homeserver/src/client_server/routes/tenants/write.rs
+++ b/pubky-homeserver/src/client_server/routes/tenants/write.rs
@@ -182,10 +182,14 @@ mod tests {
         let pk = Keypair::random().public_key();
         let user = UserRepository::create_with_quota_mb(&db, &pk, 1).await;
 
-        // 100 bytes + FILE_METADATA_SIZE is well within 1 MB
+        // 100 bytes + FILE_METADATA_SIZE is well within 1 MB. The pre-check is
+        // namespace-agnostic, so a `/priv/` path is treated exactly like `/pub/`.
         check_hint(&db, &user, None, "/test.txt", Some(100))
             .await
             .expect("small file should be within 1 MB quota");
+        check_hint(&db, &user, None, "/priv/app/small.txt", Some(100))
+            .await
+            .expect("small /priv file should be within 1 MB quota");
     }
 
     #[tokio::test]
@@ -195,27 +199,10 @@ mod tests {
         let pk = Keypair::random().public_key();
         let user = UserRepository::create_with_quota_mb(&db, &pk, 1).await;
 
-        // 1 MB content + FILE_METADATA_SIZE > 1 MB quota
+        // 1 MB content + FILE_METADATA_SIZE > 1 MB quota. Same rejection for a `/priv/` path.
         check_hint(&db, &user, None, "/test.txt", Some(1024 * 1024))
             .await
             .expect_err("content + metadata should exceed 1 MB quota");
-    }
-
-    /// The Content-Length pre-check is namespace-agnostic,
-    /// a `/priv/` path is checked against the storage quota exactly like `/pub/`.
-    #[tokio::test]
-    #[pubky_test_utils::test]
-    async fn test_priv_path_checked_like_pub() {
-        let db = SqlDb::test().await;
-        let pk = Keypair::random().public_key();
-        let user = UserRepository::create_with_quota_mb(&db, &pk, 1).await;
-
-        // Small /priv file → within quota.
-        check_hint(&db, &user, None, "/priv/app/small.txt", Some(100))
-            .await
-            .expect("small /priv file should be within 1 MB quota");
-
-        // 1 MB /priv content + FILE_METADATA_SIZE > 1 MB quota → rejected.
         check_hint(&db, &user, None, "/priv/app/big.txt", Some(1024 * 1024))
             .await
             .expect_err("/priv content + metadata should exceed 1 MB quota");

--- a/pubky-homeserver/src/persistence/files/user_quota_layer.rs
+++ b/pubky-homeserver/src/persistence/files/user_quota_layer.rs
@@ -474,10 +474,10 @@ mod tests {
         // Create user with 1 MB quota
         UserRepository::create_with_quota_mb(&db, &user_pubkey1, 1).await;
 
-        // Write a file and see if the user usage is updated
+        // Write a /pub file and see if the user usage is updated
         operator
             .write(
-                format!("{}/test.txt1", user_pubkey1_raw).as_str(),
+                format!("{}/pub/a.txt", user_pubkey1_raw).as_str(),
                 vec![0; 10],
             )
             .await
@@ -488,7 +488,7 @@ mod tests {
         // Write the same file again but with a different size
         operator
             .write(
-                format!("{}/test.txt1", user_pubkey1_raw).as_str(),
+                format!("{}/pub/a.txt", user_pubkey1_raw).as_str(),
                 vec![0; 12],
             )
             .await
@@ -496,10 +496,10 @@ mod tests {
         let user_usage = get_user_data_usage(&db, &user_pubkey1).await.unwrap();
         assert_eq!(user_usage, 12 + FILE_METADATA_SIZE);
 
-        // Write a second file and see if the user usage is updated
+        // Write a second file under /priv — it draws from the same quota bucket.
         operator
             .write(
-                format!("{}/test.txt2", user_pubkey1_raw).as_str(),
+                format!("{}/priv/app/b.txt", user_pubkey1_raw).as_str(),
                 vec![0; 5],
             )
             .await
@@ -507,106 +507,21 @@ mod tests {
         let user_usage = get_user_data_usage(&db, &user_pubkey1).await.unwrap();
         assert_eq!(user_usage, 17 + 2 * FILE_METADATA_SIZE);
 
-        // Delete the first file and see if the user usage is updated
+        // Delete the /pub file and see if the user usage is updated
         operator
-            .delete(format!("{}/test.txt1", user_pubkey1_raw).as_str())
+            .delete(format!("{}/pub/a.txt", user_pubkey1_raw).as_str())
             .await
             .unwrap();
         let user_usage = get_user_data_usage(&db, &user_pubkey1).await.unwrap();
         assert_eq!(user_usage, 5 + FILE_METADATA_SIZE);
 
-        // Delete the second file and see if the user usage is updated
+        // Delete the /priv file and see if the user usage is updated
         operator
-            .delete(format!("{}/test.txt2", user_pubkey1_raw).as_str())
+            .delete(format!("{}/priv/app/b.txt", user_pubkey1_raw).as_str())
             .await
             .unwrap();
         let user_usage = get_user_data_usage(&db, &user_pubkey1).await.unwrap();
         assert_eq!(user_usage, 0);
-    }
-
-    /// A `/priv/` write increments `used_bytes`
-    /// exactly like a `/pub/` write, and deleting it frees the bytes again.
-    #[tokio::test]
-    #[pubky_test_utils::test]
-    async fn test_priv_write_increments_used_bytes() {
-        let db = SqlDb::test().await;
-        let layer = test_quota_layer(&db, None);
-        let operator = get_memory_operator().layer(layer);
-
-        let pubkey = pubky_common::crypto::Keypair::random().public_key();
-        let raw = pubkey.z32();
-        UserRepository::create_with_quota_mb(&db, &pubkey, 1).await;
-
-        operator
-            .write(format!("{raw}/priv/secret.txt").as_str(), vec![0; 10])
-            .await
-            .unwrap();
-        let usage = get_user_data_usage(&db, &pubkey).await.unwrap();
-        assert_eq!(usage, 10 + FILE_METADATA_SIZE);
-
-        operator
-            .delete(format!("{raw}/priv/secret.txt").as_str())
-            .await
-            .unwrap();
-        let usage = get_user_data_usage(&db, &pubkey).await.unwrap();
-        assert_eq!(usage, 0);
-    }
-
-    /// A `/priv/` write that exceeds the storage
-    /// quota is rejected, and the rejected write consumes no quota.
-    #[tokio::test]
-    #[pubky_test_utils::test]
-    async fn test_priv_write_rejected_at_quota() {
-        let db = SqlDb::test().await;
-        let layer = test_quota_layer(&db, None);
-        let operator = get_memory_operator().layer(layer);
-
-        let pubkey = pubky_common::crypto::Keypair::random().public_key();
-        let raw = pubkey.z32();
-        UserRepository::create_with_quota_mb(&db, &pubkey, 1).await;
-
-        let one_mb: usize = 1024 * 1024;
-        let max_content = one_mb - FILE_METADATA_SIZE as usize;
-
-        operator
-            .write(
-                format!("{raw}/priv/big.txt").as_str(),
-                vec![0; max_content + 1],
-            )
-            .await
-            .expect_err("A /priv write over quota should be rejected");
-        let usage = get_user_data_usage(&db, &pubkey).await.unwrap();
-        assert_eq!(usage, 0, "Rejected /priv write must not consume quota");
-    }
-
-    /// `/priv/` and `/pub/` writes draw from the same per-user storage bucket,
-    /// so combined usage across both namespaces is enforced against one quota.
-    #[tokio::test]
-    #[pubky_test_utils::test]
-    async fn test_priv_and_pub_share_quota_bucket() {
-        let db = SqlDb::test().await;
-        let layer = test_quota_layer(&db, None);
-        let operator = get_memory_operator().layer(layer);
-
-        let pubkey = pubky_common::crypto::Keypair::random().public_key();
-        let raw = pubkey.z32();
-        UserRepository::create_with_quota_mb(&db, &pubkey, 1).await; // 1 MB
-
-        // 600 KB in /pub → fits within 1 MB.
-        operator
-            .write(format!("{raw}/pub/a.txt").as_str(), vec![0; 600_000])
-            .await
-            .expect("600 KB /pub write fits within 1 MB");
-
-        // Another 600 KB in /priv → combined 1.2 MB exceeds the shared quota.
-        operator
-            .write(format!("{raw}/priv/b.txt").as_str(), vec![0; 600_000])
-            .await
-            .expect_err("Combined /pub + /priv usage must exceed the shared quota");
-
-        // Usage reflects only the successful /pub write.
-        let usage = get_user_data_usage(&db, &pubkey).await.unwrap();
-        assert_eq!(usage, 600_000 + FILE_METADATA_SIZE);
     }
 
     #[tokio::test]
@@ -636,9 +551,12 @@ mod tests {
         let one_mb: usize = 1024 * 1024;
         let max_content = one_mb - FILE_METADATA_SIZE as usize;
 
-        let file_name1 = format!("{}/test1.txt", user_pubkey1_raw);
-        let entry_path1 =
-            EntryPath::new(user_pubkey1.clone(), WebDavPath::new("/test1.txt").unwrap());
+        // Exercise the full write path (reject, accept, entry, event) on a `/priv/` file.
+        let file_name1 = format!("{}/priv/app/test1.txt", user_pubkey1_raw);
+        let entry_path1 = EntryPath::new(
+            user_pubkey1.clone(),
+            WebDavPath::new("/priv/app/test1.txt").unwrap(),
+        );
 
         // Write a file that exceeds quota (content + metadata > 1 MB) — should fail.
         operator
@@ -705,8 +623,8 @@ mod tests {
             "Event should be created after successful write"
         );
 
-        let file_name2 = format!("{}/test2.txt", user_pubkey1_raw);
-        // Write a second file — even 1 byte should exceed the (now full) quota
+        // A `/pub/` write is rejected too — the quota is shared across namespaces.
+        let file_name2 = format!("{}/pub/test2.txt", user_pubkey1_raw);
         operator
             .write(file_name2.as_str(), vec![0; 1])
             .await

--- a/pubky-homeserver/src/persistence/files/user_quota_layer.rs
+++ b/pubky-homeserver/src/persistence/files/user_quota_layer.rs
@@ -524,6 +524,91 @@ mod tests {
         assert_eq!(user_usage, 0);
     }
 
+    /// A `/priv/` write increments `used_bytes`
+    /// exactly like a `/pub/` write, and deleting it frees the bytes again.
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_priv_write_increments_used_bytes() {
+        let db = SqlDb::test().await;
+        let layer = test_quota_layer(&db, None);
+        let operator = get_memory_operator().layer(layer);
+
+        let pubkey = pubky_common::crypto::Keypair::random().public_key();
+        let raw = pubkey.z32();
+        UserRepository::create_with_quota_mb(&db, &pubkey, 1).await;
+
+        operator
+            .write(format!("{raw}/priv/secret.txt").as_str(), vec![0; 10])
+            .await
+            .unwrap();
+        let usage = get_user_data_usage(&db, &pubkey).await.unwrap();
+        assert_eq!(usage, 10 + FILE_METADATA_SIZE);
+
+        operator
+            .delete(format!("{raw}/priv/secret.txt").as_str())
+            .await
+            .unwrap();
+        let usage = get_user_data_usage(&db, &pubkey).await.unwrap();
+        assert_eq!(usage, 0);
+    }
+
+    /// A `/priv/` write that exceeds the storage
+    /// quota is rejected, and the rejected write consumes no quota.
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_priv_write_rejected_at_quota() {
+        let db = SqlDb::test().await;
+        let layer = test_quota_layer(&db, None);
+        let operator = get_memory_operator().layer(layer);
+
+        let pubkey = pubky_common::crypto::Keypair::random().public_key();
+        let raw = pubkey.z32();
+        UserRepository::create_with_quota_mb(&db, &pubkey, 1).await;
+
+        let one_mb: usize = 1024 * 1024;
+        let max_content = one_mb - FILE_METADATA_SIZE as usize;
+
+        operator
+            .write(
+                format!("{raw}/priv/big.txt").as_str(),
+                vec![0; max_content + 1],
+            )
+            .await
+            .expect_err("A /priv write over quota should be rejected");
+        let usage = get_user_data_usage(&db, &pubkey).await.unwrap();
+        assert_eq!(usage, 0, "Rejected /priv write must not consume quota");
+    }
+
+    /// `/priv/` and `/pub/` writes draw from the same per-user storage bucket,
+    /// so combined usage across both namespaces is enforced against one quota.
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_priv_and_pub_share_quota_bucket() {
+        let db = SqlDb::test().await;
+        let layer = test_quota_layer(&db, None);
+        let operator = get_memory_operator().layer(layer);
+
+        let pubkey = pubky_common::crypto::Keypair::random().public_key();
+        let raw = pubkey.z32();
+        UserRepository::create_with_quota_mb(&db, &pubkey, 1).await; // 1 MB
+
+        // 600 KB in /pub → fits within 1 MB.
+        operator
+            .write(format!("{raw}/pub/a.txt").as_str(), vec![0; 600_000])
+            .await
+            .expect("600 KB /pub write fits within 1 MB");
+
+        // Another 600 KB in /priv → combined 1.2 MB exceeds the shared quota.
+        operator
+            .write(format!("{raw}/priv/b.txt").as_str(), vec![0; 600_000])
+            .await
+            .expect_err("Combined /pub + /priv usage must exceed the shared quota");
+
+        // Usage reflects only the successful /pub write.
+        let usage = get_user_data_usage(&db, &pubkey).await.unwrap();
+        assert_eq!(usage, 600_000 + FILE_METADATA_SIZE);
+    }
+
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_quota_rechead() {

--- a/pubky-homeserver/src/persistence/files/write_path_layer.rs
+++ b/pubky-homeserver/src/persistence/files/write_path_layer.rs
@@ -263,6 +263,38 @@ mod tests {
         assert_eq!(err.kind(), opendal::ErrorKind::PermissionDenied);
     }
 
+    /// `allowed_write_paths: ["/priv/app/"]` permits
+    /// `/priv/app/x`, and denies both `/priv/other/x` and `/pub/...`.
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn test_priv_scoped_write_path_allows_and_denies() {
+        let db = SqlDb::test().await;
+        let operator = build_test_operator(&db);
+
+        let pubkey = create_user_with_write_paths(&db, Some(vec![wdp("/priv/app/")])).await;
+        let raw = pubkey.z32();
+
+        // Permitted: a path under the allowed `/priv/app/` directory.
+        operator
+            .write(&format!("{raw}/priv/app/x.json"), vec![0; 10])
+            .await
+            .expect("Write to allowed /priv/app/ path should succeed");
+
+        // Denied: a sibling `/priv/` directory outside the allow list.
+        let err = operator
+            .write(&format!("{raw}/priv/other/x.json"), vec![0; 10])
+            .await
+            .expect_err("Write to disallowed /priv sibling should fail");
+        assert_eq!(err.kind(), opendal::ErrorKind::PermissionDenied);
+
+        // Denied: `/pub/...` is not covered by a `/priv/`-scoped allow list.
+        let err = operator
+            .write(&format!("{raw}/pub/app/x.json"), vec![0; 10])
+            .await
+            .expect_err("A /priv-scoped allow list must deny /pub writes");
+        assert_eq!(err.kind(), opendal::ErrorKind::PermissionDenied);
+    }
+
     #[tokio::test]
     #[pubky_test_utils::test]
     async fn test_empty_write_paths_blocks_all_writes() {

--- a/pubky-homeserver/src/persistence/files/write_path_layer.rs
+++ b/pubky-homeserver/src/persistence/files/write_path_layer.rs
@@ -237,7 +237,10 @@ mod tests {
         let db = SqlDb::test().await;
         let operator = build_test_operator(&db);
 
-        let pubkey = create_user_with_write_paths(&db, Some(vec![wdp("/pub/tokens/")])).await;
+        // A `/priv/` scope is enforced exactly like a `/pub/` one.
+        let pubkey =
+            create_user_with_write_paths(&db, Some(vec![wdp("/pub/tokens/"), wdp("/priv/app/")]))
+                .await;
 
         operator
             .write(
@@ -245,7 +248,11 @@ mod tests {
                 vec![0; 10],
             )
             .await
-            .expect("Write to allowed path should succeed");
+            .expect("Write to allowed /pub path should succeed");
+        operator
+            .write(&format!("{}/priv/app/foo.json", pubkey.z32()), vec![0; 10])
+            .await
+            .expect("Write to allowed /priv path should succeed");
     }
 
     #[tokio::test]
@@ -261,37 +268,12 @@ mod tests {
             .await
             .expect_err("Write to disallowed path should fail");
         assert_eq!(err.kind(), opendal::ErrorKind::PermissionDenied);
-    }
 
-    /// `allowed_write_paths: ["/priv/app/"]` permits
-    /// `/priv/app/x`, and denies both `/priv/other/x` and `/pub/...`.
-    #[tokio::test]
-    #[pubky_test_utils::test]
-    async fn test_priv_scoped_write_path_allows_and_denies() {
-        let db = SqlDb::test().await;
-        let operator = build_test_operator(&db);
-
-        let pubkey = create_user_with_write_paths(&db, Some(vec![wdp("/priv/app/")])).await;
-        let raw = pubkey.z32();
-
-        // Permitted: a path under the allowed `/priv/app/` directory.
-        operator
-            .write(&format!("{raw}/priv/app/x.json"), vec![0; 10])
-            .await
-            .expect("Write to allowed /priv/app/ path should succeed");
-
-        // Denied: a sibling `/priv/` directory outside the allow list.
+        // A `/pub/`-only scope also denies writes to `/priv/`.
         let err = operator
-            .write(&format!("{raw}/priv/other/x.json"), vec![0; 10])
+            .write(&format!("{}/priv/app/foo.json", pubkey.z32()), vec![0; 10])
             .await
-            .expect_err("Write to disallowed /priv sibling should fail");
-        assert_eq!(err.kind(), opendal::ErrorKind::PermissionDenied);
-
-        // Denied: `/pub/...` is not covered by a `/priv/`-scoped allow list.
-        let err = operator
-            .write(&format!("{raw}/pub/app/x.json"), vec![0; 10])
-            .await
-            .expect_err("A /priv-scoped allow list must deny /pub writes");
+            .expect_err("Write to /priv outside the allow list should fail");
         assert_eq!(err.kind(), opendal::ErrorKind::PermissionDenied);
     }
 

--- a/pubky-homeserver/src/shared/user_quota.rs
+++ b/pubky-homeserver/src/shared/user_quota.rs
@@ -1170,13 +1170,21 @@ mod tests {
 
     #[test]
     fn test_is_write_path_allowed_prefix_match() {
+        // Matching is namespace-agnostic: a `/priv/` entry behaves like a `/pub/` one.
         let q = UserQuota {
-            allowed_write_paths: Some(vec![wdp("/pub/tokens/"), wdp("/pub/paykit/")]),
+            allowed_write_paths: Some(vec![
+                wdp("/pub/tokens/"),
+                wdp("/pub/paykit/"),
+                wdp("/priv/app/"),
+            ]),
             ..Default::default()
         };
         assert!(q.is_write_path_allowed("/pub/tokens/foo.json"));
         assert!(q.is_write_path_allowed("/pub/paykit/bar"));
+        assert!(q.is_write_path_allowed("/priv/app/foo.json"));
+        assert!(q.is_write_path_allowed("/priv/app/sub/deep.json"));
         assert!(!q.is_write_path_allowed("/pub/other/file"));
+        assert!(!q.is_write_path_allowed("/priv/other/file"));
         assert!(!q.is_write_path_allowed("/pub/token")); // no trailing slash match
     }
 
@@ -1201,38 +1209,6 @@ mod tests {
         assert!(q.is_write_path_allowed("/pub/tokens/foo.json"));
         assert!(q.is_write_path_allowed("/pub/profile.json"));
         assert!(!q.is_write_path_allowed("/pub/other/file"));
-    }
-
-    #[test]
-    fn test_is_write_path_allowed_priv_prefix_match() {
-        // An allow list scoped to a `/priv/` directory
-        // permits paths under it and denies sibling `/priv/` dirs as well as `/pub/`.
-        // Path matching is namespace-agnostic — `/priv/` behaves exactly like `/pub/`.
-        let q = UserQuota {
-            allowed_write_paths: Some(vec![wdp("/priv/app/")]),
-            ..Default::default()
-        };
-        assert!(q.is_write_path_allowed("/priv/app/x"));
-        assert!(q.is_write_path_allowed("/priv/app/sub/deep.json"));
-        assert!(!q.is_write_path_allowed("/priv/other/x"));
-        assert!(!q.is_write_path_allowed("/pub/app/x"));
-        // Prefix-but-not-child must not match (`/priv/apple/` shares a prefix).
-        assert!(!q.is_write_path_allowed("/priv/apple/x"));
-        // Directory entry does not match the bare path without a trailing slash.
-        assert!(!q.is_write_path_allowed("/priv/app"));
-    }
-
-    #[test]
-    fn test_is_write_path_allowed_mixed_pub_and_priv() {
-        // An allow list can span both namespaces at once.
-        let q = UserQuota {
-            allowed_write_paths: Some(vec![wdp("/pub/tokens/"), wdp("/priv/app/")]),
-            ..Default::default()
-        };
-        assert!(q.is_write_path_allowed("/pub/tokens/foo.json"));
-        assert!(q.is_write_path_allowed("/priv/app/foo.json"));
-        assert!(!q.is_write_path_allowed("/priv/other/foo.json"));
-        assert!(!q.is_write_path_allowed("/pub/other/foo.json"));
     }
 
     #[test]

--- a/pubky-homeserver/src/shared/user_quota.rs
+++ b/pubky-homeserver/src/shared/user_quota.rs
@@ -1204,6 +1204,38 @@ mod tests {
     }
 
     #[test]
+    fn test_is_write_path_allowed_priv_prefix_match() {
+        // An allow list scoped to a `/priv/` directory
+        // permits paths under it and denies sibling `/priv/` dirs as well as `/pub/`.
+        // Path matching is namespace-agnostic — `/priv/` behaves exactly like `/pub/`.
+        let q = UserQuota {
+            allowed_write_paths: Some(vec![wdp("/priv/app/")]),
+            ..Default::default()
+        };
+        assert!(q.is_write_path_allowed("/priv/app/x"));
+        assert!(q.is_write_path_allowed("/priv/app/sub/deep.json"));
+        assert!(!q.is_write_path_allowed("/priv/other/x"));
+        assert!(!q.is_write_path_allowed("/pub/app/x"));
+        // Prefix-but-not-child must not match (`/priv/apple/` shares a prefix).
+        assert!(!q.is_write_path_allowed("/priv/apple/x"));
+        // Directory entry does not match the bare path without a trailing slash.
+        assert!(!q.is_write_path_allowed("/priv/app"));
+    }
+
+    #[test]
+    fn test_is_write_path_allowed_mixed_pub_and_priv() {
+        // An allow list can span both namespaces at once.
+        let q = UserQuota {
+            allowed_write_paths: Some(vec![wdp("/pub/tokens/"), wdp("/priv/app/")]),
+            ..Default::default()
+        };
+        assert!(q.is_write_path_allowed("/pub/tokens/foo.json"));
+        assert!(q.is_write_path_allowed("/priv/app/foo.json"));
+        assert!(!q.is_write_path_allowed("/priv/other/foo.json"));
+        assert!(!q.is_write_path_allowed("/pub/other/foo.json"));
+    }
+
+    #[test]
     fn test_is_write_path_allowed_prefix_not_child_rejected() {
         // "/pub/tokenstore/" shares a prefix with "/pub/tokens/" but is NOT a child.
         let q = UserQuota {


### PR DESCRIPTION
Closes #440.

### Summary

The verification + tests half of `/priv/` quota support. Storage accounting and `allowed_write_paths` enforcement were already path-agnostic — the quota pre-check, the `used_bytes` accounting in `UserQuotaLayer`, and `is_write_path_allowed` never special-case `/pub/` — so no production changes were needed. This PR adds the tests that prove `/priv/` behaves identically to `/pub/` and locks that in against regressions.

Coverage added:
- `used_bytes` accounting + quota rejection for `/priv/` writes (unit + e2e),
  including a test that `/priv/` and `/pub/` share one storage bucket.
- `allowed_write_paths: ["/priv/app/"]` enforcement at both the matching-logic
  and OpenDAL-layer level.
- The Content-Length quota pre-check on a `/priv/` path.

### Acceptance criteria
- [x] A `/priv/` write increments `used_bytes` and is rejected at quota like a `/pub/` write.
- [x] `allowed_write_paths: ["/priv/app/"]` permits `/priv/app/x`, denies `/priv/other/x` and `/pub/...`.
- [x] Verification + new tests; confirmed no code assumes `/pub/`.