### PR TITLE
refactor(homeserver): restructure PKARR republishing

### DIFF
--- a/pubky-homeserver/src/republishers/pkarr_republisher/batch_republisher.rs
+++ b/pubky-homeserver/src/republishers/pkarr_republisher/batch_republisher.rs
@@ -1,6 +1,6 @@
 use super::republish_summary::{RepublishResult, RepublishSummary};
-use super::republisher::{Republisher, RepublisherSettings};
-use super::retrying_republisher::RetryingRepublisher;
+use super::republisher::{RepublishOutcome, Republisher, RepublisherSettings};
+use super::retrying_republisher::{RetrySettings, RetryingRepublisher};
 use futures_util::{stream::FuturesUnordered, TryStreamExt};
 use pkarr::{ClientBuilder, PublicKey};
 use std::{num::NonZeroUsize, sync::Mutex};
@@ -16,23 +16,41 @@ pub enum BatchRepublisherError {
     BuildError(#[from] pkarr::errors::BuildError),
 }
 
+/// Settings for republishing a batch of keys.
+#[derive(Debug, Clone)]
+pub struct BatchRepublisherSettings {
+    republisher: RepublisherSettings,
+    retry: RetrySettings,
+    max_concurrent_workers: NonZeroUsize,
+}
+
+impl Default for BatchRepublisherSettings {
+    fn default() -> Self {
+        Self {
+            republisher: RepublisherSettings::default(),
+            retry: RetrySettings::default(),
+            max_concurrent_workers: NonZeroUsize::new(12).expect("worker count should be non-zero"),
+        }
+    }
+}
+
 /// Republish multiple keys serially or concurrently.
 #[derive(Debug, Clone, Default)]
 pub struct BatchRepublisher {
-    settings: RepublisherSettings,
+    settings: BatchRepublisherSettings,
     client_builder: ClientBuilder,
 }
 
 impl BatchRepublisher {
-    /// Create a new republisher with the settings.
-    pub fn new(settings: RepublisherSettings, client_builder: ClientBuilder) -> Self {
+    /// Create a batch republisher with the provided settings.
+    pub fn new(settings: BatchRepublisherSettings, client_builder: ClientBuilder) -> Self {
         Self {
             settings,
             client_builder,
         }
     }
 
-    /// Republish keys concurrently with at most `max_concurrent_workers` active clients.
+    /// Republish keys concurrently with at most the configured number of active clients.
     ///
     /// # Errors
     ///
@@ -40,9 +58,12 @@ impl BatchRepublisher {
     pub async fn run(
         &self,
         public_keys: Vec<PublicKey>,
-        max_concurrent_workers: NonZeroUsize,
     ) -> Result<RepublishSummary, BatchRepublisherError> {
-        let worker_count = max_concurrent_workers.get().min(public_keys.len());
+        let worker_count = self
+            .settings
+            .max_concurrent_workers
+            .get()
+            .min(public_keys.len());
         let public_keys = Mutex::new(public_keys);
 
         (0..worker_count)
@@ -60,8 +81,8 @@ impl BatchRepublisher {
         if client.dht().is_none() {
             return Err(BatchRepublisherError::DhtNotEnabled);
         }
-        let republisher = Republisher::new_with_settings(client, self.settings.clone());
-        let republisher = RetryingRepublisher::new(republisher, &self.settings.retry_settings);
+        let republisher = Republisher::new(client, self.settings.republisher.clone());
+        let republisher = RetryingRepublisher::new(republisher, &self.settings.retry);
 
         let mut summary = RepublishSummary::default();
         while let Some(public_key) = pop(public_keys) {
@@ -80,14 +101,13 @@ async fn republish_key(
     let elapsed = start.elapsed().as_millis();
 
     match &result {
-        Ok(info) => tracing::info!(
-            "Republished {public_key} successfully on {} nodes within {elapsed}ms. attempts={}",
-            info.published_nodes_count,
-            info.attempts_needed
-        ),
-        Err(error) => tracing::warn!(
-            "Failed to republish public_key {public_key} within {elapsed}ms. {error}"
-        ),
+        Ok(info) => match info.outcome {
+            RepublishOutcome::Published(_) => {
+                tracing::info!(%public_key, ?info, %elapsed, "Republished successfully")
+            }
+            _ => tracing::debug!(%public_key, ?info, %elapsed, "Did not republish"),
+        },
+        Err(error) => tracing::warn!(%public_key, %error, %elapsed, "Republishing failed"),
     }
     result
 }
@@ -112,8 +132,9 @@ mod tests {
 
     use pkarr::{dns::Name, Keypair, PublicKey};
 
-    use super::{BatchRepublisher, RepublishSummary};
-    use crate::republishers::pkarr_republisher::republisher::RepublisherSettings;
+    use super::{
+        BatchRepublisher, BatchRepublisherSettings, RepublishSummary, RepublisherSettings,
+    };
 
     async fn publish_sample_packets(client: &pkarr::Client, count: usize) -> Vec<PublicKey> {
         let keys: Vec<Keypair> = (0..count).map(|_| Keypair::random()).collect();
@@ -145,11 +166,17 @@ mod tests {
         let pkarr_client = pkarr_builder.clone().build().unwrap();
         let public_keys = publish_sample_packets(&pkarr_client, key_count).await;
 
-        let mut settings = RepublisherSettings::default();
-        settings.min_sufficient_node_publish_count(min_sufficient_node_publish_count);
+        let settings = BatchRepublisherSettings {
+            republisher: RepublisherSettings {
+                min_sufficient_node_publish_count,
+                ..RepublisherSettings::default()
+            },
+            max_concurrent_workers,
+            ..BatchRepublisherSettings::default()
+        };
 
         BatchRepublisher::new(settings, pkarr_builder)
-            .run(public_keys, max_concurrent_workers)
+            .run(public_keys)
             .await
             .unwrap()
     }
@@ -173,7 +200,7 @@ mod tests {
         let summary = republish_single_key(NonZeroU8::new(4).unwrap()).await;
 
         assert_eq!(summary.len(), 1);
-        assert_eq!(summary.publishing_failed_count(), 1);
+        assert_eq!(summary.failed_count(), 1);
     }
 
     #[tokio::test]
@@ -183,10 +210,16 @@ mod tests {
 
         assert_eq!(summary.len(), 5);
         assert_eq!(summary.success_count(), 5);
-        assert_eq!(summary.publishing_failed_count(), 0);
+        assert_eq!(summary.failed_count(), 0);
         assert_eq!(summary.missing_count(), 0);
+        assert_eq!(summary.skipped_count(), 0);
+        assert_eq!(summary.invalid_signed_packet_count(), 0);
         assert_eq!(
-            summary.success_count() + summary.publishing_failed_count() + summary.missing_count(),
+            summary.success_count()
+                + summary.skipped_count()
+                + summary.failed_count()
+                + summary.missing_count()
+                + summary.invalid_signed_packet_count(),
             summary.len()
         );
     }

--- a/pubky-homeserver/src/republishers/pkarr_republisher/mod.rs
+++ b/pubky-homeserver/src/republishers/pkarr_republisher/mod.rs
@@ -5,6 +5,5 @@ mod republisher;
 mod retrying_republisher;
 mod verify;
 
-pub use batch_republisher::{BatchRepublisher, BatchRepublisherError};
+pub use batch_republisher::{BatchRepublisher, BatchRepublisherError, BatchRepublisherSettings};
 pub use republish_summary::RepublishSummary;
-pub use republisher::RepublisherSettings;

--- a/pubky-homeserver/src/republishers/pkarr_republisher/republish_summary.rs
+++ b/pubky-homeserver/src/republishers/pkarr_republisher/republish_summary.rs
@@ -1,13 +1,17 @@
-use super::{republisher::RepublishError, retrying_republisher::RepublishInfo};
+use super::{
+    publisher::PublishError, republisher::RepublishOutcome, retrying_republisher::RepublishInfo,
+};
 
-pub(super) type RepublishResult = Result<RepublishInfo, RepublishError>;
+pub(super) type RepublishResult = Result<RepublishInfo, PublishError>;
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct RepublishSummary {
     total_count: usize,
     success_count: usize,
-    publishing_failed_count: usize,
+    skipped_count: usize,
     missing_count: usize,
+    invalid_signed_packet_count: usize,
+    failed_count: usize,
 }
 
 impl RepublishSummary {
@@ -15,27 +19,51 @@ impl RepublishSummary {
         self.total_count += 1;
 
         match result {
-            Ok(_) => self.success_count += 1,
-            Err(RepublishError::PublishFailed(_)) => self.publishing_failed_count += 1,
-            Err(RepublishError::Missing) => self.missing_count += 1,
+            Ok(RepublishInfo {
+                outcome: RepublishOutcome::Published(_),
+                ..
+            }) => self.success_count += 1,
+            Ok(RepublishInfo {
+                outcome: RepublishOutcome::Skipped,
+                ..
+            }) => self.skipped_count += 1,
+            Ok(RepublishInfo {
+                outcome: RepublishOutcome::Missing,
+                ..
+            }) => self.missing_count += 1,
+            Ok(RepublishInfo {
+                outcome: RepublishOutcome::InvalidSignedPacket,
+                ..
+            }) => self.invalid_signed_packet_count += 1,
+            Err(_) => self.failed_count += 1,
         }
     }
 
     pub(crate) fn merge(mut self, other: Self) -> Self {
         self.total_count += other.total_count;
         self.success_count += other.success_count;
-        self.publishing_failed_count += other.publishing_failed_count;
+        self.skipped_count += other.skipped_count;
         self.missing_count += other.missing_count;
+        self.invalid_signed_packet_count += other.invalid_signed_packet_count;
+        self.failed_count += other.failed_count;
         self
-    }
-
-    /// Number of republish attempts.
-    pub fn len(&self) -> usize {
-        self.total_count
     }
 
     pub fn is_empty(&self) -> bool {
         self.total_count == 0
+    }
+
+    /// Whether any key was missing, invalid, or failed to publish.
+    pub fn has_issues(&self) -> bool {
+        self.missing_count > 0 || self.invalid_signed_packet_count > 0 || self.failed_count > 0
+    }
+}
+
+#[cfg(test)]
+impl RepublishSummary {
+    /// Number of republish attempts.
+    pub fn len(&self) -> usize {
+        self.total_count
     }
 
     /// Number of successfully published keys.
@@ -43,40 +71,56 @@ impl RepublishSummary {
         self.success_count
     }
 
-    /// Number of keys that failed to publish.
-    pub fn publishing_failed_count(&self) -> usize {
-        self.publishing_failed_count
+    /// Number of keys that did not satisfy the republish condition.
+    pub fn skipped_count(&self) -> usize {
+        self.skipped_count
     }
 
     /// Number of keys that are missing and could not be republished.
     pub fn missing_count(&self) -> usize {
         self.missing_count
     }
+
+    /// Number of resolved packets that were invalid.
+    pub fn invalid_signed_packet_count(&self) -> usize {
+        self.invalid_signed_packet_count
+    }
+
+    /// Number of keys that failed to publish.
+    pub fn failed_count(&self) -> usize {
+        self.failed_count
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{RepublishError, RepublishInfo, RepublishSummary};
-    use crate::republishers::pkarr_republisher::publisher::PublishError;
+    use super::{PublishError, RepublishInfo, RepublishOutcome, RepublishSummary};
 
     #[test]
     fn records_and_merges_republish_outcomes() {
         let mut summary = RepublishSummary::default();
-        summary.record(Ok(RepublishInfo::new(3, 1)));
+        summary.record(Ok(RepublishInfo::new(RepublishOutcome::Published(3), 1)));
+        summary.record(Ok(RepublishInfo::new(RepublishOutcome::Skipped, 1)));
+        assert!(!summary.has_issues());
 
         let mut other = RepublishSummary::default();
-        other.record(Err(RepublishError::Missing));
-        other.record(Err(RepublishError::PublishFailed(
-            PublishError::InsufficientlyPublished {
-                published_nodes_count: 1,
-            },
+        other.record(Ok(RepublishInfo::new(RepublishOutcome::Missing, 1)));
+        other.record(Ok(RepublishInfo::new(
+            RepublishOutcome::InvalidSignedPacket,
+            1,
         )));
+        other.record(Err(PublishError::InsufficientlyPublished {
+            published_nodes_count: 1,
+        }));
 
         let summary = summary.merge(other);
 
-        assert_eq!(summary.len(), 3);
+        assert_eq!(summary.len(), 5);
         assert_eq!(summary.success_count(), 1);
+        assert_eq!(summary.skipped_count(), 1);
         assert_eq!(summary.missing_count(), 1);
-        assert_eq!(summary.publishing_failed_count(), 1);
+        assert_eq!(summary.invalid_signed_packet_count(), 1);
+        assert_eq!(summary.failed_count(), 1);
+        assert!(summary.has_issues());
     }
 }

--- a/pubky-homeserver/src/republishers/pkarr_republisher/republisher.rs
+++ b/pubky-homeserver/src/republishers/pkarr_republisher/republisher.rs
@@ -1,37 +1,26 @@
 //!
 //! Republishes a single public key.
 //!
-use pkarr::PublicKey;
-use pkarr::SignedPacket;
+use pkarr::{PublicKey, SignedPacket};
 use std::{num::NonZeroU8, sync::Arc};
 
 use super::publisher::{PublishError, Publisher, PublisherSettings};
-use super::retrying_republisher::RetrySettings;
 
-#[derive(thiserror::Error, Debug, Clone)]
-pub enum RepublishError {
-    #[error("The packet can't be resolved on the DHT and therefore can't be republished.")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum RepublishOutcome {
+    Published(usize),
+    Skipped,
     Missing,
-    #[error(transparent)]
-    PublishFailed(#[from] PublishError),
+    InvalidSignedPacket,
 }
 
-impl RepublishError {
-    pub(super) fn is_recoverable(&self) -> bool {
-        // TODO: We do not retry on Missing because in the next pkarr version it
-        // returns Missing when it is truly missing and not just an error.
-        matches!(self, Self::PublishFailed(_))
-    }
-}
-
-pub type RepublishCondition = dyn Fn(&SignedPacket) -> bool + Send + Sync;
+pub(super) type RepublishCondition = dyn Fn(&SignedPacket) -> bool + Send + Sync;
 
 /// Settings for creating a republisher
 #[derive(Clone)]
-pub struct RepublisherSettings {
-    pub(crate) min_sufficient_node_publish_count: NonZeroU8,
-    pub(super) retry_settings: RetrySettings,
-    pub(crate) republish_condition: Option<Arc<RepublishCondition>>,
+pub(super) struct RepublisherSettings {
+    pub(super) min_sufficient_node_publish_count: NonZeroU8,
+    pub(super) republish_condition: Option<Arc<RepublishCondition>>,
 }
 
 impl std::fmt::Debug for RepublisherSettings {
@@ -41,27 +30,11 @@ impl std::fmt::Debug for RepublisherSettings {
                 "min_sufficient_node_publish_count",
                 &self.min_sufficient_node_publish_count,
             )
-            .field("retry_settings", &self.retry_settings)
-            .finish_non_exhaustive()
-    }
-}
-
-#[cfg(test)]
-impl RepublisherSettings {
-    /// Set a closure that determines whether a packet should be republished
-    pub fn republish_condition<F>(&mut self, f: F) -> &mut Self
-    where
-        F: Fn(&SignedPacket) -> bool + Send + Sync + 'static,
-    {
-        self.republish_condition = Some(Arc::new(f));
-        self
-    }
-
-    /// Set the minimum sufficient number of nodes a key needs to be stored in
-    /// to be considered a success
-    pub fn min_sufficient_node_publish_count(&mut self, count: NonZeroU8) -> &mut Self {
-        self.min_sufficient_node_publish_count = count;
-        self
+            .field(
+                "has_republish_condition",
+                &self.republish_condition.is_some(),
+            )
+            .finish()
     }
 }
 
@@ -69,48 +42,42 @@ impl Default for RepublisherSettings {
     fn default() -> Self {
         Self {
             min_sufficient_node_publish_count: NonZeroU8::new(10).expect("Should always be > 0"),
-            retry_settings: RetrySettings::default(),
             republish_condition: None,
         }
     }
 }
 
 /// Tries to republish a single key once.
-#[derive(Clone)]
-pub struct Republisher {
+#[derive(Debug)]
+pub(super) struct Republisher {
     client: pkarr::Client,
     settings: RepublisherSettings,
 }
 
-impl std::fmt::Debug for Republisher {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Republisher")
-            .field("client", &self.client)
-            .field("settings", &self.settings)
-            .finish_non_exhaustive()
-    }
-}
-
 impl Republisher {
-    pub fn new_with_settings(client: pkarr::Client, settings: RepublisherSettings) -> Self {
+    pub(super) fn new(client: pkarr::Client, settings: RepublisherSettings) -> Self {
         Self { client, settings }
     }
 
     /// Republish a single public key.
-    pub async fn republish(&self, public_key: &PublicKey) -> Result<usize, RepublishError> {
-        let packet = self
-            .client
-            .resolve_most_recent(public_key)
-            .await
-            .ok_or(RepublishError::Missing)?;
+    pub(super) async fn republish(
+        &self,
+        public_key: &PublicKey,
+    ) -> Result<RepublishOutcome, PublishError> {
+        let Some(packet) = self.client.resolve_most_recent(public_key).await else {
+            return Ok(RepublishOutcome::Missing);
+        };
+        if packet.public_key() != *public_key {
+            return Ok(RepublishOutcome::InvalidSignedPacket);
+        }
 
-        if self
+        let should_republish = self
             .settings
             .republish_condition
             .as_ref()
-            .is_some_and(|condition| !condition(&packet))
-        {
-            return Ok(0);
+            .is_none_or(|condition| condition(&packet));
+        if !should_republish {
+            return Ok(RepublishOutcome::Skipped);
         }
 
         let mut settings = PublisherSettings::default();
@@ -120,18 +87,16 @@ impl Republisher {
         let publisher = Publisher::new_with_settings(packet, settings)
             .expect("infallible because pkarr client provided");
 
-        publisher.publish().await.map_err(Into::into)
+        publisher.publish().await.map(RepublishOutcome::Published)
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroU8;
+    use super::*;
+    use pkarr::{dns::Name, Keypair};
 
-    use super::{RepublishError, Republisher, RepublisherSettings};
-    use pkarr::{dns::Name, Keypair, PublicKey};
-
-    async fn publish_sample_packets(client: &pkarr::Client) -> PublicKey {
+    async fn publish_sample_packet(client: &pkarr::Client) -> PublicKey {
         let key = Keypair::random();
 
         let packet = pkarr::SignedPacketBuilder::default()
@@ -141,87 +106,111 @@ mod tests {
         client
             .publish(&packet, None)
             .await
-            .expect("to be published");
+            .expect("sample packet should publish");
 
         key.public_key()
     }
 
     #[tokio::test]
-    async fn single_key_republish_success() {
+    async fn republish_returns_published_for_resolved_packet() {
         let dht = pkarr::mainline::Testnet::builder(1).build().unwrap();
         let mut pkarr_builder = pkarr::ClientBuilder::default();
         pkarr_builder
             .no_default_network()
             .bootstrap(&dht.bootstrap)
             .no_relays();
-        let pkarr_client = pkarr_builder.clone().build().unwrap();
-        let public_key = publish_sample_packets(&pkarr_client).await;
+        let pkarr_client = pkarr_builder.build().unwrap();
+        let public_key = publish_sample_packet(&pkarr_client).await;
 
-        let required_nodes = 1;
-        let mut settings = RepublisherSettings::default();
-        settings.min_sufficient_node_publish_count(NonZeroU8::new(required_nodes).unwrap());
-        let publisher = Republisher::new_with_settings(pkarr_client, settings);
-        let res = publisher.republish(&public_key).await;
+        let settings = RepublisherSettings {
+            min_sufficient_node_publish_count: NonZeroU8::MIN,
+            ..RepublisherSettings::default()
+        };
+        let republisher = Republisher::new(pkarr_client, settings);
+        let outcome = republisher.republish(&public_key).await.unwrap();
 
-        assert_eq!(res.unwrap(), 1);
+        assert_eq!(outcome, RepublishOutcome::Published(1));
     }
 
     #[tokio::test]
-    async fn single_key_republish_missing() {
+    async fn republish_returns_missing_for_unknown_key() {
         let dht = pkarr::mainline::Testnet::builder(1).build().unwrap();
         let mut pkarr_builder = pkarr::ClientBuilder::default();
         pkarr_builder.bootstrap(&dht.bootstrap).no_relays();
-        let pkarr_client = pkarr_builder.clone().build().unwrap();
+        let pkarr_client = pkarr_builder.build().unwrap();
         let public_key = Keypair::random().public_key();
 
-        let required_nodes = 1;
-        let mut settings = RepublisherSettings::default();
-        settings.min_sufficient_node_publish_count(NonZeroU8::new(required_nodes).unwrap());
-        let publisher = Republisher::new_with_settings(pkarr_client, settings);
-        let res = publisher.republish(&public_key).await;
+        let settings = RepublisherSettings {
+            min_sufficient_node_publish_count: NonZeroU8::MIN,
+            ..RepublisherSettings::default()
+        };
+        let republisher = Republisher::new(pkarr_client, settings);
+        let outcome = republisher.republish(&public_key).await.unwrap();
 
-        assert!(matches!(res, Err(RepublishError::Missing)));
+        assert_eq!(outcome, RepublishOutcome::Missing);
     }
 
     #[tokio::test]
-    async fn republish_with_condition_fail() {
+    async fn republish_returns_skipped_when_condition_rejects_packet() {
         let dht = pkarr::mainline::Testnet::builder(1).build().unwrap();
         let mut pkarr_builder = pkarr::ClientBuilder::default();
         pkarr_builder.bootstrap(&dht.bootstrap).no_relays();
-        let pkarr_client = pkarr_builder.clone().build().unwrap();
-        let public_key = publish_sample_packets(&pkarr_client).await;
+        let pkarr_client = pkarr_builder.build().unwrap();
+        let public_key = publish_sample_packet(&pkarr_client).await;
 
-        let required_nodes = 1;
-        let mut settings = RepublisherSettings::default();
-        settings
-            .min_sufficient_node_publish_count(NonZeroU8::new(required_nodes).unwrap())
-            // Only republish if the packet has a TTL greater than 300
-            .republish_condition(|_| false);
+        let settings = RepublisherSettings {
+            min_sufficient_node_publish_count: NonZeroU8::MIN,
+            republish_condition: Some(Arc::new(|_| false)),
+        };
 
-        let publisher = Republisher::new_with_settings(pkarr_client, settings);
-        let res = publisher.republish(&public_key).await;
+        let republisher = Republisher::new(pkarr_client, settings);
+        let outcome = republisher.republish(&public_key).await.unwrap();
 
-        assert_eq!(res.unwrap(), 0);
+        assert_eq!(outcome, RepublishOutcome::Skipped);
     }
 
     #[tokio::test]
-    async fn republish_with_condition_success() {
+    async fn republish_returns_published_when_condition_accepts_packet() {
         let dht = pkarr::mainline::Testnet::builder(1).build().unwrap();
         let mut pkarr_builder = pkarr::ClientBuilder::default();
         pkarr_builder.bootstrap(&dht.bootstrap).no_relays();
-        let pkarr_client = pkarr_builder.clone().build().unwrap();
-        let public_key = publish_sample_packets(&pkarr_client).await;
+        let pkarr_client = pkarr_builder.build().unwrap();
+        let public_key = publish_sample_packet(&pkarr_client).await;
 
-        let required_nodes = 1;
-        let mut settings = RepublisherSettings::default();
-        settings
-            .min_sufficient_node_publish_count(NonZeroU8::new(required_nodes).unwrap())
-            // Only republish if the packet has a TTL greater than 300
-            .republish_condition(|_| true);
+        let settings = RepublisherSettings {
+            min_sufficient_node_publish_count: NonZeroU8::MIN,
+            republish_condition: Some(Arc::new(|_| true)),
+        };
 
-        let publisher = Republisher::new_with_settings(pkarr_client, settings);
-        let res = publisher.republish(&public_key).await;
+        let republisher = Republisher::new(pkarr_client, settings);
+        let outcome = republisher.republish(&public_key).await.unwrap();
 
-        assert_eq!(res.unwrap(), 1);
+        assert_eq!(outcome, RepublishOutcome::Published(1));
+    }
+
+    #[tokio::test]
+    async fn republish_returns_publish_error_when_insufficiently_published() {
+        let dht = pkarr::mainline::Testnet::builder(1).build().unwrap();
+        let mut pkarr_builder = pkarr::ClientBuilder::default();
+        pkarr_builder
+            .no_default_network()
+            .bootstrap(&dht.bootstrap)
+            .no_relays();
+        let pkarr_client = pkarr_builder.build().unwrap();
+        let public_key = publish_sample_packet(&pkarr_client).await;
+
+        let settings = RepublisherSettings {
+            min_sufficient_node_publish_count: NonZeroU8::new(2).unwrap(),
+            ..RepublisherSettings::default()
+        };
+        let republisher = Republisher::new(pkarr_client, settings);
+        let result = republisher.republish(&public_key).await;
+
+        assert!(matches!(
+            result,
+            Err(PublishError::InsufficientlyPublished {
+                published_nodes_count: 1
+            })
+        ));
     }
 }

--- a/pubky-homeserver/src/republishers/pkarr_republisher/retrying_republisher.rs
+++ b/pubky-homeserver/src/republishers/pkarr_republisher/retrying_republisher.rs
@@ -3,20 +3,24 @@ use std::{future::Future, num::NonZeroU8, time::Duration};
 use backon::{ExponentialBuilder, Retryable};
 use pkarr::PublicKey;
 
-use super::republisher::{RepublishError, Republisher};
+use super::{
+    publisher::PublishError,
+    republisher::{RepublishOutcome, Republisher},
+};
 
 #[derive(Debug, Clone)]
 pub(super) struct RepublishInfo {
-    /// How many nodes the key got published on.
-    pub(super) published_nodes_count: usize,
+    /// Result of the republish attempt.
+    pub(super) outcome: RepublishOutcome,
     /// Number of publishing attempts needed to successfully republish.
+    #[allow(dead_code)]
     pub(super) attempts_needed: usize,
 }
 
 impl RepublishInfo {
-    pub(super) fn new(published_nodes_count: usize, attempts_needed: usize) -> Self {
+    pub(super) fn new(outcome: RepublishOutcome, attempts_needed: usize) -> Self {
         Self {
-            published_nodes_count,
+            outcome,
             attempts_needed,
         }
     }
@@ -76,7 +80,7 @@ impl RetryingRepublisher {
     pub(super) async fn republish(
         &self,
         public_key: &PublicKey,
-    ) -> Result<RepublishInfo, RepublishError> {
+    ) -> Result<RepublishInfo, PublishError> {
         republish_with_retry(public_key, self.backoff, self.max_retry_delay, || {
             self.republisher.republish(public_key)
         })
@@ -89,16 +93,15 @@ async fn republish_with_retry<F, Fut>(
     backoff: ExponentialBuilder,
     max_retry_delay: Duration,
     republish: F,
-) -> Result<RepublishInfo, RepublishError>
+) -> Result<RepublishInfo, PublishError>
 where
     F: FnMut() -> Fut,
-    Fut: Future<Output = Result<usize, RepublishError>>,
+    Fut: Future<Output = Result<RepublishOutcome, PublishError>>,
 {
     let mut attempts_count = 1;
 
     republish
         .retry(backoff)
-        .when(RepublishError::is_recoverable)
         // BackON adds jitter after applying its maximum delay.
         .adjust(|_, delay| delay.map(|delay| delay.min(max_retry_delay)))
         .notify(|error, delay| {
@@ -112,7 +115,7 @@ where
             attempts_count += 1;
         })
         .await
-        .map(|published_nodes_count| RepublishInfo::new(published_nodes_count, attempts_count))
+        .map(|outcome| RepublishInfo::new(outcome, attempts_count))
 }
 
 #[cfg(test)]
@@ -122,8 +125,7 @@ mod tests {
     use backon::BackoffBuilder;
     use pkarr::Keypair;
 
-    use super::{republish_with_retry, RepublishError, RetrySettings};
-    use crate::republishers::pkarr_republisher::publisher::PublishError;
+    use super::{republish_with_retry, PublishError, RepublishOutcome, RetrySettings};
 
     fn retry_settings(max_attempts: u8) -> RetrySettings {
         RetrySettings {
@@ -133,10 +135,10 @@ mod tests {
         }
     }
 
-    fn recoverable_error() -> RepublishError {
-        RepublishError::PublishFailed(PublishError::InsufficientlyPublished {
+    fn publish_error() -> PublishError {
+        PublishError::InsufficientlyPublished {
             published_nodes_count: 0,
-        })
+        }
     }
 
     #[test]
@@ -172,7 +174,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn retries_recoverable_errors_until_success() {
+    async fn retries_publish_errors_until_success() {
         let public_key = Keypair::random().public_key();
         let settings = retry_settings(3);
         let attempts = Cell::new(0);
@@ -185,9 +187,9 @@ mod tests {
                 let attempt = attempts.get() + 1;
                 attempts.set(attempt);
                 ready(if attempt < 3 {
-                    Err(recoverable_error())
+                    Err(publish_error())
                 } else {
-                    Ok(7)
+                    Ok(RepublishOutcome::Published(7))
                 })
             },
         )
@@ -196,11 +198,11 @@ mod tests {
 
         assert_eq!(attempts.get(), 3);
         assert_eq!(info.attempts_needed, 3);
-        assert_eq!(info.published_nodes_count, 7);
+        assert_eq!(info.outcome, RepublishOutcome::Published(7));
     }
 
     #[tokio::test]
-    async fn stops_immediately_on_missing_packet() {
+    async fn returns_missing_outcome_without_retrying() {
         let public_key = Keypair::random().public_key();
         let settings = retry_settings(3);
         let attempts = Cell::new(0);
@@ -211,12 +213,14 @@ mod tests {
             settings.max_retry_delay,
             || {
                 attempts.set(attempts.get() + 1);
-                ready(Err(RepublishError::Missing))
+                ready(Ok(RepublishOutcome::Missing))
             },
         )
-        .await;
+        .await
+        .unwrap();
 
-        assert!(matches!(result, Err(RepublishError::Missing)));
+        assert_eq!(result.outcome, RepublishOutcome::Missing);
+        assert_eq!(result.attempts_needed, 1);
         assert_eq!(attempts.get(), 1);
     }
 
@@ -232,12 +236,15 @@ mod tests {
             settings.max_retry_delay,
             || {
                 attempts.set(attempts.get() + 1);
-                ready(Err(recoverable_error()))
+                ready(Err(publish_error()))
             },
         )
         .await;
 
-        assert!(matches!(result, Err(RepublishError::PublishFailed(_))));
+        assert!(matches!(
+            result,
+            Err(PublishError::InsufficientlyPublished { .. })
+        ));
         assert_eq!(attempts.get(), 3);
     }
 }

--- a/pubky-homeserver/src/republishers/user_keys_republisher.rs
+++ b/pubky-homeserver/src/republishers/user_keys_republisher.rs
@@ -1,7 +1,7 @@
-use std::{num::NonZeroUsize, time::Duration};
+use std::time::Duration;
 
 use super::pkarr_republisher::{
-    BatchRepublisher, BatchRepublisherError, RepublishSummary, RepublisherSettings,
+    BatchRepublisher, BatchRepublisherError, BatchRepublisherSettings, RepublishSummary,
 };
 use pubky_common::crypto::PublicKey;
 use tokio::{
@@ -96,7 +96,11 @@ impl UserKeysRepublisher {
             }
         };
         let elapsed = start.elapsed();
-        Self::log_republish_summary(&summary, elapsed);
+        if summary.has_issues() {
+            tracing::warn!(?summary, ?elapsed, "Processed user keys");
+        } else {
+            tracing::debug!(?summary, ?elapsed, "Processed user keys");
+        }
     }
 
     async fn republish_impl(&self) -> Result<RepublishSummary, UserKeysRepublisherError> {
@@ -105,36 +109,16 @@ impl UserKeysRepublisher {
             tracing::debug!("No user keys to republish.");
             return Ok(RepublishSummary::default());
         }
-        let settings = RepublisherSettings::default();
+        let settings = BatchRepublisherSettings::default();
         let republisher = BatchRepublisher::new(settings, self.pkarr_builder.clone());
         // TODO: Only publish if user points to this home server.
         let pkarr_keys = keys.into_iter().map(Into::into).collect();
-        let max_concurrent_workers =
-            NonZeroUsize::new(12).expect("worker count should be non-zero");
-        Ok(republisher.run(pkarr_keys, max_concurrent_workers).await?)
+        Ok(republisher.run(pkarr_keys).await?)
     }
 
     async fn get_all_user_keys(&self) -> Result<Vec<PublicKey>, sqlx::Error> {
         let users = UserRepository::get_all(&mut self.db.pool().into()).await?;
         Ok(users.into_iter().map(|user| user.public_key).collect())
-    }
-
-    fn log_republish_summary(summary: &RepublishSummary, elapsed: Duration) {
-        let total_count = summary.len();
-        let elapsed_secs = elapsed.as_secs_f32();
-        let success_count = summary.success_count();
-        let missing_count = summary.missing_count();
-        let failed_count = summary.publishing_failed_count();
-
-        if missing_count == 0 {
-            tracing::debug!(
-                "Republished {total_count} user keys within {elapsed_secs:.1}s. {success_count} success, {missing_count} missing, {failed_count} failed.",
-            );
-        } else {
-            tracing::warn!(
-                "Republished {total_count} user keys within {elapsed_secs:.1}s. {success_count} success, {missing_count} missing, {failed_count} failed.",
-            );
-        }
     }
 }
 
@@ -167,6 +151,6 @@ mod tests {
         assert_eq!(summary.len(), 10);
         assert_eq!(summary.success_count(), 0);
         assert_eq!(summary.missing_count(), 10);
-        assert_eq!(summary.publishing_failed_count(), 0);
+        assert_eq!(summary.failed_count(), 0);
     }
 }


### PR DESCRIPTION
Separate batch, retry, and single-key settings by ownership.
Return typed outcomes and summarize non-publish results explicitly.
Propagate PublishError directly through retry handling.
