### PR TITLE
fix: cache policy for priv events

### DIFF
--- a/e2e/src/tests/events/stream_private.rs
+++ b/e2e/src/tests/events/stream_private.rs
@@ -108,6 +108,20 @@ async fn events_stream_private_path_requires_auth() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        response
+            .headers()
+            .get("cache-control")
+            .and_then(|value| value.to_str().ok()),
+        Some("no-store")
+    );
+    assert_eq!(
+        response
+            .headers()
+            .get("vary")
+            .and_then(|value| value.to_str().ok()),
+        Some("pubky-host, Authorization, Cookie")
+    );
 }
 
 /// An authorized owner (root capability) receives their own private events,
@@ -151,6 +165,20 @@ async fn events_stream_authorized_owner_receives_private() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response
+            .headers()
+            .get("cache-control")
+            .and_then(|value| value.to_str().ok()),
+        Some("no-store")
+    );
+    assert_eq!(
+        response
+            .headers()
+            .get("vary")
+            .and_then(|value| value.to_str().ok()),
+        Some("pubky-host, Authorization, Cookie")
+    );
     let mut stream = response.bytes_stream().eventsource();
     let event = stream.next().await.unwrap().unwrap();
     assert!(event

--- a/pubky-homeserver/README.md
+++ b/pubky-homeserver/README.md
@@ -83,9 +83,12 @@ Use `cargo run -- --data-dir=~/.pubky`.
 ## Caching and Proxies
 
 Tenant-private responses must never be stored by shared caches. `/priv/...`
-responses and `/events-stream` use `Cache-Control: no-store` and vary on
+data responses and `/events-stream` use `Cache-Control: no-store` and vary on
 `pubky-host`, `Authorization`, and `Cookie`; `/pub/...` file validators keep
-their existing tenant-aware caching behavior.
+their existing tenant-aware caching behavior. 
+
+Note: CORS preflight `OPTIONS` is
+handled upstream by the CORS layer and carries no private body.
 
 ## Signup Token
 

--- a/pubky-homeserver/README.md
+++ b/pubky-homeserver/README.md
@@ -80,6 +80,13 @@ async fn main() -> anyhow::Result<()> {
 
 Use `cargo run -- --data-dir=~/.pubky`.
 
+## Caching and Proxies
+
+Tenant-private responses must never be stored by shared caches. `/priv/...`
+responses and `/events-stream` use `Cache-Control: no-store` and vary on
+`pubky-host`, `Authorization`, and `Cookie`; `/pub/...` file validators keep
+their existing tenant-aware caching behavior.
+
 ## Signup Token
 
 If homeserver is set to require signup tokens, you can create a new signup token using the admin endpoint:

--- a/pubky-homeserver/openapi.yml
+++ b/pubky-homeserver/openapi.yml
@@ -448,13 +448,19 @@ paths:
               schema:
                 type: string
             Cache-Control:
+              description: |
+                `/pub/...` files use `private, must-revalidate`; `/priv/...`
+                files and private directory listings use `no-store`.
               schema:
                 type: string
-                example: private, must-revalidate
+                example: no-store
             Vary:
+              description: |
+                `/pub/...` files vary by `pubky-host`; authentication-dependent
+                `/priv/...` responses vary by `pubky-host, Authorization, Cookie`.
               schema:
                 type: string
-                example: pubky-host
+                example: pubky-host, Authorization, Cookie
           content:
             application/octet-stream:
               schema:
@@ -479,15 +485,30 @@ paths:
               schema:
                 type: string
             Cache-Control:
+              description: |
+                `private, must-revalidate` for `/pub/...`; `no-store` for `/priv/...`.
               schema:
                 type: string
             Vary:
+              description: |
+                `pubky-host` for `/pub/...`; `pubky-host, Authorization, Cookie` for `/priv/...`.
               schema:
                 type: string
         "400":
           description: Invalid cursor
         "404":
           description: File or directory not found, or tenant (user) does not exist
+          headers:
+            Cache-Control:
+              description: Present as `no-store` for private-path errors.
+              schema:
+                type: string
+                example: no-store
+            Vary:
+              description: Present as full auth vary for private-path errors.
+              schema:
+                type: string
+                example: pubky-host, Authorization, Cookie
 
     head:
       tags: [Data]
@@ -513,6 +534,7 @@ paths:
             Cache-Control:
               schema:
                 type: string
+                example: no-store
             Vary:
               schema:
                 type: string
@@ -711,6 +733,15 @@ paths:
       responses:
         "200":
           description: SSE event stream
+          headers:
+            Cache-Control:
+              schema:
+                type: string
+                example: no-store
+            Vary:
+              schema:
+                type: string
+                example: pubky-host, Authorization, Cookie
           content:
             text/event-stream:
               schema:

--- a/pubky-homeserver/src/client_server/app.rs
+++ b/pubky-homeserver/src/client_server/app.rs
@@ -14,7 +14,7 @@ use std::net::TcpListener;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use axum::{routing::get, Router};
+use axum::{middleware as axum_middleware, routing::get, Router};
 use axum_server::{
     tls_rustls::{RustlsAcceptor, RustlsConfig},
     Handle,
@@ -25,6 +25,7 @@ use tower_cookies::CookieManagerLayer;
 use tower_http::cors::CorsLayer;
 
 use super::auth::{self, AuthenticationLayer};
+use super::cache_policy;
 use super::middleware::{
     pubky_host::PubkyHostLayer,
     rate_limiter::{BandwidthQuotaLimitLayer, RequestRateLimitLayer},
@@ -210,7 +211,11 @@ fn base() -> Router<AppState> {
         .route("/signup_tokens/{token}", get(signup_tokens::get))
         // Events
         .route("/events/", get(events::feed))
-        .route("/events-stream", get(events::feed_stream))
+        .route(
+            "/events-stream",
+            get(events::feed_stream)
+                .layer(axum_middleware::from_fn(cache_policy::sse_cache_policy)),
+        )
 
     // TODO: add size limit
     // TODO: revisit if we enable streaming big payloads

--- a/pubky-homeserver/src/client_server/cache_policy.rs
+++ b/pubky-homeserver/src/client_server/cache_policy.rs
@@ -1,0 +1,233 @@
+use axum::{
+    extract::Request,
+    http::{header, HeaderValue},
+    middleware::Next,
+    response::Response,
+};
+use percent_encoding::percent_decode_str;
+use pubky_common::storage;
+
+use crate::shared::webdav::WebDavPath;
+
+pub(crate) const CACHE_CONTROL_NO_STORE: &str = "no-store";
+pub(crate) const VARY_PRIVATE: &str = "pubky-host, Authorization, Cookie";
+
+pub(crate) async fn private_cache_policy(request: Request, next: Next) -> Response {
+    let is_private = is_private_tenant_request_path(request.uri().path());
+    let mut response = next.run(request).await;
+
+    if is_private {
+        apply_private_cache_headers(&mut response);
+        if response.status().as_u16() >= 400 {
+            remove_validators(&mut response);
+        }
+    }
+
+    response
+}
+
+pub(crate) async fn sse_cache_policy(request: Request, next: Next) -> Response {
+    let mut response = next.run(request).await;
+    apply_private_cache_headers(&mut response);
+    response
+}
+
+fn apply_private_cache_headers(response: &mut Response) {
+    let headers = response.headers_mut();
+    headers.insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static(CACHE_CONTROL_NO_STORE),
+    );
+    headers.insert(header::VARY, HeaderValue::from_static(VARY_PRIVATE));
+}
+
+fn remove_validators(response: &mut Response) {
+    let headers = response.headers_mut();
+    headers.remove(header::ETAG);
+    headers.remove(header::LAST_MODIFIED);
+}
+
+fn is_private_tenant_request_path(raw_path: &str) -> bool {
+    if storage::is_private_path(raw_path) {
+        return true;
+    }
+
+    let decoded = percent_decode_str(raw_path)
+        .decode_utf8()
+        .map(|path| path.into_owned())
+        .unwrap_or_else(|_| raw_path.to_string());
+
+    if storage::is_private_path(&decoded) {
+        return true;
+    }
+
+    WebDavPath::new(&decoded)
+        .map(|path| storage::is_private_path(path.as_str()))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{header, HeaderMap, Response, StatusCode},
+        middleware,
+        response::IntoResponse,
+        routing::{get, post},
+        Router,
+    };
+    use axum_test::TestServer;
+
+    use super::*;
+
+    fn header_value(headers: &HeaderMap, name: header::HeaderName) -> Option<&str> {
+        headers.get(name).and_then(|value| value.to_str().ok())
+    }
+
+    fn response_with_private_file_headers(status: StatusCode) -> Response<Body> {
+        Response::builder()
+            .status(status)
+            .header(header::CACHE_CONTROL, "private, must-revalidate")
+            .header(header::VARY, "pubky-host")
+            .header(header::ETAG, "\"hash\"")
+            .header(header::LAST_MODIFIED, "Wed, 21 Oct 2015 07:28:00 GMT")
+            .body(Body::empty())
+            .unwrap()
+    }
+
+    async fn success() -> impl IntoResponse {
+        response_with_private_file_headers(StatusCode::OK)
+    }
+
+    async fn missing() -> impl IntoResponse {
+        response_with_private_file_headers(StatusCode::NOT_FOUND)
+    }
+
+    #[test]
+    fn tenant_private_path_detection_uses_normalized_path() {
+        assert!(is_private_tenant_request_path("/priv/secret.txt"));
+        assert!(is_private_tenant_request_path("/pub/../priv/secret.txt"));
+        assert!(is_private_tenant_request_path(
+            "/pub/%2e%2e/priv/secret.txt"
+        ));
+        assert!(is_private_tenant_request_path("/priv/%00"));
+
+        assert!(!is_private_tenant_request_path("/pub/file.txt"));
+        assert!(!is_private_tenant_request_path("/priv"));
+        assert!(!is_private_tenant_request_path("/privstuff/file.txt"));
+        assert!(!is_private_tenant_request_path("/../../priv/secret.txt"));
+    }
+
+    #[tokio::test]
+    async fn private_cache_policy_rewrites_private_success_headers() {
+        let server = TestServer::new(
+            Router::new()
+                .route("/{*path}", get(success))
+                .layer(middleware::from_fn(private_cache_policy)),
+        )
+        .unwrap();
+
+        let response = server.get("/priv/secret.txt").await;
+
+        assert_eq!(
+            header_value(response.headers(), header::CACHE_CONTROL),
+            Some("no-store")
+        );
+        assert_eq!(
+            header_value(response.headers(), header::VARY),
+            Some("pubky-host, Authorization, Cookie")
+        );
+        assert!(response.headers().contains_key(header::ETAG));
+        assert!(response.headers().contains_key(header::LAST_MODIFIED));
+    }
+
+    #[tokio::test]
+    async fn private_cache_policy_rewrites_normalized_private_paths() {
+        let server = TestServer::new(
+            Router::new()
+                .route("/{*path}", get(success))
+                .layer(middleware::from_fn(private_cache_policy)),
+        )
+        .unwrap();
+
+        let response = server.get("/pub/../priv/secret.txt").await;
+
+        assert_eq!(
+            header_value(response.headers(), header::CACHE_CONTROL),
+            Some("no-store")
+        );
+        assert_eq!(
+            header_value(response.headers(), header::VARY),
+            Some("pubky-host, Authorization, Cookie")
+        );
+    }
+
+    #[tokio::test]
+    async fn private_cache_policy_strips_error_validators() {
+        let server = TestServer::new(
+            Router::new()
+                .route("/{*path}", post(missing))
+                .layer(middleware::from_fn(private_cache_policy)),
+        )
+        .unwrap();
+
+        let response = server.post("/priv/missing.txt").await;
+
+        response.assert_status(StatusCode::NOT_FOUND);
+        assert_eq!(
+            header_value(response.headers(), header::CACHE_CONTROL),
+            Some("no-store")
+        );
+        assert_eq!(
+            header_value(response.headers(), header::VARY),
+            Some("pubky-host, Authorization, Cookie")
+        );
+        assert!(!response.headers().contains_key(header::ETAG));
+        assert!(!response.headers().contains_key(header::LAST_MODIFIED));
+    }
+
+    #[tokio::test]
+    async fn private_cache_policy_leaves_public_responses_unchanged() {
+        let server = TestServer::new(
+            Router::new()
+                .route("/{*path}", get(success))
+                .layer(middleware::from_fn(private_cache_policy)),
+        )
+        .unwrap();
+
+        let response = server.get("/pub/file.txt").await;
+
+        assert_eq!(
+            header_value(response.headers(), header::CACHE_CONTROL),
+            Some("private, must-revalidate")
+        );
+        assert_eq!(
+            header_value(response.headers(), header::VARY),
+            Some("pubky-host")
+        );
+    }
+
+    #[tokio::test]
+    async fn sse_cache_policy_stamps_success_and_error_responses() {
+        let server = TestServer::new(
+            Router::new()
+                .route("/events-stream", get(success).post(missing))
+                .layer(middleware::from_fn(sse_cache_policy)),
+        )
+        .unwrap();
+
+        for response in [
+            server.get("/events-stream").await,
+            server.post("/events-stream").await,
+        ] {
+            assert_eq!(
+                header_value(response.headers(), header::CACHE_CONTROL),
+                Some("no-store")
+            );
+            assert_eq!(
+                header_value(response.headers(), header::VARY),
+                Some("pubky-host, Authorization, Cookie")
+            );
+        }
+    }
+}

--- a/pubky-homeserver/src/client_server/cache_policy.rs
+++ b/pubky-homeserver/src/client_server/cache_policy.rs
@@ -9,8 +9,9 @@ use pubky_common::storage;
 
 use crate::shared::webdav::WebDavPath;
 
-pub(crate) const CACHE_CONTROL_NO_STORE: &str = "no-store";
-pub(crate) const VARY_PRIVATE: &str = "pubky-host, Authorization, Cookie";
+pub(crate) const CACHE_CONTROL_NO_STORE: HeaderValue = HeaderValue::from_static("no-store");
+pub(crate) const VARY_PRIVATE: HeaderValue =
+    HeaderValue::from_static("pubky-host, Authorization, Cookie");
 
 pub(crate) async fn private_cache_policy(request: Request, next: Next) -> Response {
     let is_private = is_private_tenant_request_path(request.uri().path());
@@ -34,11 +35,8 @@ pub(crate) async fn sse_cache_policy(request: Request, next: Next) -> Response {
 
 fn apply_private_cache_headers(response: &mut Response) {
     let headers = response.headers_mut();
-    headers.insert(
-        header::CACHE_CONTROL,
-        HeaderValue::from_static(CACHE_CONTROL_NO_STORE),
-    );
-    headers.insert(header::VARY, HeaderValue::from_static(VARY_PRIVATE));
+    headers.insert(header::CACHE_CONTROL, CACHE_CONTROL_NO_STORE);
+    headers.insert(header::VARY, VARY_PRIVATE);
 }
 
 fn remove_validators(response: &mut Response) {

--- a/pubky-homeserver/src/client_server/mod.rs
+++ b/pubky-homeserver/src/client_server/mod.rs
@@ -7,6 +7,7 @@
 mod app;
 pub(crate) mod app_state;
 pub(crate) mod auth;
+pub(crate) mod cache_policy;
 mod middleware;
 mod query_params;
 pub(crate) mod routes;

--- a/pubky-homeserver/src/client_server/routes/tenants/mod.rs
+++ b/pubky-homeserver/src/client_server/routes/tenants/mod.rs
@@ -9,9 +9,9 @@
 //! read handlers call [`crate::client_server::auth::has_read_permission`] to
 //! enforce capability-based access control.
 
-use axum::{extract::DefaultBodyLimit, routing::get, Router};
+use axum::{extract::DefaultBodyLimit, middleware, routing::get, Router};
 
-use crate::client_server::AppState;
+use crate::client_server::{cache_policy::private_cache_policy, AppState};
 
 pub mod read;
 pub mod write;
@@ -30,4 +30,5 @@ pub fn router() -> Router<AppState> {
         )
         // TODO: different max size for sessions and other routes?
         .layer(DefaultBodyLimit::max(100 * 1024 * 1024))
+        .layer(middleware::from_fn(private_cache_policy))
 }

--- a/pubky-homeserver/src/client_server/routes/tenants/read.rs
+++ b/pubky-homeserver/src/client_server/routes/tenants/read.rs
@@ -241,7 +241,7 @@ impl EntryEntity {
 
 #[cfg(test)]
 mod tests {
-    use axum::http::{header, Method, StatusCode};
+    use axum::http::{header, HeaderMap, Method, StatusCode};
     use axum::Router;
     use axum_test::TestServer;
     use pubky_common::{
@@ -253,11 +253,12 @@ mod tests {
     use crate::app_context::AppContext;
     use crate::client_server::ClientServer;
 
-    pub async fn create_root_user(
+    async fn create_user_with_capabilities(
         server: &axum_test::TestServer,
         keypair: &Keypair,
+        capabilities: Vec<Capability>,
     ) -> anyhow::Result<String> {
-        let auth_token = AuthToken::sign(keypair, vec![Capability::root()]);
+        let auth_token = AuthToken::sign(keypair, capabilities);
         let body_bytes: axum::body::Bytes = auth_token.serialize().into();
         let response = server
             .post("/signup")
@@ -276,20 +277,78 @@ mod tests {
         Ok(header_value)
     }
 
-    pub async fn create_environment(
-    ) -> anyhow::Result<(AppContext, Router, TestServer, PublicKey, String)> {
+    pub async fn create_root_user(
+        server: &axum_test::TestServer,
+        keypair: &Keypair,
+    ) -> anyhow::Result<String> {
+        create_user_with_capabilities(server, keypair, vec![Capability::root()]).await
+    }
+
+    async fn sign_in_with_capabilities(
+        server: &axum_test::TestServer,
+        keypair: &Keypair,
+        capabilities: Vec<Capability>,
+    ) -> anyhow::Result<String> {
+        let auth_token = AuthToken::sign(keypair, capabilities);
+        let body_bytes: axum::body::Bytes = auth_token.serialize().into();
+        let response = server
+            .post("/session")
+            .add_header("host", keypair.public_key().to_z32())
+            .bytes(body_bytes)
+            .expect_success()
+            .await;
+
+        Ok(response
+            .headers()
+            .get(header::SET_COOKIE)
+            .and_then(|h| h.to_str().ok())
+            .expect("should return a set-cookie header")
+            .to_string())
+    }
+
+    async fn create_environment_with_keypair(
+    ) -> anyhow::Result<(AppContext, Router, TestServer, Keypair, String)> {
         let context = AppContext::test().await;
         let router = ClientServer::create_router(&context)?;
         let server = axum_test::TestServer::new(router.clone()).unwrap();
 
         let keypair = Keypair::random();
+        let cookie = create_root_user(&server, &keypair).await?.to_string();
+
+        Ok((context, router, server, keypair, cookie))
+    }
+
+    pub async fn create_environment(
+    ) -> anyhow::Result<(AppContext, Router, TestServer, PublicKey, String)> {
+        let (context, router, server, keypair, cookie) = create_environment_with_keypair().await?;
         let public_key = keypair.public_key();
-        let cookie = create_root_user(&server, &keypair)
-            .await
-            .unwrap()
-            .to_string();
 
         Ok((context, router, server, public_key, cookie))
+    }
+
+    fn header_value(headers: &HeaderMap, name: header::HeaderName) -> Option<&str> {
+        headers.get(name).and_then(|value| value.to_str().ok())
+    }
+
+    fn assert_private_cache_policy(headers: &HeaderMap) {
+        assert_eq!(
+            header_value(headers, header::CACHE_CONTROL),
+            Some("no-store")
+        );
+        assert_eq!(
+            header_value(headers, header::VARY),
+            Some("pubky-host, Authorization, Cookie")
+        );
+    }
+
+    fn assert_no_validators(headers: &HeaderMap) {
+        assert!(!headers.contains_key(header::ETAG));
+        assert!(!headers.contains_key(header::LAST_MODIFIED));
+    }
+
+    fn assert_validators_present(headers: &HeaderMap) {
+        assert!(headers.contains_key(header::ETAG));
+        assert!(headers.contains_key(header::LAST_MODIFIED));
     }
 
     #[tokio::test]
@@ -655,5 +714,155 @@ mod tests {
             body.contains("/priv/app/b.txt"),
             "listing should include b.txt, got: {body}"
         );
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn priv_responses_use_no_store_and_auth_vary() {
+        let (_, _, server, keypair, cookie) = create_environment_with_keypair().await.unwrap();
+        let public_key = keypair.public_key();
+
+        server
+            .put("/priv/secret.txt")
+            .add_header("host", public_key.z32())
+            .add_header(header::COOKIE, cookie.clone())
+            .bytes(Vec::from("top secret").into())
+            .expect_success()
+            .await;
+        server
+            .put("/priv/app/a.txt")
+            .add_header("host", public_key.z32())
+            .add_header(header::COOKIE, cookie.clone())
+            .bytes(Vec::from("a").into())
+            .expect_success()
+            .await;
+
+        let ok = server
+            .get("/priv/secret.txt")
+            .add_header("host", public_key.z32())
+            .add_header(header::COOKIE, cookie.clone())
+            .expect_success()
+            .await;
+        assert_private_cache_policy(ok.headers());
+        assert_validators_present(ok.headers());
+
+        let not_modified = server
+            .get("/priv/secret.txt")
+            .add_header("host", public_key.z32())
+            .add_header(header::COOKIE, cookie.clone())
+            .add_header(
+                header::IF_NONE_MATCH,
+                ok.headers().get(header::ETAG).unwrap(),
+            )
+            .await;
+        not_modified.assert_status(StatusCode::NOT_MODIFIED);
+        assert_private_cache_policy(not_modified.headers());
+        assert_validators_present(not_modified.headers());
+
+        let head = server
+            .method(Method::HEAD, "/priv/secret.txt")
+            .add_header("host", public_key.z32())
+            .add_header(header::COOKIE, cookie.clone())
+            .await;
+        head.assert_status(StatusCode::OK);
+        assert_private_cache_policy(head.headers());
+        assert_validators_present(head.headers());
+
+        let listing = server
+            .get("/priv/app/")
+            .add_header("host", public_key.z32())
+            .add_header(header::COOKIE, cookie.clone())
+            .expect_success()
+            .await;
+        assert_private_cache_policy(listing.headers());
+
+        let unauthorized = server
+            .get("/priv/secret.txt")
+            .add_header("host", public_key.z32())
+            .await;
+        unauthorized.assert_status(StatusCode::UNAUTHORIZED);
+        assert_private_cache_policy(unauthorized.headers());
+        assert_no_validators(unauthorized.headers());
+
+        let write_only_cookie =
+            sign_in_with_capabilities(&server, &keypair, vec![Capability::write("/priv/")])
+                .await
+                .unwrap();
+        let forbidden = server
+            .get("/priv/secret.txt")
+            .add_header("host", public_key.z32())
+            .add_header(header::COOKIE, write_only_cookie)
+            .await;
+        forbidden.assert_status(StatusCode::FORBIDDEN);
+        assert_private_cache_policy(forbidden.headers());
+        assert_no_validators(forbidden.headers());
+
+        let missing = server
+            .get("/priv/missing.txt")
+            .add_header("host", public_key.z32())
+            .add_header(header::COOKIE, cookie)
+            .await;
+        missing.assert_status(StatusCode::NOT_FOUND);
+        assert_private_cache_policy(missing.headers());
+        assert_no_validators(missing.headers());
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn pub_headers_are_unchanged_by_private_cache_policy() {
+        let (_, _, server, public_key, cookie) = create_environment().await.unwrap();
+
+        server
+            .put("/pub/file.txt")
+            .add_header("host", public_key.z32())
+            .add_header(header::COOKIE, cookie.clone())
+            .bytes(Vec::from("public").into())
+            .expect_success()
+            .await;
+        server
+            .put("/pub/app/a.txt")
+            .add_header("host", public_key.z32())
+            .add_header(header::COOKIE, cookie)
+            .bytes(Vec::from("a").into())
+            .expect_success()
+            .await;
+
+        let ok = server
+            .get("/pub/file.txt")
+            .add_header("host", public_key.z32())
+            .expect_success()
+            .await;
+        assert_eq!(
+            header_value(ok.headers(), header::CACHE_CONTROL),
+            Some("private, must-revalidate")
+        );
+        assert_eq!(header_value(ok.headers(), header::VARY), Some("pubky-host"));
+        assert_validators_present(ok.headers());
+
+        let not_modified = server
+            .get("/pub/file.txt")
+            .add_header("host", public_key.z32())
+            .add_header(
+                header::IF_NONE_MATCH,
+                ok.headers().get(header::ETAG).unwrap(),
+            )
+            .await;
+        not_modified.assert_status(StatusCode::NOT_MODIFIED);
+        assert_eq!(
+            header_value(not_modified.headers(), header::CACHE_CONTROL),
+            Some("private, must-revalidate")
+        );
+        assert_eq!(
+            header_value(not_modified.headers(), header::VARY),
+            Some("pubky-host")
+        );
+        assert_validators_present(not_modified.headers());
+
+        let listing = server
+            .get("/pub/app/")
+            .add_header("host", public_key.z32())
+            .expect_success()
+            .await;
+        assert!(header_value(listing.headers(), header::CACHE_CONTROL).is_none());
     }
 }


### PR DESCRIPTION
Closes #435.

### Summary

Centralizes cache policy for private tenant responses and event streams.

This adds response-mapping middleware instead of threading cache headers through individual error sites:
- `/priv/...` tenant responses get `Cache-Control: no-store` and `Vary: pubky-host, Authorization, Cookie`.
- Private-path error responses strip `ETag` and `Last-Modified`.
- `/events-stream` is unconditionally `no-store` with the full auth `Vary`.
- `/pub/...` file caching stays unchanged, and public listings are not given the private policy.
- Updates OpenAPI and the homeserver README with the private no-store invariant.