### PR TITLE
feat(Dockerfile)!: Use ENTRYPOINT instead of CMD

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,7 @@ ARG BUILD_TARGET=testnet
 RUN apk add --no-cache ca-certificates
 
 # Copy the compiled binary from the builder stage
-COPY --from=builder /usr/src/app/target/release/pubky-$BUILD_TARGET /usr/local/bin/homeserver
+COPY --from=builder /usr/src/app/target/release/pubky-$BUILD_TARGET /usr/local/bin/pubky-homeserver
 
 # Set the working directory
 WORKDIR /usr/local/bin
@@ -63,5 +63,5 @@ WORKDIR /usr/local/bin
 # Expose the port the homeserver listens on (should match that of config.toml)
 EXPOSE 6287
 
-# Set the default command to run the binary
-CMD ["homeserver"]
+# Run the binary by default and pass docker run arguments to it.
+ENTRYPOINT ["homeserver"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,4 +64,4 @@ WORKDIR /usr/local/bin
 EXPOSE 6287
 
 # Run the binary by default and pass docker run arguments to it.
-ENTRYPOINT ["homeserver"]
+ENTRYPOINT ["pubky-homeserver"]


### PR DESCRIPTION
Replaces `CMD` with `ENTRYPOINT` in the Dockerfile.

This simplifies the docker commands like
`docker run --rm pubky-homeserver homeserver --version`
to
`docker run --rm pubky-homeserver --version`  aka avoid the duplicated homeserver mention.

At the same time, this PR standardizes the binary name, renaming it from `homeserver` to `pubky-homeserver`.

FYI @86667 

Related to https://github.com/pubky/pubky-core/pull/431