### PR TITLE
test(homeserver): e2e for private data

### DIFF
--- a/e2e/src/tests/events/feed.rs
+++ b/e2e/src/tests/events/feed.rs
@@ -160,3 +160,47 @@ async fn read_after_event() {
     let body = resp.bytes().await.unwrap();
     assert_eq!(body.as_ref(), &[0]);
 }
+
+#[tokio::test]
+#[pubky_testnet::test]
+async fn feed_excludes_private_paths() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+
+    let signer = pubky.signer(Keypair::random());
+    let session = signer
+        .signup_cookie(&server.public_key(), None)
+        .await
+        .unwrap();
+
+    // Interleave public and private writes.
+    session.storage().put("/pub/a.txt", vec![1]).await.unwrap();
+    session
+        .storage()
+        .put("/priv/app/secret.txt", vec![2])
+        .await
+        .unwrap();
+    session.storage().put("/pub/b.txt", vec![3]).await.unwrap();
+
+    // The anonymous public feed must never surface a private path.
+    let feed_url = format!("https://{}/events/?limit=100", server.public_key().z32());
+    let text = pubky
+        .client()
+        .request(Method::GET, &feed_url)
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    assert!(
+        !text.contains("/priv/"),
+        "public feed leaked a private path:\n{text}"
+    );
+    assert!(
+        text.contains("/pub/a.txt") && text.contains("/pub/b.txt"),
+        "public events should be present:\n{text}"
+    );
+}

--- a/e2e/src/tests/mod.rs
+++ b/e2e/src/tests/mod.rs
@@ -3,6 +3,7 @@ mod auth;
 mod events;
 mod http;
 mod metrics;
+mod private_data;
 mod rate_limiting;
 mod storage;
 

