### PR TITLE
refactor(homeserver): simplify republisher internals

### DIFF
--- a/pubky-homeserver/src/homeserver_app.rs
+++ b/pubky-homeserver/src/homeserver_app.rs
@@ -20,8 +20,6 @@ use pubky_common::crypto::PublicKey;
 use std::path::PathBuf;
 use std::time::Duration;
 
-const INITIAL_DELAY_BEFORE_REPUBLISH: Duration = Duration::from_secs(60);
-
 /// Errors that can occur when building a `HomeserverApp`.
 #[derive(thiserror::Error, Debug)]
 pub enum HomeserverAppBuildError {
@@ -49,9 +47,8 @@ pub struct HomeserverApp {
     // Republishing is stopped when the UserKeysRepublisherJob is dropped.
     _user_keys_republisher_job: Option<UserKeysRepublisherJob>,
 
-    #[allow(dead_code)]
-    // Keep this alive. Republishing is stopped when the HomeserverKeyRepublisher is dropped.
-    key_republisher: HomeserverKeyRepublisher,
+    // Republishing is stopped when the HomeserverKeyRepublisher is dropped.
+    _key_republisher: HomeserverKeyRepublisher,
 
     #[allow(dead_code)] // Keep this alive. When dropped, the admin server will stop.
     admin_server: Option<AdminServer>,
@@ -92,11 +89,10 @@ impl HomeserverApp {
         pkarr_builder.no_relays(); // Disable relays to avoid their rate limiting.
         let republish_interval =
             Duration::from_secs(context.config_toml.pkdns.user_keys_republisher_interval);
-        let user_keys_republisher_job = UserKeysRepublisherJob::start_delayed(
+        let user_keys_republisher_job = UserKeysRepublisherJob::start(
             context.sql_db.clone(),
             pkarr_builder,
             republish_interval,
-            INITIAL_DELAY_BEFORE_REPUBLISH,
         );
 
         let admin_server = if context.config_toml.admin.enabled {
@@ -125,7 +121,7 @@ impl HomeserverApp {
             admin_server,
             metrics_server,
             _user_keys_republisher_job: user_keys_republisher_job,
-            key_republisher,
+            _key_republisher: key_republisher,
         })
     }
 

--- a/pubky-homeserver/src/homeserver_app.rs
+++ b/pubky-homeserver/src/homeserver_app.rs
@@ -9,7 +9,7 @@ use crate::admin_server::{AdminServer, AdminServerBuildError};
 use crate::client_server::{ClientServer, ClientServerBuildError};
 use crate::metrics_server::{MetricsServer, MetricsServerBuildError};
 use crate::republishers::{
-    HomeserverKeyRepublisher, KeyRepublisherBuildError, UserKeysRepublisher,
+    HomeserverKeyRepublisher, KeyRepublisherBuildError, UserKeysRepublisherJob,
 };
 use crate::tracing::init_tracing_logs_with_config_if_set;
 #[cfg(any(test, feature = "testing"))]
@@ -46,13 +46,12 @@ pub struct HomeserverApp {
     #[allow(dead_code)] // Keep this alive. When dropped, the homeserver will stop.
     client_server: ClientServer,
 
-    #[allow(dead_code)]
-    // Keep this alive. Republishing is stopped when the UserKeysRepublisher is dropped.
-    pub(crate) user_keys_republisher: UserKeysRepublisher,
+    // Republishing is stopped when the UserKeysRepublisherJob is dropped.
+    _user_keys_republisher_job: Option<UserKeysRepublisherJob>,
 
     #[allow(dead_code)]
     // Keep this alive. Republishing is stopped when the HomeserverKeyRepublisher is dropped.
-    pub(crate) key_republisher: HomeserverKeyRepublisher,
+    key_republisher: HomeserverKeyRepublisher,
 
     #[allow(dead_code)] // Keep this alive. When dropped, the admin server will stop.
     admin_server: Option<AdminServer>,
@@ -89,8 +88,16 @@ impl HomeserverApp {
 
         tracing::debug!("Homeserver data dir: {}", context.data_dir.path().display());
 
-        let user_keys_republisher =
-            UserKeysRepublisher::start_delayed(&context, INITIAL_DELAY_BEFORE_REPUBLISH);
+        let mut pkarr_builder = context.pkarr_builder.clone();
+        pkarr_builder.no_relays(); // Disable relays to avoid their rate limiting.
+        let republish_interval =
+            Duration::from_secs(context.config_toml.pkdns.user_keys_republisher_interval);
+        let user_keys_republisher_job = UserKeysRepublisherJob::start_delayed(
+            context.sql_db.clone(),
+            pkarr_builder,
+            republish_interval,
+            INITIAL_DELAY_BEFORE_REPUBLISH,
+        );
 
         let admin_server = if context.config_toml.admin.enabled {
             Some(AdminServer::start(&context).await?)
@@ -117,7 +124,7 @@ impl HomeserverApp {
             client_server,
             admin_server,
             metrics_server,
-            user_keys_republisher,
+            _user_keys_republisher_job: user_keys_republisher_job,
             key_republisher,
         })
     }

--- a/pubky-homeserver/src/republishers/key_republisher.rs
+++ b/pubky-homeserver/src/republishers/key_republisher.rs
@@ -52,10 +52,7 @@ impl HomeserverKeyRepublisher {
     ) -> Result<(), PublishError> {
         let res = client.publish(signed_packet, None).await;
         if let Err(e) = &res {
-            tracing::warn!(
-                "Failed to publish the homeserver's pkarr packet to the DHT: {}",
-                e
-            );
+            tracing::warn!("Failed to publish the homeserver's pkarr packet to the DHT: {e}",);
         } else {
             tracing::info!("Published the homeserver's pkarr packet to the DHT.");
         }

--- a/pubky-homeserver/src/republishers/mod.rs
+++ b/pubky-homeserver/src/republishers/mod.rs
@@ -11,4 +11,4 @@ mod user_keys_republisher;
 
 pub(crate) use key_republisher::HomeserverKeyRepublisher;
 pub use key_republisher::KeyRepublisherBuildError;
-pub(crate) use user_keys_republisher::UserKeysRepublisher;
+pub(crate) use user_keys_republisher::UserKeysRepublisherJob;

--- a/pubky-homeserver/src/republishers/pkarr_republisher/multi_republisher.rs
+++ b/pubky-homeserver/src/republishers/pkarr_republisher/multi_republisher.rs
@@ -23,41 +23,32 @@ impl MultiRepublishResult {
         self.results.is_empty()
     }
 
-    /// Successfully published keys
-    pub fn success(&self) -> Vec<PublicKey> {
+    /// Number of successfully published keys.
+    pub fn success_count(&self) -> usize {
         self.results
-            .iter()
-            .filter(|(_, result)| result.is_ok())
-            .map(|(key, _)| key.clone())
-            .collect()
+            .values()
+            .filter(|result| result.is_ok())
+            .count()
     }
 
-    /// Keys that failed to publish
-    pub fn publishing_failed(&self) -> Vec<PublicKey> {
+    /// Number of keys that failed to publish.
+    pub fn publishing_failed_count(&self) -> usize {
         self.results
-            .iter()
-            .filter(|(_, val)| {
-                if let Err(e) = val {
-                    return e.is_publish_failed();
-                }
-                false
+            .values()
+            .filter(|result| {
+                result
+                    .as_ref()
+                    .is_err_and(RepublishError::is_publish_failed)
             })
-            .map(|entry| entry.0.clone())
-            .collect()
+            .count()
     }
 
-    /// Keys that are missing and could not be republished
-    pub fn missing(&self) -> Vec<PublicKey> {
+    /// Number of keys that are missing and could not be republished.
+    pub fn missing_count(&self) -> usize {
         self.results
-            .iter()
-            .filter(|(_, val)| {
-                if let Err(e) = val {
-                    return e.is_missing();
-                }
-                false
-            })
-            .map(|entry| entry.0.clone())
-            .collect()
+            .values()
+            .filter(|result| result.as_ref().is_err_and(RepublishError::is_missing))
+            .count()
     }
 }
 
@@ -74,13 +65,12 @@ impl MultiRepublisher {
     /// pkarr clients instead of just one.
     pub fn new_with_settings(
         mut settings: RepublisherSettings,
-        client_builder: Option<pkarr::ClientBuilder>,
+        client_builder: pkarr::ClientBuilder,
     ) -> Self {
         settings.client = None; // Remove client if it's there because every thread will have it's own.
-        let builder = client_builder.unwrap_or_default();
         Self {
             settings,
-            client_builder: builder,
+            client_builder,
         }
     }
 
@@ -119,11 +109,7 @@ impl MultiRepublisher {
                     )
                 }
                 Err(e) => {
-                    tracing::warn!(
-                        "Failed to republish public_key {} within {elapsed}ms. {}",
-                        key,
-                        e
-                    );
+                    tracing::warn!("Failed to republish public_key {key} within {elapsed}ms. {e}");
                 }
             }
 
@@ -147,7 +133,7 @@ impl MultiRepublisher {
             .collect::<Vec<_>>();
 
         // Run in parallel
-        let mut handles = vec![];
+        let mut handles = Vec::new();
         for chunk in chunks {
             let publisher = self.clone();
             let handle = tokio::spawn(async move { publisher.run_serially(chunk).await });
@@ -157,14 +143,11 @@ impl MultiRepublisher {
         // Join results of all tasks
         let mut results = HashMap::with_capacity(public_keys.len());
         for handle in handles {
-            let join_result = handle.await;
-            if let Err(e) = join_result {
-                tracing::error!("Failed to join handle in MultiRepublisher::run: {e}");
-                continue;
-            }
-            let result = join_result.unwrap()?;
-            for entry in result {
-                results.insert(entry.0, entry.1);
+            match handle.await {
+                Ok(result) => results.extend(result?),
+                Err(e) => {
+                    tracing::error!("Failed to join handle in MultiRepublisher::run: {e}");
+                }
             }
         }
 
@@ -211,7 +194,7 @@ mod tests {
         settings
             .pkarr_client(pkarr_client)
             .min_sufficient_node_publish_count(NonZeroU8::new(3).unwrap());
-        let publisher = MultiRepublisher::new_with_settings(settings, Some(pkarr_builder));
+        let publisher = MultiRepublisher::new_with_settings(settings, pkarr_builder);
         let results = publisher.run_serially(public_keys).await.unwrap();
         let result = results.get(&public_key).unwrap();
         if let Err(e) = result {
@@ -237,7 +220,7 @@ mod tests {
         settings
             .pkarr_client(pkarr_client)
             .min_sufficient_node_publish_count(NonZeroU8::new(4).unwrap());
-        let publisher = MultiRepublisher::new_with_settings(settings, Some(pkarr_builder));
+        let publisher = MultiRepublisher::new_with_settings(settings, pkarr_builder);
         let results = publisher.run_serially(public_keys).await.unwrap();
         let result = results.get(&public_key).unwrap();
         assert!(result.is_err());

--- a/pubky-homeserver/src/republishers/pkarr_republisher/publisher.rs
+++ b/pubky-homeserver/src/republishers/pkarr_republisher/publisher.rs
@@ -143,7 +143,7 @@ impl Publisher {
     }
 
     /// Publish a single public key.
-    pub async fn publish_once(&self) -> Result<PublishInfo, PublishError> {
+    pub async fn publish(&self) -> Result<PublishInfo, PublishError> {
         if let Err(e) = self.client.publish(&self.packet, None).await {
             return Err(e.into());
         }
@@ -196,7 +196,7 @@ mod tests {
             .pkarr_client(pkarr_client)
             .min_sufficient_node_publish_count(NonZeroU8::new(required_nodes).unwrap());
         let publisher = Publisher::new_with_settings(packet, settings).unwrap();
-        let res = publisher.publish_once().await;
+        let res = publisher.publish().await;
         assert!(res.is_ok());
         let success = res.unwrap();
         assert_eq!(success.published_nodes_count, 3);
@@ -219,7 +219,7 @@ mod tests {
             .pkarr_client(pkarr_client)
             .min_sufficient_node_publish_count(NonZeroU8::new(required_nodes).unwrap());
         let publisher = Publisher::new_with_settings(packet, settings).unwrap();
-        let res = publisher.publish_once().await;
+        let res = publisher.publish().await;
 
         assert!(res.is_err());
         let err = res.unwrap_err();

--- a/pubky-homeserver/src/republishers/pkarr_republisher/republisher.rs
+++ b/pubky-homeserver/src/republishers/pkarr_republisher/republisher.rs
@@ -164,12 +164,12 @@ impl Republisher {
     }
 
     /// Republish a single public key.
-    pub async fn republish_once(&self) -> Result<RepublishInfo, RepublishError> {
-        let packet = self.client.resolve_most_recent(&self.public_key).await;
-        if packet.is_none() {
-            return Err(RepublishError::Missing);
-        }
-        let packet = packet.unwrap();
+    async fn republish_once(&self) -> Result<RepublishInfo, RepublishError> {
+        let packet = self
+            .client
+            .resolve_most_recent(&self.public_key)
+            .await
+            .ok_or(RepublishError::Missing)?;
 
         // Check if the packet should be republished
         if !(self.republish_condition)(&packet) {
@@ -182,7 +182,7 @@ impl Republisher {
             .min_sufficient_node_publish_count(self.min_sufficient_node_publish_count);
         let publisher = Publisher::new_with_settings(packet, settings)
             .expect("infallible because pkarr client provided");
-        match publisher.publish_once().await {
+        match publisher.publish().await {
             Ok(info) => Ok(RepublishInfo::new(info.published_nodes_count, 1)),
             Err(e) => Err(e.into()),
         }
@@ -191,9 +191,7 @@ impl Republisher {
     // Republishes the key with an exponential backoff
     pub async fn republish(&self) -> Result<RepublishInfo, RepublishError> {
         let max_retries = self.retry_settings.max_retries.get();
-        let mut retry_count = 0;
-        let mut last_error: Option<RepublishError> = None;
-        while retry_count < max_retries {
+        for retry_count in 0..max_retries {
             match self.republish_once().await {
                 Ok(mut success) => {
                     success.attempts_needed = retry_count as usize + 1;
@@ -201,23 +199,25 @@ impl Republisher {
                 }
                 Err(e) => {
                     tracing::debug!(
-                        "{retry_count}/{max_retries} Failed to publish {}: {e}",
+                        "{retry_count}/{max_retries} Failed to republish {}: {e}",
                         self.public_key
                     );
-                    last_error = Some(e);
+                    if retry_count + 1 == max_retries {
+                        return Err(e);
+                    }
                 }
             }
 
             let delay = self.get_retry_delay(retry_count);
-            retry_count += 1;
             tracing::debug!(
-                "{} {retry_count}/{max_retries} Sleep for {delay:?} before trying again.",
-                self.public_key
+                "{} {}/{max_retries} Sleep for {delay:?} before trying again.",
+                self.public_key,
+                retry_count + 1
             );
             tokio::time::sleep(delay).await;
         }
 
-        Err(last_error.expect("infallible"))
+        unreachable!("max_retries is non-zero")
     }
 }
 

--- a/pubky-homeserver/src/republishers/user_keys_republisher.rs
+++ b/pubky-homeserver/src/republishers/user_keys_republisher.rs
@@ -9,37 +9,35 @@ use tokio::{
     time::{interval, Instant},
 };
 
-use crate::{
-    app_context::AppContext,
-    persistence::sql::{user::UserRepository, SqlDb},
-};
+use crate::persistence::sql::{user::UserRepository, SqlDb};
+
+const MIN_REPUBLISH_INTERVAL: Duration = Duration::from_secs(30 * 60);
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum UserKeysRepublisherError {
     #[error(transparent)]
-    DB(sqlx::Error),
+    DB(#[from] sqlx::Error),
     #[error(transparent)]
-    Pkarr(ResilientClientBuilderError),
+    Pkarr(#[from] ResilientClientBuilderError),
 }
-
-const MIN_REPUBLISH_INTERVAL: Duration = Duration::from_secs(30 * 60);
 
 /// Publishes the pkarr keys of all users to the Mainline DHT.
-pub(crate) struct UserKeysRepublisher {
-    handle: Option<JoinHandle<()>>,
+pub(crate) struct UserKeysRepublisherJob {
+    handle: JoinHandle<()>,
 }
 
-impl UserKeysRepublisher {
+impl UserKeysRepublisherJob {
     /// Run the user keys republisher with an initial delay.
-    pub fn start_delayed(context: &AppContext, initial_delay: Duration) -> Self {
-        let db = context.sql_db.clone();
-        let is_disabled = context.config_toml.pkdns.user_keys_republisher_interval == 0;
-        if is_disabled {
+    pub fn start_delayed(
+        db: SqlDb,
+        pkarr_builder: pkarr::ClientBuilder,
+        mut republish_interval: Duration,
+        initial_delay: Duration,
+    ) -> Option<Self> {
+        if republish_interval.is_zero() {
             tracing::info!("User keys republisher is disabled.");
-            return Self { handle: None };
+            return None;
         }
-        let mut republish_interval =
-            Duration::from_secs(context.config_toml.pkdns.user_keys_republisher_interval);
         if republish_interval < MIN_REPUBLISH_INTERVAL {
             tracing::warn!(
                 "The configured user keys republisher interval is less than {}s. To avoid spamming the Mainline DHT, the value is set to {}s.",
@@ -60,103 +58,79 @@ impl UserKeysRepublisher {
             );
         }
 
-        let mut pkarr_builder = context.pkarr_builder.clone();
-        pkarr_builder.no_relays(); // Disable relays to avoid their rate limiting.
+        let republisher = UserKeysRepublisher { db, pkarr_builder };
         let handle = tokio::spawn(async move {
             tokio::time::sleep(initial_delay).await;
-            Self::run_loop(&db, republish_interval, pkarr_builder).await
+            let mut interval = interval(republish_interval);
+            loop {
+                interval.tick().await;
+                republisher.republish().await;
+            }
         });
-        Self {
-            handle: Some(handle),
-        }
+        Some(Self { handle })
+    }
+}
+
+impl Drop for UserKeysRepublisherJob {
+    fn drop(&mut self) {
+        self.handle.abort();
+    }
+}
+
+struct UserKeysRepublisher {
+    db: SqlDb,
+    pkarr_builder: pkarr::ClientBuilder,
+}
+
+impl UserKeysRepublisher {
+    async fn republish(&self) {
+        let start = Instant::now();
+        tracing::debug!("Republishing user keys...");
+        let result = match self.republish_impl().await {
+            Ok(result) if result.is_empty() => return,
+            Ok(result) => result,
+            Err(e) => {
+                tracing::error!("Error republishing user keys: {e:?}");
+                return;
+            }
+        };
+        let elapsed = start.elapsed();
+        Self::log_republish_result(&result, elapsed);
     }
 
-    // Get all user public keys from the database.
-    async fn get_all_user_keys(db: &SqlDb) -> Result<Vec<PublicKey>, sqlx::Error> {
-        let users = UserRepository::get_all(&mut db.pool().into()).await?;
-
-        let keys: Vec<PublicKey> = users.into_iter().map(|user| user.public_key).collect();
-        Ok(keys)
-    }
-
-    /// Republishes all user pkarr keys to the Mainline DHT once.
-    ///
-    /// # Errors
-    ///
-    /// - If the database cannot be read, an error is returned.
-    /// - If the pkarr keys cannot be republished, an error is returned.
-    async fn republish_keys_once(
-        db: &SqlDb,
-        pkarr_builder: pkarr::ClientBuilder,
-    ) -> Result<MultiRepublishResult, UserKeysRepublisherError> {
-        let keys = Self::get_all_user_keys(db)
-            .await
-            .map_err(UserKeysRepublisherError::DB)?;
+    async fn republish_impl(&self) -> Result<MultiRepublishResult, UserKeysRepublisherError> {
+        let keys = self.get_all_user_keys().await?;
         if keys.is_empty() {
             tracing::debug!("No user keys to republish.");
             return Ok(MultiRepublishResult::new(HashMap::new()));
         }
         let settings = RepublisherSettings::default();
-        let republisher = MultiRepublisher::new_with_settings(settings, Some(pkarr_builder));
+        let republisher = MultiRepublisher::new_with_settings(settings, self.pkarr_builder.clone());
         // TODO: Only publish if user points to this home server.
-        let pkarr_keys: Vec<pkarr::PublicKey> =
-            keys.into_iter().map(pkarr::PublicKey::from).collect();
-        let results = republisher
-            .run(pkarr_keys, 12)
-            .await
-            .map_err(UserKeysRepublisherError::Pkarr)?;
-        Ok(results)
+        let pkarr_keys = keys.into_iter().map(Into::into).collect();
+        Ok(republisher.run(pkarr_keys, 12).await?)
     }
 
-    /// Internal run loop that publishes all user pkarr keys to the Mainline DHT continuously.
-    async fn run_loop(
-        db: &SqlDb,
-        republish_interval: Duration,
-        pkarr_builder: pkarr::ClientBuilder,
-    ) {
-        let mut interval = interval(republish_interval);
-        loop {
-            interval.tick().await;
-            let start = Instant::now();
-            tracing::debug!("Republishing user keys...");
-            let result = match Self::republish_keys_once(db, pkarr_builder.clone()).await {
-                Ok(result) => result,
-                Err(e) => {
-                    tracing::error!("Error republishing user keys: {:?}", e);
-                    continue;
-                }
-            };
-            let elapsed = start.elapsed();
-            if result.is_empty() {
-                continue;
-            }
-            if result.missing().is_empty() {
-                tracing::debug!(
-                    "Republished {} user keys within {:.1}s. {} success, {} missing, {} failed.",
-                    result.len(),
-                    elapsed.as_secs_f32(),
-                    result.success().len(),
-                    result.missing().len(),
-                    result.publishing_failed().len()
-                );
-            } else {
-                tracing::warn!(
-                    "Republished {} user keys within {:.1}s. {} success, {} missing, {} failed.",
-                    result.len(),
-                    elapsed.as_secs_f32(),
-                    result.success().len(),
-                    result.missing().len(),
-                    result.publishing_failed().len()
-                );
-            }
-        }
+    async fn get_all_user_keys(&self) -> Result<Vec<PublicKey>, sqlx::Error> {
+        let users = UserRepository::get_all(&mut self.db.pool().into()).await?;
+        Ok(users.into_iter().map(|user| user.public_key).collect())
     }
-}
 
-impl Drop for UserKeysRepublisher {
-    fn drop(&mut self) {
-        if let Some(handle) = self.handle.take() {
-            handle.abort();
+    fn log_republish_result(result: &MultiRepublishResult, elapsed: Duration) {
+        let total_count = result.len();
+        let elapsed_secs = elapsed.as_secs_f32();
+        let success_count = result.success_count();
+        let missing_count = result.missing_count();
+        let failed_count = result.publishing_failed_count();
+
+        if missing_count == 0 {
+            tracing::debug!(
+                "Republished {total_count} user keys within {elapsed_secs:.1}s. {success_count} success, {missing_count} missing, {failed_count} failed.",
+            );
+        } else {
+            tracing::warn!(
+                "Republished {total_count} user keys within {elapsed_secs:.1}s. {success_count} success, {missing_count} missing, {failed_count} failed.",
+            );
         }
     }
 }
@@ -185,12 +159,11 @@ mod tests {
     async fn test_republish_keys_once() {
         let db = init_db_with_users(10).await;
         let pkarr_builder = pkarr::ClientBuilder::default();
-        let result = UserKeysRepublisher::republish_keys_once(&db, pkarr_builder)
-            .await
-            .unwrap();
+        let worker = UserKeysRepublisher { db, pkarr_builder };
+        let result = worker.republish_impl().await.unwrap();
         assert_eq!(result.len(), 10);
-        assert_eq!(result.success().len(), 0);
-        assert_eq!(result.missing().len(), 10);
-        assert_eq!(result.publishing_failed().len(), 0);
+        assert_eq!(result.success_count(), 0);
+        assert_eq!(result.missing_count(), 10);
+        assert_eq!(result.publishing_failed_count(), 0);
     }
 }

--- a/pubky-homeserver/src/republishers/user_keys_republisher.rs
+++ b/pubky-homeserver/src/republishers/user_keys_republisher.rs
@@ -27,12 +27,13 @@ pub(crate) struct UserKeysRepublisherJob {
 }
 
 impl UserKeysRepublisherJob {
+    const INITIAL_DELAY_BEFORE_REPUBLISH: Duration = Duration::from_secs(60);
+
     /// Run the user keys republisher with an initial delay.
-    pub fn start_delayed(
+    pub fn start(
         db: SqlDb,
         pkarr_builder: pkarr::ClientBuilder,
         mut republish_interval: Duration,
-        initial_delay: Duration,
     ) -> Option<Self> {
         if republish_interval.is_zero() {
             tracing::info!("User keys republisher is disabled.");
@@ -49,7 +50,7 @@ impl UserKeysRepublisherJob {
         tracing::info!(
             "Initialize user keys republisher with an interval of {:?} and an initial delay of {:?}",
             republish_interval,
-            initial_delay
+            Self::INITIAL_DELAY_BEFORE_REPUBLISH
         );
 
         if republish_interval < Duration::from_secs(60 * 60) {
@@ -60,7 +61,7 @@ impl UserKeysRepublisherJob {
 
         let republisher = UserKeysRepublisher { db, pkarr_builder };
         let handle = tokio::spawn(async move {
-            tokio::time::sleep(initial_delay).await;
+            tokio::time::sleep(Self::INITIAL_DELAY_BEFORE_REPUBLISH).await;
             let mut interval = interval(republish_interval);
             loop {
                 interval.tick().await;


### PR DESCRIPTION
Make the user keys republisher optional at startup and pass only the
database, pkarr client builder, and interval into the worker.

Store worker dependencies on the worker itself and replace allocating
multi-republisher result helpers with count helpers.
