### PR TITLE
chore: bind testnet `HttpRelay` to all addresses

### DIFF
--- a/pubky-testnet/src/static_testnet.rs
+++ b/pubky-testnet/src/static_testnet.rs
@@ -330,6 +330,7 @@ impl StaticTestnet {
     /// Creates a fixed http relay.
     async fn run_fixed_http_relay(&mut self) -> anyhow::Result<()> {
         let relay = HttpRelay::builder()
+            .bind_address(BIND_ALL)
             .http_port(testnet_ports::HTTP_RELAY)
             .cors_allow_all(true)
             .run()


### PR DESCRIPTION
For testnet setups, it is useful to bind the local services to all available interfaces.

This is especially so for `pubky-docker`, where the services are exposed to the developer through a Docker bridge. In that situation, the HTTP Relay (bound to `127.0.0.1` by default) was not reachable from the Docker host:

```
Docker host:
127.0.0.1:15412
        |
        | Docker DNAT / proxy
        v
Container:
172.18.0.4:15412      <-- no listener here

Container:
127.0.0.1:15412       <-- relay is listening here instead
```

This PR addresses this, binding the HTTP Relay to all available interfaces.