--- a/e2e/src/tests/private_data.rs
+++ b/e2e/src/tests/private_data.rs
@@ -1,0 +1,300 @@
+//! Authorization matrix for private (`/priv/`) resources: each actor tier
+//! (anonymous, under-scoped owner, other tenant, authorized owner) against
+//! every storage action.
+//!
+//! `/events-stream` authorization is covered in `events::stream_private`.
+
+use super::build_full_testnet;
+use pubky_testnet::pubky::{
+    AuthFlowKind, ClientId, IntoPubkyResource, Keypair, Method, PubkyGrantAuthFlow,
+    PubkyHttpClient, PubkySession, PubkySigner, StatusCode,
+};
+use pubky_testnet::pubky_common::capabilities::Capabilities;
+use pubky_testnet::pubky_common::crypto::PublicKey;
+use pubky_testnet::EphemeralTestnet;
+
+const SECRET: &str = "/priv/app/secret.txt";
+const ABSENT: &str = "/priv/app/absent.txt";
+const DIR: &str = "/priv/app/";
+
+/// Approve a grant with `caps` for `signer` and return the resulting session.
+async fn grant_session(
+    testnet: &EphemeralTestnet,
+    signer: &PubkySigner,
+    caps: Capabilities,
+) -> PubkySession {
+    let pubky = testnet.sdk().unwrap();
+    let auth = PubkyGrantAuthFlow::builder(
+        &caps,
+        AuthFlowKind::signin(),
+        ClientId::new("test.app").unwrap(),
+    )
+    .relay(testnet.http_relay().local_link_url())
+    .client(pubky.client().clone())
+    .start()
+    .unwrap();
+    signer
+        .approve_auth(&auth.authorization_url())
+        .await
+        .unwrap();
+    auth.await_approval().await.unwrap()
+}
+
+/// Transport URL for `path` in `owner`'s namespace.
+fn owner_url(owner: &PublicKey, path: &str) -> String {
+    format!("{}/{}", owner, path.trim_start_matches('/'))
+        .into_pubky_resource()
+        .unwrap()
+        .to_transport_url()
+        .unwrap()
+        .to_string()
+}
+
+/// Send a raw request and return its status.
+async fn req_status(
+    client: &PubkyHttpClient,
+    method: Method,
+    url: &str,
+    bearer: Option<&str>,
+    body: Option<Vec<u8>>,
+) -> StatusCode {
+    let mut rb = client.request(method, &url);
+    if let Some(bearer) = bearer {
+        rb = rb.header("Authorization", format!("Bearer {bearer}"));
+    }
+    if let Some(body) = body {
+        rb = rb.body(body);
+    }
+    rb.send().await.unwrap().status()
+}
+
+/// Every verb against a private resource, expecting the same denied `status`
+/// for both an existing and an absent path (no existence oracle).
+async fn assert_all_verbs_denied(
+    client: &PubkyHttpClient,
+    owner: &PublicKey,
+    bearer: Option<&str>,
+    status: StatusCode,
+) {
+    let secret = owner_url(owner, SECRET);
+    let absent = owner_url(owner, ABSENT);
+    let dir = owner_url(owner, DIR);
+
+    assert_eq!(
+        req_status(client, Method::PUT, &secret, bearer, Some(vec![0])).await,
+        status
+    );
+    assert_eq!(
+        req_status(client, Method::DELETE, &secret, bearer, None).await,
+        status
+    );
+    assert_eq!(
+        req_status(client, Method::GET, &dir, bearer, None).await,
+        status
+    );
+
+    for method in [Method::GET, Method::HEAD] {
+        let existing = req_status(client, method.clone(), &secret, bearer, None).await;
+        let missing = req_status(client, method, &absent, bearer, None).await;
+        assert_eq!(existing, status);
+        assert_eq!(
+            existing, missing,
+            "existing and absent must return the same status"
+        );
+    }
+}
+
+#[tokio::test]
+#[pubky_testnet::test]
+async fn anonymous_priv_access_is_unauthorized() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+
+    let signer = pubky.signer(Keypair::random());
+    signer.signup(&server.public_key(), None).await.unwrap();
+    let owner = signer.public_key();
+
+    // Seed the private file so the existence-oracle check has a real target.
+    let covering = grant_session(
+        &testnet,
+        &signer,
+        Capabilities::builder().read_write(DIR).finish(),
+    )
+    .await;
+    covering.storage().put(SECRET, vec![1, 2, 3]).await.unwrap();
+
+    assert_all_verbs_denied(pubky.client(), &owner, None, StatusCode::UNAUTHORIZED).await;
+}
+
+#[tokio::test]
+#[pubky_testnet::test]
+async fn under_scoped_owner_priv_access_is_forbidden() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+
+    let signer = pubky.signer(Keypair::random());
+    signer.signup(&server.public_key(), None).await.unwrap();
+    let owner = signer.public_key();
+
+    let covering = grant_session(
+        &testnet,
+        &signer,
+        Capabilities::builder().read_write(DIR).finish(),
+    )
+    .await;
+    covering.storage().put(SECRET, vec![1, 2, 3]).await.unwrap();
+
+    // Same owner, session scoped to a sibling subtree that does not cover `/priv/app/`.
+    let under = grant_session(
+        &testnet,
+        &signer,
+        Capabilities::builder().read_write("/priv/other/").finish(),
+    )
+    .await;
+    let token = under.as_grant().unwrap().current_bearer().await;
+
+    assert_all_verbs_denied(pubky.client(), &owner, Some(&token), StatusCode::FORBIDDEN).await;
+}
+
+#[tokio::test]
+#[pubky_testnet::test]
+async fn cross_tenant_priv_access_is_forbidden() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+
+    let owner_signer = pubky.signer(Keypair::random());
+    owner_signer
+        .signup(&server.public_key(), None)
+        .await
+        .unwrap();
+    let owner = owner_signer.public_key();
+    let covering = grant_session(
+        &testnet,
+        &owner_signer,
+        Capabilities::builder().read_write(DIR).finish(),
+    )
+    .await;
+    covering.storage().put(SECRET, vec![1, 2, 3]).await.unwrap();
+
+    // A different tenant, even with an identically scoped cap in their own namespace.
+    let tenant_signer = pubky.signer(Keypair::random());
+    tenant_signer
+        .signup(&server.public_key(), None)
+        .await
+        .unwrap();
+    let tenant = grant_session(
+        &testnet,
+        &tenant_signer,
+        Capabilities::builder().read_write(DIR).finish(),
+    )
+    .await;
+    let token = tenant.as_grant().unwrap().current_bearer().await;
+
+    assert_all_verbs_denied(pubky.client(), &owner, Some(&token), StatusCode::FORBIDDEN).await;
+}
+
+#[tokio::test]
+#[pubky_testnet::test]
+async fn owner_with_cap_priv_access_is_authorized() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+
+    let signer = pubky.signer(Keypair::random());
+    signer.signup(&server.public_key(), None).await.unwrap();
+    let owner = signer.public_key();
+    let session = grant_session(
+        &testnet,
+        &signer,
+        Capabilities::builder().read_write(DIR).finish(),
+    )
+    .await;
+    let token = session.as_grant().unwrap().current_bearer().await;
+    let bearer = Some(token.as_str());
+
+    let client = pubky.client();
+    let secret = owner_url(&owner, SECRET);
+    let absent = owner_url(&owner, ABSENT);
+    let dir = owner_url(&owner, DIR);
+
+    // Write, read, list, delete — all authorized.
+    assert_eq!(
+        req_status(client, Method::PUT, &secret, bearer, Some(vec![1, 2, 3])).await,
+        StatusCode::CREATED
+    );
+    assert_eq!(
+        req_status(client, Method::GET, &secret, bearer, None).await,
+        StatusCode::OK
+    );
+    assert_eq!(
+        req_status(client, Method::HEAD, &secret, bearer, None).await,
+        StatusCode::OK
+    );
+    assert_eq!(
+        req_status(client, Method::GET, &dir, bearer, None).await,
+        StatusCode::OK
+    );
+    assert_eq!(
+        req_status(client, Method::DELETE, &secret, bearer, None).await,
+        StatusCode::NO_CONTENT
+    );
+
+    // The authorized tier distinguishes absent (404) from the denied tiers' uniform status.
+    assert_eq!(
+        req_status(client, Method::GET, &absent, bearer, None).await,
+        StatusCode::NOT_FOUND
+    );
+    assert_eq!(
+        req_status(client, Method::HEAD, &absent, bearer, None).await,
+        StatusCode::NOT_FOUND
+    );
+}
+
+#[tokio::test]
+#[pubky_testnet::test]
+async fn anonymous_events_feed_excludes_private() {
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+
+    let signer = pubky.signer(Keypair::random());
+    signer.signup(&server.public_key(), None).await.unwrap();
+    let session = grant_session(
+        &testnet,
+        &signer,
+        Capabilities::builder()
+            .read_write("/pub/")
+            .read_write(DIR)
+            .finish(),
+    )
+    .await;
+
+    // Interleave public and private writes.
+    session.storage().put("/pub/a.txt", vec![1]).await.unwrap();
+    session.storage().put(SECRET, vec![2]).await.unwrap();
+    session.storage().put("/pub/b.txt", vec![3]).await.unwrap();
+
+    // The anonymous public feed must never surface a private path.
+    let feed_url = format!("https://{}/events/?limit=100", server.public_key().z32());
+    let text = pubky
+        .client()
+        .request(Method::GET, &feed_url)
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    assert!(
+        !text.contains("/priv/"),
+        "public feed leaked a private path:\n{text}"
+    );
+    assert!(
+        text.contains("/pub/a.txt") && text.contains("/pub/b.txt"),
+        "public events should be present:\n{text}"
+    );
+}

