### PR TITLE
refactor: resolve workspace clippy warnings

### DIFF
--- a/e2e/src/tests/events/feed.rs
+++ b/e2e/src/tests/events/feed.rs
@@ -51,7 +51,13 @@ async fn list_events() {
         let lines = text.split('\n').collect::<Vec<_>>();
 
         // last line is "cursor: <id>"
-        let cursor = lines.last().unwrap().split(' ').last().unwrap().to_string();
+        let cursor = lines
+            .last()
+            .unwrap()
+            .split(' ')
+            .next_back()
+            .unwrap()
+            .to_string();
 
         assert_eq!(
             lines,
@@ -142,7 +148,13 @@ async fn read_after_event() {
 
         let text = resp.text().await.unwrap();
         let lines = text.split('\n').collect::<Vec<_>>();
-        let cursor = lines.last().unwrap().split(' ').last().unwrap().to_string();
+        let cursor = lines
+            .last()
+            .unwrap()
+            .split(' ')
+            .next_back()
+            .unwrap()
+            .to_string();
 
         assert_eq!(
             lines,

--- a/e2e/src/tests/storage/listing.rs
+++ b/e2e/src/tests/storage/listing.rs
@@ -31,7 +31,7 @@ async fn list_deep() {
     }
 
     // List all files with no cursor, no limit
-    let url = format!("/pub/example.com/");
+    let url = "/pub/example.com/".to_string();
     {
         let list = owner_session
             .storage()
@@ -173,7 +173,7 @@ async fn list_shallow() {
     }
 
     // List all files with no cursor, no limit
-    let url = format!("/pub/");
+    let url = "/pub/".to_string();
     {
         let list = owner_session
             .storage()

--- a/pubky-homeserver/src/client_server/query_params.rs
+++ b/pubky-homeserver/src/client_server/query_params.rs
@@ -61,7 +61,7 @@ where
         let limit = params
             .get("limit")
             // Treat `limit=` as None
-            .and_then(|l| if l.is_empty() { None } else { Some(l) })
+            .filter(|&l| !l.is_empty())
             .and_then(|l| l.parse::<u16>().ok());
         let cursor = Self::extract_cursor(&params);
 

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -151,10 +151,8 @@ fn parse_query_params(query: &str) -> Result<EventStreamQueryParams, EventStream
                 live = value == "true" || value == "1";
             }
             // `path` is repeatable; empty values are ignored.
-            "path" => {
-                if !value.is_empty() {
-                    paths.push(value.to_string());
-                }
+            "path" if !value.is_empty() => {
+                paths.push(value.to_string());
             }
             _ => {} // Ignore unknown parameters
         }

--- a/pubky-sdk/bindings/js/src/actors/browser_grant_key_store.rs
+++ b/pubky-sdk/bindings/js/src/actors/browser_grant_key_store.rs
@@ -378,13 +378,13 @@ impl BrowserGrantKeyStore {
         #[cfg(not(target_arch = "wasm32"))]
         {
             let _ = key_id;
-            return delegated_sign_callback(|_| async {
+            delegated_sign_callback(|_| async {
                 Err(pubky::Error::Authentication(
                     pubky::errors::AuthError::Validation(
                         "Delegated grant signing is only available in wasm browser builds.".into(),
                     ),
                 ))
-            });
+            })
         }
     }
 

--- a/pubky-sdk/src/actors/auth/grant/pop_signer.rs
+++ b/pubky-sdk/src/actors/auth/grant/pop_signer.rs
@@ -186,18 +186,18 @@ mod tests {
 
     #[tokio::test]
     async fn delegated_signer_sign_value() {
+        #[derive(serde::Serialize)]
+        struct DummyClaims;
+        let claims = DummyClaims {};
+
         let signer = GrantPopSigner::delegated(
             "delegated-test-key".into(),
             Keypair::random().public_key(),
             delegated_sign_callback(|_| async { Ok(vec![0; 64]) }),
         );
 
-        #[derive(serde::Serialize)]
-        struct DummyClaims;
-        let claims = DummyClaims {};
-
-        let signed = signer.sign_jws("test", &claims).await.unwrap();
-        let base64_signature = signed.split('.').nth(2).unwrap();
+        let signed_jwt = signer.sign_jws("test", &claims).await.unwrap();
+        let base64_signature = signed_jwt.split('.').nth(2).unwrap();
         assert_eq!(
             base64_signature,
             "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",

--- a/pubky-sdk/src/actors/auth/relay/http_relay_link_channel.rs
+++ b/pubky-sdk/src/actors/auth/relay/http_relay_link_channel.rs
@@ -394,7 +394,7 @@ mod tests {
         let chan = channel.clone();
         let produce_handle = tokio::spawn(async move {
             // Wait for the first poll to timeout
-            tokio::time::sleep(Duration::from_millis(1_000)).await;
+            tokio::time::sleep(Duration::from_secs(1)).await;
             let client = PubkyHttpClient::new().unwrap();
             chan.produce(&client, b"Hello, world!").await.unwrap();
         });

--- a/pubky-sdk/src/actors/signer/auth.rs
+++ b/pubky-sdk/src/actors/signer/auth.rs
@@ -149,8 +149,7 @@ impl PubkySigner {
     ) -> Vec<u8> {
         let now = web_time::SystemTime::now()
             .duration_since(web_time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs());
         let claims = GrantClaims {
             iss: self.keypair.public_key(),
             client_id,

--- a/pubky-sdk/src/actors/signer/session.rs
+++ b/pubky-sdk/src/actors/signer/session.rs
@@ -265,8 +265,7 @@ impl PubkySigner {
     ) -> GrantClaims {
         let now = web_time::SystemTime::now()
             .duration_since(web_time::UNIX_EPOCH)
-            .map(|d| d.as_secs())
-            .unwrap_or(0);
+            .map_or(0, |d| d.as_secs());
         GrantClaims {
             iss: self.keypair.public_key(),
             client_id,


### PR DESCRIPTION
Apply lint-suggested iterator, control-flow, duration, and test
cleanups without changing behavior.
