### PR TITLE
refactor(homeserver): simplify concurrent pkarr republishing

### DIFF
--- a/pubky-homeserver/src/republishers/pkarr_republisher/mod.rs
+++ b/pubky-homeserver/src/republishers/pkarr_republisher/mod.rs
@@ -1,9 +1,11 @@
 mod multi_republisher;
 mod publisher;
+mod republish_summary;
 mod republisher;
 mod resilient_client;
 mod verify;
 
-pub use multi_republisher::{MultiRepublishResult, MultiRepublisher};
+pub use multi_republisher::MultiRepublisher;
+pub use republish_summary::RepublishSummary;
 pub use republisher::RepublisherSettings;
 pub use resilient_client::ResilientClientBuilderError;

--- a/pubky-homeserver/src/republishers/pkarr_republisher/multi_republisher.rs
+++ b/pubky-homeserver/src/republishers/pkarr_republisher/multi_republisher.rs
@@ -1,184 +1,124 @@
-use super::republisher::{RepublishError, RepublishInfo, RepublisherSettings};
+use super::republish_summary::{RepublishResult, RepublishSummary};
+use super::republisher::RepublisherSettings;
 use super::resilient_client::{ResilientClient, ResilientClientBuilderError};
-use pkarr::PublicKey;
-use std::collections::HashMap;
+use futures_util::{stream::FuturesUnordered, TryStreamExt};
+use pkarr::{ClientBuilder, PublicKey};
+use std::{num::NonZeroUsize, sync::Mutex};
 use tokio::time::Instant;
 
-#[derive(Debug, Clone)]
-pub struct MultiRepublishResult {
-    results: HashMap<PublicKey, Result<RepublishInfo, RepublishError>>,
-}
+type PublicKeyQueue = Mutex<Vec<PublicKey>>;
 