--- a/e2e/src/tests/private_data.rs
+++ b/e2e/src/tests/private_data.rs
@@ -1,8 +1,7 @@
-//! Authorization matrix for private (`/priv/`) resources: each actor tier
-//! (anonymous, under-scoped owner, other tenant, authorized owner) against
-//! every storage action.
-//!
-//! `/events-stream` authorization is covered in `events::stream_private`.
+//! Unauthorized-access matrix for private (`/priv/`) resources: every denied
+//! actor tier (anonymous, under-scoped owner, other tenant) against every
+//! storage action, asserting the status-by-auth-tier contract invariant to
+//! existence — anonymous → 401, under-scoped / other tenant → 403.
 
 use super::build_full_testnet;
 use pubky_testnet::pubky::{
@@ -194,107 +193,4 @@ async fn cross_tenant_priv_access_is_forbidden() {
     let token = tenant.as_grant().unwrap().current_bearer().await;
 
     assert_all_verbs_denied(pubky.client(), &owner, Some(&token), StatusCode::FORBIDDEN).await;
-}
-
-#[tokio::test]
-#[pubky_testnet::test]
-async fn owner_with_cap_priv_access_is_authorized() {
-    let testnet = build_full_testnet().await;
-    let server = testnet.homeserver_app();
-    let pubky = testnet.sdk().unwrap();
-
-    let signer = pubky.signer(Keypair::random());
-    signer.signup(&server.public_key(), None).await.unwrap();
-    let owner = signer.public_key();
-    let session = grant_session(
-        &testnet,
-        &signer,
-        Capabilities::builder().read_write(DIR).finish(),
-    )
-    .await;
-    let token = session.as_grant().unwrap().current_bearer().await;
-    let bearer = Some(token.as_str());
-
-    let client = pubky.client();
-    let secret = owner_url(&owner, SECRET);
-    let absent = owner_url(&owner, ABSENT);
-    let dir = owner_url(&owner, DIR);
-
-    // Write, read, list, delete — all authorized.
-    assert_eq!(
-        req_status(client, Method::PUT, &secret, bearer, Some(vec![1, 2, 3])).await,
-        StatusCode::CREATED
-    );
-    assert_eq!(
-        req_status(client, Method::GET, &secret, bearer, None).await,
-        StatusCode::OK
-    );
-    assert_eq!(
-        req_status(client, Method::HEAD, &secret, bearer, None).await,
-        StatusCode::OK
-    );
-    assert_eq!(
-        req_status(client, Method::GET, &dir, bearer, None).await,
-        StatusCode::OK
-    );
-    assert_eq!(
-        req_status(client, Method::DELETE, &secret, bearer, None).await,
-        StatusCode::NO_CONTENT
-    );
-
-    // The authorized tier distinguishes absent (404) from the denied tiers' uniform status.
-    assert_eq!(
-        req_status(client, Method::GET, &absent, bearer, None).await,
-        StatusCode::NOT_FOUND
-    );
-    assert_eq!(
-        req_status(client, Method::HEAD, &absent, bearer, None).await,
-        StatusCode::NOT_FOUND
-    );
-}
-
-#[tokio::test]
-#[pubky_testnet::test]
-async fn anonymous_events_feed_excludes_private() {
-    let testnet = build_full_testnet().await;
-    let server = testnet.homeserver_app();
-    let pubky = testnet.sdk().unwrap();
-
-    let signer = pubky.signer(Keypair::random());
-    signer.signup(&server.public_key(), None).await.unwrap();
-    let session = grant_session(
-        &testnet,
-        &signer,
-        Capabilities::builder()
-            .read_write("/pub/")
-            .read_write(DIR)
-            .finish(),
-    )
-    .await;
-
-    // Interleave public and private writes.
-    session.storage().put("/pub/a.txt", vec![1]).await.unwrap();
-    session.storage().put(SECRET, vec![2]).await.unwrap();
-    session.storage().put("/pub/b.txt", vec![3]).await.unwrap();
-
-    // The anonymous public feed must never surface a private path.
-    let feed_url = format!("https://{}/events/?limit=100", server.public_key().z32());
-    let text = pubky
-        .client()
-        .request(Method::GET, &feed_url)
-        .send()
-        .await
-        .unwrap()
-        .text()
-        .await
-        .unwrap();
-
-    assert!(
-        !text.contains("/priv/"),
-        "public feed leaked a private path:\n{text}"
-    );
-    assert!(
-        text.contains("/pub/a.txt") && text.contains("/pub/b.txt"),
-        "public events should be present:\n{text}"
-    );
 }

--- a/e2e/src/tests/storage/authorization.rs
+++ b/e2e/src/tests/storage/authorization.rs
@@ -72,60 +72,27 @@ async fn unauthorized_put_delete() {
 
 #[tokio::test]
 #[pubky_testnet::test]
-async fn priv_writes_are_accepted() {
-    // `/priv/` writes are authorized exactly like `/pub/` writes
+async fn priv_owner_with_cap_is_authorized() {
+    // The owner exercises the full read/write surface on their own `/priv/` data,
+    // and gets a real 404 (not 401/403) for an absent private path. Denial for the
+    // other actor tiers is covered by the `private_data` matrix.
     let testnet = build_full_testnet().await;
     let server = testnet.homeserver_app();
     let pubky = testnet.sdk().unwrap();
 
     let owner = pubky.signer(Keypair::random());
-    let owner_session = owner
+    let session = owner
         .signup_cookie(&server.public_key(), None)
         .await
         .unwrap();
 
-    let path = "/priv/foo.txt";
+    let path = "/priv/app/secret.txt";
+    let content = vec![1, 2, 3];
 
-    // Owner writes to /priv successfully
-    let resp = owner_session
-        .storage()
-        .put(path, vec![0, 1, 2, 3, 4])
-        .await
-        .unwrap();
-    assert!(resp.status().is_success());
-
-    // Owner deletes the /priv file successfully.
-    let resp = owner_session.storage().delete(path).await.unwrap();
-    assert!(resp.status().is_success());
-}
-
-#[tokio::test]
-#[pubky_testnet::test]
-async fn priv_reads_require_auth() {
-    // The owner can read back their own `/priv/` data, anonymous callers get 401.
-    let testnet = build_full_testnet().await;
-    let server = testnet.homeserver_app();
-    let pubky = testnet.sdk().unwrap();
-
-    let owner = pubky.signer(Keypair::random());
-    let owner_session = owner
-        .signup_cookie(&server.public_key(), None)
-        .await
-        .unwrap();
-
-    let path = "/priv/secret.txt";
-    let content = vec![9, 8, 7, 6, 5];
-
-    // Owner writes the private file.
-    let resp = owner_session
-        .storage()
-        .put(path, content.clone())
-        .await
-        .unwrap();
-    assert!(resp.status().is_success());
-
-    // Owner reads it back → 200 with the same bytes.
-    let body = owner_session
+    // Write, then read back the same bytes.
+    let resp = session.storage().put(path, content.clone()).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CREATED);
+    let body = session
         .storage()
         .get(path)
         .await
@@ -135,22 +102,30 @@ async fn priv_reads_require_auth() {
         .unwrap();
     assert_eq!(body, bytes::Bytes::from(content));
 
-    // Anonymous read of the owners private path → 401 Unauthorized.
-    let owner_url = format!(
-        "{}/{}",
-        owner_session.info().public_key(),
-        path.trim_start_matches('/')
-    );
-    let owner_transport_url = owner_url
-        .into_pubky_resource()
+    // The private directory lists for the owner.
+    let listing = session
+        .storage()
+        .list("/priv/app/")
         .unwrap()
-        .to_transport_url()
-        .unwrap();
-    let response = pubky
-        .client()
-        .request(Method::GET, &owner_transport_url)
         .send()
         .await
         .unwrap();
-    assert!(matches!(response.status(), StatusCode::UNAUTHORIZED));
+    assert!(
+        !listing.is_empty(),
+        "owner should see their private listing"
+    );
+
+    // Delete succeeds.
+    let resp = session.storage().delete(path).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+
+    // An absent private path is a real 404 for the authorized owner.
+    let err = session
+        .storage()
+        .get("/priv/app/absent.txt")
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, Error::Request(RequestError::Server { status, .. }) if status == StatusCode::NOT_FOUND)
+    );
 }


### PR DESCRIPTION
Closes #441.

### Summary

Cross-cutting e2e authorization matrix for private (`/priv/`) data. This adds an explicit actor × operation × expected grid in a new `e2e/src/tests/private_data.rs` module. Tests-only, no production changes.

Each of the four actor tiers hits the owner's resource URL with only its credential varied, asserting the status-by-auth-tier contract, invariant to existence:
- **anonymous** → `401`
- **owner with an under-scoped cap** / **other tenant** → `403`
- **owner with a covering cap** → `200`/`404`

### Acceptance criteria
- [x] All cells of the matrix asserted and green.
- [x] Existence-oracle regression: identical status for existing vs nonexistent private resources at the anonymous (`401`) and under-scoped/wrong-tenant (`403`) tiers.
- [x] Leak regression: no private path via the anonymous `/events/` feed (no-`path` stream covered by `events::stream_private`).