-impl MultiRepublishResult {
-    pub fn new(results: HashMap<PublicKey, Result<RepublishInfo, RepublishError>>) -> Self {
-        Self { results }
-    }
-
-    /// Number of keys
-    pub fn len(&self) -> usize {
-        self.results.len()
-    }
-
-    pub fn is_empty(&self) -> bool {
-        self.results.is_empty()
-    }
-
-    /// Number of successfully published keys.
-    pub fn success_count(&self) -> usize {
-        self.results
-            .values()
-            .filter(|result| result.is_ok())
-            .count()
-    }
-
-    /// Number of keys that failed to publish.
-    pub fn publishing_failed_count(&self) -> usize {
-        self.results
-            .values()
-            .filter(|result| {
-                result
-                    .as_ref()
-                    .is_err_and(RepublishError::is_publish_failed)
-            })
-            .count()
-    }
-
-    /// Number of keys that are missing and could not be republished.
-    pub fn missing_count(&self) -> usize {
-        self.results
-            .values()
-            .filter(|result| result.as_ref().is_err_and(RepublishError::is_missing))
-            .count()
-    }
-}
-
-/// Republish multiple keys in a serially or multi-threaded way/
+/// Republish multiple keys serially or concurrently.
 #[derive(Debug, Clone, Default)]
 pub struct MultiRepublisher {
     settings: RepublisherSettings,
-    client_builder: pkarr::ClientBuilder,
+    client_builder: ClientBuilder,
 }
 
 impl MultiRepublisher {
     /// Create a new republisher with the settings.
-    /// The republisher ignores the settings.client but instead uses the client_builder to create multiple
-    /// pkarr clients instead of just one.
-    pub fn new_with_settings(
-        mut settings: RepublisherSettings,
-        client_builder: pkarr::ClientBuilder,
-    ) -> Self {
-        settings.client = None; // Remove client if it's there because every thread will have it's own.
+    pub fn new_with_settings(settings: RepublisherSettings, client_builder: ClientBuilder) -> Self {
         Self {
             settings,
             client_builder,
         }
     }
 
-    /// Go through the list of all public keys and republish them serially.
-    async fn run_serially(
-        &self,
-        public_keys: Vec<PublicKey>,
-    ) -> Result<
-        HashMap<PublicKey, Result<RepublishInfo, RepublishError>>,
-        ResilientClientBuilderError,
-    > {
-        let mut results: HashMap<PublicKey, Result<RepublishInfo, RepublishError>> =
-            HashMap::with_capacity(public_keys.len());
-        tracing::debug!("Start to republish {} public keys.", public_keys.len());
-        // TODO: Inspect pkarr reliability.
-        // pkarr client gets really unreliable when used in parallel. To get around this, we use one client per run().
-        let client = self.client_builder.clone().build()?;
-        let rclient =
-            ResilientClient::new_with_client(client, self.settings.retry_settings.clone())?;
-        for key in public_keys {
-            let start = Instant::now();
-            let res = rclient
-                .republish(
-                    key.clone(),
-                    Some(self.settings.min_sufficient_node_publish_count),
-                )
-                .await;
-
-            let elapsed = start.elapsed().as_millis();
-            match &res {
-                Ok(info) => {
-                    tracing::info!(
-                        "Republished {key} successfully on {} nodes within {elapsed}ms. attemps={}",
-                        info.published_nodes_count,
-                        info.attempts_needed
-                    )
-                }
-                Err(e) => {
-                    tracing::warn!("Failed to republish public_key {key} within {elapsed}ms. {e}");
-                }
-            }
-
-            results.insert(key.clone(), res);
-        }
-        Ok(results)
-    }
-
-    /// Republish keys in a parallel fashion, using multiple threads for better performance.
-    /// A good thread size is around 10 for most computers. With high performance cores, you can push
-    /// it to 40+.
+    /// Republish keys concurrently with at most `max_concurrent_workers` active clients.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if a worker cannot build a DHT-enabled pkarr client.
     pub async fn run(
         &self,
         public_keys: Vec<PublicKey>,
-        thread_count: u8,
-    ) -> Result<MultiRepublishResult, ResilientClientBuilderError> {
-        let chunk_size = public_keys.len().div_ceil(thread_count as usize);
-        let chunks = public_keys
-            .chunks(chunk_size)
-            .map(|chunk| chunk.to_vec())
-            .collect::<Vec<_>>();
+        max_concurrent_workers: NonZeroUsize,
+    ) -> Result<RepublishSummary, ResilientClientBuilderError> {
+        let worker_count = max_concurrent_workers.get().min(public_keys.len());
+        let public_keys = Mutex::new(public_keys);
 
-        // Run in parallel
-        let mut handles = Vec::new();
-        for chunk in chunks {
-            let publisher = self.clone();
-            let handle = tokio::spawn(async move { publisher.run_serially(chunk).await });
-            handles.push(handle);
-        }
-
-        // Join results of all tasks
-        let mut results = HashMap::with_capacity(public_keys.len());
-        for handle in handles {
-            match handle.await {
-                Ok(result) => results.extend(result?),
-                Err(e) => {
-                    tracing::error!("Failed to join handle in MultiRepublisher::run: {e}");
-                }
-            }
-        }
-
-        Ok(MultiRepublishResult::new(results))
+        (0..worker_count)
+            .map(|_| self.run_worker(&public_keys))
+            .collect::<FuturesUnordered<_>>()
+            .try_fold(RepublishSummary::default(), merge_summaries)
+            .await
     }
+
+    async fn run_worker(
+        &self,
+        public_keys: &PublicKeyQueue,
+    ) -> Result<RepublishSummary, ResilientClientBuilderError> {
+        let client = self.client_builder.build()?;
+        let client = ResilientClient::new(client, self.settings.clone())?;
+
+        let mut summary = RepublishSummary::default();
+        while let Some(public_key) = pop(public_keys) {
+            summary.record(republish_key(&client, &public_key).await);
+        }
+        Ok(summary)
+    }
+}
+
+async fn republish_key(client: &ResilientClient, public_key: &PublicKey) -> RepublishResult {
+    let start = Instant::now();
+    let result = client.republish(public_key).await;
+    let elapsed = start.elapsed().as_millis();
+
+    match &result {
+        Ok(info) => tracing::info!(
+            "Republished {public_key} successfully on {} nodes within {elapsed}ms. attempts={}",
+            info.published_nodes_count,
+            info.attempts_needed
+        ),
+        Err(error) => tracing::warn!(
+            "Failed to republish public_key {public_key} within {elapsed}ms. {error}"
+        ),
+    }
+    result
+}
+
+async fn merge_summaries(
+    summary: RepublishSummary,
+    worker_summary: RepublishSummary,
+) -> Result<RepublishSummary, ResilientClientBuilderError> {
+    Ok(summary.merge(worker_summary))
+}
+
+fn pop(public_keys: &PublicKeyQueue) -> Option<PublicKey> {
+    public_keys
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .pop()
 }
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU8;
+    use std::num::{NonZeroU8, NonZeroUsize};
 
     use pkarr::{dns::Name, Keypair, PublicKey};
 
-    use super::MultiRepublisher;
+    use super::{MultiRepublisher, RepublishSummary};
     use crate::republishers::pkarr_republisher::republisher::RepublisherSettings;
 
     async fn publish_sample_packets(client: &pkarr::Client, count: usize) -> Vec<PublicKey> {
         let keys: Vec<Keypair> = (0..count).map(|_| Keypair::random()).collect();
-        for key in keys.iter() {
+        for key in &keys {
             let packet = pkarr::SignedPacketBuilder::default()
                 .cname(Name::new("test").unwrap(), Name::new("test2").unwrap(), 600)
                 .build(key)
                 .unwrap();
-            let _ = client.publish(&packet, None).await;
+            client
+                .publish(&packet, None)
+                .await
+                .expect("sample packet should publish");
         }
 
         keys.into_iter().map(|key| key.public_key()).collect()
     }
 
-    #[tokio::test]
-    async fn single_key_republish_success() {
+    async fn republish_single_key(
+        min_sufficient_node_publish_count: NonZeroU8,
+    ) -> RepublishSummary {
         let dht = pkarr::mainline::Testnet::builder(3)
             .seeded(false)
             .build()
@@ -186,43 +126,30 @@ mod tests {
         let mut pkarr_builder = pkarr::ClientBuilder::default();
         pkarr_builder.bootstrap(&dht.bootstrap).no_relays();
         let pkarr_client = pkarr_builder.clone().build().unwrap();
-
         let public_keys = publish_sample_packets(&pkarr_client, 1).await;
-        let public_key = public_keys.first().unwrap().clone();
 
         let mut settings = RepublisherSettings::default();
-        settings
-            .pkarr_client(pkarr_client)
-            .min_sufficient_node_publish_count(NonZeroU8::new(3).unwrap());
-        let publisher = MultiRepublisher::new_with_settings(settings, pkarr_builder);
-        let results = publisher.run_serially(public_keys).await.unwrap();
-        let result = results.get(&public_key).unwrap();
-        if let Err(e) = result {
-            println!("Err {e}");
-        }
-        assert!(result.is_ok());
+        settings.min_sufficient_node_publish_count(min_sufficient_node_publish_count);
+
+        MultiRepublisher::new_with_settings(settings, pkarr_builder)
+            .run(public_keys, NonZeroUsize::MIN)
+            .await
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn single_key_republish_success() {
+        let summary = republish_single_key(NonZeroU8::new(3).unwrap()).await;
+
+        assert_eq!(summary.len(), 1);
+        assert_eq!(summary.success_count(), 1);
     }
 
     #[tokio::test]
     async fn single_key_republish_insufficient() {
-        let dht = pkarr::mainline::Testnet::builder(3)
-            .seeded(false)
-            .build()
-            .unwrap();
-        let mut pkarr_builder = pkarr::ClientBuilder::default();
-        pkarr_builder.bootstrap(&dht.bootstrap).no_relays();
-        let pkarr_client = pkarr_builder.clone().build().unwrap();
+        let summary = republish_single_key(NonZeroU8::new(4).unwrap()).await;
 
-        let public_keys = publish_sample_packets(&pkarr_client, 1).await;
-        let public_key = public_keys.first().unwrap().clone();
-
-        let mut settings = RepublisherSettings::default();
-        settings
-            .pkarr_client(pkarr_client)
-            .min_sufficient_node_publish_count(NonZeroU8::new(4).unwrap());
-        let publisher = MultiRepublisher::new_with_settings(settings, pkarr_builder);
-        let results = publisher.run_serially(public_keys).await.unwrap();
-        let result = results.get(&public_key).unwrap();
-        assert!(result.is_err());
+        assert_eq!(summary.len(), 1);
+        assert_eq!(summary.publishing_failed_count(), 1);
     }
 }

--- a/pubky-homeserver/src/republishers/pkarr_republisher/multi_republisher.rs
+++ b/pubky-homeserver/src/republishers/pkarr_republisher/multi_republisher.rs
@@ -116,7 +116,9 @@ mod tests {
         keys.into_iter().map(|key| key.public_key()).collect()
     }
 
-    async fn republish_single_key(
+    async fn republish_keys(
+        key_count: usize,
+        max_concurrent_workers: NonZeroUsize,
         min_sufficient_node_publish_count: NonZeroU8,
     ) -> RepublishSummary {
         let dht = pkarr::mainline::Testnet::builder(3)
@@ -126,15 +128,21 @@ mod tests {
         let mut pkarr_builder = pkarr::ClientBuilder::default();
         pkarr_builder.bootstrap(&dht.bootstrap).no_relays();
         let pkarr_client = pkarr_builder.clone().build().unwrap();
-        let public_keys = publish_sample_packets(&pkarr_client, 1).await;
+        let public_keys = publish_sample_packets(&pkarr_client, key_count).await;
 
         let mut settings = RepublisherSettings::default();
         settings.min_sufficient_node_publish_count(min_sufficient_node_publish_count);
 
         MultiRepublisher::new_with_settings(settings, pkarr_builder)
-            .run(public_keys, NonZeroUsize::MIN)
+            .run(public_keys, max_concurrent_workers)
             .await
             .unwrap()
+    }
+
+    async fn republish_single_key(
+        min_sufficient_node_publish_count: NonZeroU8,
+    ) -> RepublishSummary {
+        republish_keys(1, NonZeroUsize::MIN, min_sufficient_node_publish_count).await
     }
 
     #[tokio::test]
@@ -151,5 +159,20 @@ mod tests {
 
         assert_eq!(summary.len(), 1);
         assert_eq!(summary.publishing_failed_count(), 1);
+    }
+
+    #[tokio::test]
+    async fn multiple_keys_republish_with_multiple_workers() {
+        let summary =
+            republish_keys(5, NonZeroUsize::new(2).unwrap(), NonZeroU8::new(3).unwrap()).await;
+
+        assert_eq!(summary.len(), 5);
+        assert_eq!(summary.success_count(), 5);
+        assert_eq!(summary.publishing_failed_count(), 0);
+        assert_eq!(summary.missing_count(), 0);
+        assert_eq!(
+            summary.success_count() + summary.publishing_failed_count() + summary.missing_count(),
+            summary.len()
+        );
     }
 }

--- a/pubky-homeserver/src/republishers/pkarr_republisher/republish_summary.rs
+++ b/pubky-homeserver/src/republishers/pkarr_republisher/republish_summary.rs
@@ -1,0 +1,82 @@
+use super::republisher::{RepublishError, RepublishInfo};
+
+pub(crate) type RepublishResult = Result<RepublishInfo, RepublishError>;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct RepublishSummary {
+    total_count: usize,
+    success_count: usize,
+    publishing_failed_count: usize,
+    missing_count: usize,
+}
+
+impl RepublishSummary {
+    pub(crate) fn record(&mut self, result: RepublishResult) {
+        self.total_count += 1;
+
+        match result {
+            Ok(_) => self.success_count += 1,
+            Err(RepublishError::PublishFailed(_)) => self.publishing_failed_count += 1,
+            Err(RepublishError::Missing) => self.missing_count += 1,
+        }
+    }
+
+    pub(crate) fn merge(mut self, other: Self) -> Self {
+        self.total_count += other.total_count;
+        self.success_count += other.success_count;
+        self.publishing_failed_count += other.publishing_failed_count;
+        self.missing_count += other.missing_count;
+        self
+    }
+
+    /// Number of republish attempts.
+    pub fn len(&self) -> usize {
+        self.total_count
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.total_count == 0
+    }
+
+    /// Number of successfully published keys.
+    pub fn success_count(&self) -> usize {
+        self.success_count
+    }
+
+    /// Number of keys that failed to publish.
+    pub fn publishing_failed_count(&self) -> usize {
+        self.publishing_failed_count
+    }
+
+    /// Number of keys that are missing and could not be republished.
+    pub fn missing_count(&self) -> usize {
+        self.missing_count
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{RepublishError, RepublishInfo, RepublishSummary};
+    use crate::republishers::pkarr_republisher::publisher::PublishError;
+
+    #[test]
+    fn records_and_merges_republish_outcomes() {
+        let mut summary = RepublishSummary::default();
+        summary.record(Ok(RepublishInfo::new(3, 1)));
+
+        let mut other = RepublishSummary::default();
+        other.record(Err(RepublishError::Missing));
+        other.record(Err(RepublishError::PublishFailed(
+            PublishError::InsufficientlyPublished {
+                published_nodes_count: 1,
+            },
+        )));
+
+        let summary = summary.merge(other);
+
+        assert_eq!(summary.len(), 3);
+        assert_eq!(summary.success_count(), 1);
+        assert_eq!(summary.missing_count(), 1);
+        assert_eq!(summary.publishing_failed_count(), 1);
+    }
+}

--- a/pubky-homeserver/src/republishers/pkarr_republisher/republisher.rs
+++ b/pubky-homeserver/src/republishers/pkarr_republisher/republisher.rs
@@ -15,16 +15,6 @@ pub enum RepublishError {
     PublishFailed(#[from] PublishError),
 }
 
-impl RepublishError {
-    pub fn is_missing(&self) -> bool {
-        matches!(self, RepublishError::Missing)
-    }
-
-    pub fn is_publish_failed(&self) -> bool {
-        matches!(self, RepublishError::PublishFailed { .. })
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct RepublishInfo {
     /// How many nodes the key got published on.
@@ -47,7 +37,6 @@ pub type RepublishCondition = dyn Fn(&SignedPacket) -> bool + Send + Sync;
 /// Settings for creating a republisher
 #[derive(Clone)]
 pub struct RepublisherSettings {
-    pub(crate) client: Option<pkarr::Client>,
     pub(crate) min_sufficient_node_publish_count: NonZeroU8,
     pub(crate) retry_settings: RetrySettings,
     pub(crate) republish_condition: Option<Arc<RepublishCondition>>,
@@ -56,27 +45,12 @@ pub struct RepublisherSettings {
 impl std::fmt::Debug for RepublisherSettings {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("RepublisherSettings")
-            .field("client", &self.client)
             .field(
                 "min_sufficient_node_publish_count",
                 &self.min_sufficient_node_publish_count,
             )
             .field("retry_settings", &self.retry_settings)
             .finish_non_exhaustive()
-    }
-}
-
-impl RepublisherSettings {
-    /// Set a custom pkarr client
-    pub fn pkarr_client(&mut self, client: pkarr::Client) -> &mut Self {
-        self.client = Some(client);
-        self
-    }
-
-    /// Set settings in relation to retries.
-    pub fn retry_settings(&mut self, settings: RetrySettings) -> &mut Self {
-        self.retry_settings = settings;
-        self
     }
 }
 
@@ -102,7 +76,6 @@ impl RepublisherSettings {
 impl Default for RepublisherSettings {
     fn default() -> Self {
         Self {
-            client: None,
             min_sufficient_node_publish_count: NonZeroU8::new(10).expect("Should always be > 0"),
             retry_settings: RetrySettings::default(),
             republish_condition: None,
@@ -113,86 +86,69 @@ impl Default for RepublisherSettings {
 /// Tries to republish a single key.
 /// Retries in case of errors with an exponential backoff.
 pub struct Republisher {
-    public_key: PublicKey,
     client: pkarr::Client,
-    min_sufficient_node_publish_count: NonZeroU8,
-    retry_settings: RetrySettings,
-    republish_condition: Arc<dyn Fn(&SignedPacket) -> bool + Send + Sync>,
+    settings: RepublisherSettings,
 }
 
 impl std::fmt::Debug for Republisher {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Republisher")
-            .field("public_key", &self.public_key)
             .field("client", &self.client)
-            .field(
-                "min_sufficient_node_publish_count",
-                &self.min_sufficient_node_publish_count,
-            )
-            .field("retry_settings", &self.retry_settings)
+            .field("settings", &self.settings)
             .finish_non_exhaustive()
     }
 }
 
 impl Republisher {
-    pub fn new_with_settings(
-        public_key: PublicKey,
-        settings: RepublisherSettings,
-    ) -> Result<Self, pkarr::errors::BuildError> {
-        let client = match &settings.client {
-            Some(c) => c.clone(),
-            None => pkarr::Client::builder().build()?,
-        };
-        Ok(Republisher {
-            public_key,
-            client,
-            min_sufficient_node_publish_count: settings.min_sufficient_node_publish_count,
-            retry_settings: settings.retry_settings,
-            republish_condition: settings
-                .republish_condition
-                .unwrap_or_else(|| Arc::new(|_| true)),
-        })
+    pub fn new_with_settings(client: pkarr::Client, settings: RepublisherSettings) -> Self {
+        Self { client, settings }
     }
 
     /// Exponential backoff delay starting with `INITIAL_DELAY_MS` and maxing out at  `MAX_DELAY_MS`
     fn get_retry_delay(&self, retry_count: u8) -> Duration {
-        let initial_ms = self.retry_settings.initial_retry_delay.as_millis() as u64;
+        let initial_ms = self.settings.retry_settings.initial_retry_delay.as_millis() as u64;
         let multiplicator = 2u64.pow(retry_count as u32);
         let delay_ms = initial_ms * multiplicator;
         let delay = Duration::from_millis(delay_ms);
-        delay.min(self.retry_settings.max_retry_delay)
+        delay.min(self.settings.retry_settings.max_retry_delay)
     }
 
     /// Republish a single public key.
-    async fn republish_once(&self) -> Result<RepublishInfo, RepublishError> {
+    async fn republish_once(
+        &self,
+        public_key: &PublicKey,
+    ) -> Result<RepublishInfo, RepublishError> {
         let packet = self
             .client
-            .resolve_most_recent(&self.public_key)
+            .resolve_most_recent(public_key)
             .await
             .ok_or(RepublishError::Missing)?;
 
-        // Check if the packet should be republished
-        if !(self.republish_condition)(&packet) {
+        if self
+            .settings
+            .republish_condition
+            .as_ref()
+            .is_some_and(|condition| !condition(&packet))
+        {
             return Ok(RepublishInfo::new(0, 1));
         }
 
         let mut settings = PublisherSettings::default();
         settings
             .pkarr_client(self.client.clone())
-            .min_sufficient_node_publish_count(self.min_sufficient_node_publish_count);
+            .min_sufficient_node_publish_count(self.settings.min_sufficient_node_publish_count);
         let publisher = Publisher::new_with_settings(packet, settings)
             .expect("infallible because pkarr client provided");
-        match publisher.publish().await {
-            Ok(info) => Ok(RepublishInfo::new(info.published_nodes_count, 1)),
-            Err(e) => Err(e.into()),
-        }
+
+        let info = publisher.publish().await?;
+        Ok(RepublishInfo::new(info.published_nodes_count, 1))
     }
 
     // Republishes the key with an exponential backoff
-    pub async fn republish(&self) -> Result<RepublishInfo, RepublishError> {
-        let max_retries = self.retry_settings.max_retries.get();
+    pub async fn republish(&self, public_key: &PublicKey) -> Result<RepublishInfo, RepublishError> {
+        let max_retries = self.settings.retry_settings.max_retries.get();
         for retry_count in 0..max_retries {
-            match self.republish_once().await {
+            match self.republish_once(public_key).await {
                 Ok(mut success) => {
                     success.attempts_needed = retry_count as usize + 1;
                     return Ok(success);
@@ -200,7 +156,7 @@ impl Republisher {
                 Err(e) => {
                     tracing::debug!(
                         "{retry_count}/{max_retries} Failed to republish {}: {e}",
-                        self.public_key
+                        public_key
                     );
                     if retry_count + 1 == max_retries {
                         return Err(e);
@@ -210,8 +166,7 @@ impl Republisher {
 
             let delay = self.get_retry_delay(retry_count);
             tracing::debug!(
-                "{} {}/{max_retries} Sleep for {delay:?} before trying again.",
-                self.public_key,
+                "{public_key} {}/{max_retries} Sleep for {delay:?} before trying again.",
                 retry_count + 1
             );
             tokio::time::sleep(delay).await;
@@ -225,7 +180,7 @@ impl Republisher {
 mod tests {
     use std::{num::NonZeroU8, time::Duration};
 
-    use super::{Republisher, RepublisherSettings};
+    use super::{RepublishError, Republisher, RepublisherSettings};
     use pkarr::{dns::Name, Keypair, PublicKey};
 
     async fn publish_sample_packets(client: &pkarr::Client) -> PublicKey {
@@ -256,11 +211,9 @@ mod tests {
 
         let required_nodes = 1;
         let mut settings = RepublisherSettings::default();
-        settings
-            .pkarr_client(pkarr_client)
-            .min_sufficient_node_publish_count(NonZeroU8::new(required_nodes).unwrap());
-        let publisher = Republisher::new_with_settings(public_key, settings).unwrap();
-        let res = publisher.republish_once().await;
+        settings.min_sufficient_node_publish_count(NonZeroU8::new(required_nodes).unwrap());
+        let publisher = Republisher::new_with_settings(pkarr_client, settings);
+        let res = publisher.republish_once(&public_key).await;
         assert!(res.is_ok());
         let success = res.unwrap();
         assert_eq!(success.published_nodes_count, 1);
@@ -276,15 +229,11 @@ mod tests {
 
         let required_nodes = 1;
         let mut settings = RepublisherSettings::default();
-        settings
-            .pkarr_client(pkarr_client)
-            .min_sufficient_node_publish_count(NonZeroU8::new(required_nodes).unwrap());
-        let publisher = Republisher::new_with_settings(public_key, settings).unwrap();
-        let res = publisher.republish_once().await;
+        settings.min_sufficient_node_publish_count(NonZeroU8::new(required_nodes).unwrap());
+        let publisher = Republisher::new_with_settings(pkarr_client, settings);
+        let res = publisher.republish_once(&public_key).await;
 
-        assert!(res.is_err());
-        let err = res.unwrap_err();
-        assert!(err.is_missing());
+        assert!(matches!(res, Err(RepublishError::Missing)));
     }
 
     #[tokio::test]
@@ -293,19 +242,15 @@ mod tests {
         let mut pkarr_builder = pkarr::ClientBuilder::default();
         pkarr_builder.bootstrap(&dht.bootstrap).no_relays();
         let pkarr_client = pkarr_builder.clone().build().unwrap();
-        let public_key = Keypair::random().public_key();
-
         let required_nodes = 1;
         let mut settings = RepublisherSettings::default();
-        settings
-            .pkarr_client(pkarr_client)
-            .min_sufficient_node_publish_count(NonZeroU8::new(required_nodes).unwrap());
+        settings.min_sufficient_node_publish_count(NonZeroU8::new(required_nodes).unwrap());
         settings
             .retry_settings
             .max_retries(NonZeroU8::new(10).unwrap())
             .initial_retry_delay(Duration::from_millis(100))
             .max_retry_delay(Duration::from_secs(10));
-        let publisher = Republisher::new_with_settings(public_key, settings).unwrap();
+        let publisher = Republisher::new_with_settings(pkarr_client, settings);
 
         let first_delay = publisher.get_retry_delay(0);
         assert_eq!(first_delay.as_millis(), 100);
@@ -327,18 +272,15 @@ mod tests {
 
         let required_nodes = 1;
         let mut settings = RepublisherSettings::default();
-        settings
-            .pkarr_client(pkarr_client)
-            .min_sufficient_node_publish_count(NonZeroU8::new(required_nodes).unwrap());
+        settings.min_sufficient_node_publish_count(NonZeroU8::new(required_nodes).unwrap());
         settings
             .retry_settings
             .max_retries(NonZeroU8::new(3).unwrap())
             .initial_retry_delay(Duration::from_millis(100));
-        let publisher = Republisher::new_with_settings(public_key, settings).unwrap();
-        let res = publisher.republish().await;
+        let publisher = Republisher::new_with_settings(pkarr_client, settings);
+        let res = publisher.republish(&public_key).await;
 
-        assert!(res.is_err());
-        assert!(res.unwrap_err().is_missing());
+        assert!(matches!(res, Err(RepublishError::Missing)));
     }
 
     #[tokio::test]
@@ -352,13 +294,12 @@ mod tests {
         let required_nodes = 1;
         let mut settings = RepublisherSettings::default();
         settings
-            .pkarr_client(pkarr_client.clone())
             .min_sufficient_node_publish_count(NonZeroU8::new(required_nodes).unwrap())
             // Only republish if the packet has a TTL greater than 300
             .republish_condition(|_| false);
 
-        let publisher = Republisher::new_with_settings(public_key.clone(), settings).unwrap();
-        let res = publisher.republish_once().await;
+        let publisher = Republisher::new_with_settings(pkarr_client, settings);
+        let res = publisher.republish_once(&public_key).await;
         assert!(res.is_ok());
         let info = res.unwrap();
         assert_eq!(info.published_nodes_count, 0);
@@ -375,13 +316,12 @@ mod tests {
         let required_nodes = 1;
         let mut settings = RepublisherSettings::default();
         settings
-            .pkarr_client(pkarr_client.clone())
             .min_sufficient_node_publish_count(NonZeroU8::new(required_nodes).unwrap())
             // Only republish if the packet has a TTL greater than 300
             .republish_condition(|_| true);
 
-        let publisher = Republisher::new_with_settings(public_key.clone(), settings).unwrap();
-        let res = publisher.republish_once().await;
+        let publisher = Republisher::new_with_settings(pkarr_client, settings);
+        let res = publisher.republish_once(&public_key).await;
         assert!(res.is_ok());
         let info = res.unwrap();
         assert_eq!(info.published_nodes_count, 1);

--- a/pubky-homeserver/src/republishers/pkarr_republisher/resilient_client.rs
+++ b/pubky-homeserver/src/republishers/pkarr_republisher/resilient_client.rs
@@ -1,8 +1,5 @@
-use std::num::NonZeroU8;
-
 use pkarr::PublicKey;
 
-use super::publisher::RetrySettings;
 use super::republisher::{RepublishError, RepublishInfo, Republisher, RepublisherSettings};
 
 #[derive(Debug, thiserror::Error)]
@@ -22,37 +19,24 @@ pub enum ResilientClientBuilderError {
 #[derive(Debug, Clone)]
 pub struct ResilientClient {
     client: pkarr::Client,
-    retry_settings: RetrySettings,
+    settings: RepublisherSettings,
 }
 
 impl ResilientClient {
-    pub fn new_with_client(
+    pub fn new(
         client: pkarr::Client,
-        retry_settings: RetrySettings,
+        settings: RepublisherSettings,
     ) -> Result<Self, ResilientClientBuilderError> {
         if client.dht().is_none() {
             return Err(ResilientClientBuilderError::DhtNotEnabled);
         }
-        Ok(Self {
-            client,
-            retry_settings,
-        })
+        Ok(Self { client, settings })
     }
 
     /// Republishes a pkarr packet with retries. Verifies it's been stored correctly.
-    pub async fn republish(
-        &self,
-        public_key: PublicKey,
-        min_sufficient_node_publish_count: Option<NonZeroU8>,
-    ) -> Result<RepublishInfo, RepublishError> {
-        let mut settings = RepublisherSettings::default();
-        settings.pkarr_client(self.client.clone());
-        if let Some(count) = min_sufficient_node_publish_count {
-            settings.min_sufficient_node_publish_count = count;
-        };
-        settings.retry_settings(self.retry_settings.clone());
-        let publisher = Republisher::new_with_settings(public_key, settings)
-            .expect("infallible because pkarr client provided.");
-        publisher.republish().await
+    pub async fn republish(&self, public_key: &PublicKey) -> Result<RepublishInfo, RepublishError> {
+        Republisher::new_with_settings(self.client.clone(), self.settings.clone())
+            .republish(public_key)
+            .await
     }
 }

--- a/pubky-homeserver/src/republishers/user_keys_republisher.rs
+++ b/pubky-homeserver/src/republishers/user_keys_republisher.rs
@@ -1,7 +1,7 @@
-use std::{collections::HashMap, time::Duration};
+use std::{num::NonZeroUsize, time::Duration};
 
 use super::pkarr_republisher::{
-    MultiRepublishResult, MultiRepublisher, RepublisherSettings, ResilientClientBuilderError,
+    MultiRepublisher, RepublishSummary, RepublisherSettings, ResilientClientBuilderError,
 };
 use pubky_common::crypto::PublicKey;
 use tokio::{
@@ -87,29 +87,31 @@ impl UserKeysRepublisher {
     async fn republish(&self) {
         let start = Instant::now();
         tracing::debug!("Republishing user keys...");
-        let result = match self.republish_impl().await {
-            Ok(result) if result.is_empty() => return,
-            Ok(result) => result,
+        let summary = match self.republish_impl().await {
+            Ok(summary) if summary.is_empty() => return,
+            Ok(summary) => summary,
             Err(e) => {
                 tracing::error!("Error republishing user keys: {e:?}");
                 return;
             }
         };
         let elapsed = start.elapsed();
-        Self::log_republish_result(&result, elapsed);
+        Self::log_republish_summary(&summary, elapsed);
     }
 
-    async fn republish_impl(&self) -> Result<MultiRepublishResult, UserKeysRepublisherError> {
+    async fn republish_impl(&self) -> Result<RepublishSummary, UserKeysRepublisherError> {
         let keys = self.get_all_user_keys().await?;
         if keys.is_empty() {
             tracing::debug!("No user keys to republish.");
-            return Ok(MultiRepublishResult::new(HashMap::new()));
+            return Ok(RepublishSummary::default());
         }
         let settings = RepublisherSettings::default();
         let republisher = MultiRepublisher::new_with_settings(settings, self.pkarr_builder.clone());
         // TODO: Only publish if user points to this home server.
         let pkarr_keys = keys.into_iter().map(Into::into).collect();
-        Ok(republisher.run(pkarr_keys, 12).await?)
+        let max_concurrent_workers =
+            NonZeroUsize::new(12).expect("worker count should be non-zero");
+        Ok(republisher.run(pkarr_keys, max_concurrent_workers).await?)
     }
 
     async fn get_all_user_keys(&self) -> Result<Vec<PublicKey>, sqlx::Error> {
@@ -117,12 +119,12 @@ impl UserKeysRepublisher {
         Ok(users.into_iter().map(|user| user.public_key).collect())
     }
 
-    fn log_republish_result(result: &MultiRepublishResult, elapsed: Duration) {
-        let total_count = result.len();
+    fn log_republish_summary(summary: &RepublishSummary, elapsed: Duration) {
+        let total_count = summary.len();
         let elapsed_secs = elapsed.as_secs_f32();
-        let success_count = result.success_count();
-        let missing_count = result.missing_count();
-        let failed_count = result.publishing_failed_count();
+        let success_count = summary.success_count();
+        let missing_count = summary.missing_count();
+        let failed_count = summary.publishing_failed_count();
 
         if missing_count == 0 {
             tracing::debug!(
@@ -161,10 +163,10 @@ mod tests {
         let db = init_db_with_users(10).await;
         let pkarr_builder = pkarr::ClientBuilder::default();
         let worker = UserKeysRepublisher { db, pkarr_builder };
-        let result = worker.republish_impl().await.unwrap();
-        assert_eq!(result.len(), 10);
-        assert_eq!(result.success_count(), 0);
-        assert_eq!(result.missing_count(), 10);
-        assert_eq!(result.publishing_failed_count(), 0);
+        let summary = worker.republish_impl().await.unwrap();
+        assert_eq!(summary.len(), 10);
+        assert_eq!(summary.success_count(), 0);
+        assert_eq!(summary.missing_count(), 10);
+        assert_eq!(summary.publishing_failed_count(), 0);
     }
 }


### PR DESCRIPTION
Reuse one DHT-enabled client per bounded worker and process keys from a
shared queue. Aggregate outcomes into summaries without retaining
per-key results.
