### PR TITLE
ci: cache npm dependencies

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -225,10 +225,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
+          cache: npm
+          cache-dependency-path: pubky-sdk/bindings/js/pkg/package-lock.json
 
       - uses: taiki-e/install-action@v2
         with:
           tool: wasm-pack
+
+      - name: Install JS dependencies
+        working-directory: pubky-sdk/bindings/js/pkg
+        run: npm ci --prefer-offline --no-audit --no-fund
 
       - name: Cache
         uses: Swatinem/rust-cache@v2
@@ -264,7 +270,6 @@ jobs:
       - name: Build WASM
         working-directory: pubky-sdk/bindings/js/pkg
         run: |
-          npm install
           npm run build
 
       - name: Run the testnet

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -232,14 +232,6 @@ jobs:
         with:
           tool: wasm-pack
 
-      - name: Cache node_modules
-        uses: actions/cache@v4
-        with:
-          path: pubky-sdk/bindings/js/pkg/node_modules
-          key: node_modules-${{ runner.os }}-${{ hashFiles('pubky-sdk/bindings/js/pkg/package-lock.json') }}
-          restore-keys: |
-            node_modules-${{ runner.os }}-
-
       - name: Install JS dependencies
         working-directory: pubky-sdk/bindings/js/pkg
         run: npm ci --prefer-offline --no-audit --no-fund

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -232,6 +232,14 @@ jobs:
         with:
           tool: wasm-pack
 
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: pubky-sdk/bindings/js/pkg/node_modules
+          key: node_modules-${{ runner.os }}-${{ hashFiles('pubky-sdk/bindings/js/pkg/package-lock.json') }}
+          restore-keys: |
+            node_modules-${{ runner.os }}-
+
       - name: Install JS dependencies
         working-directory: pubky-sdk/bindings/js/pkg
         run: npm ci --prefer-offline --no-audit --no-fund


### PR DESCRIPTION
This PR partially addresses #486.

It focuses on the `wasm-test` job's npm dependency path to make CI faster and more cache-friendly.

### Changes
- Configured npm download caching via `actions/setup-node@v4`:
  - `cache: npm`
  - `cache-dependency-path: pubky-sdk/bindings/js/pkg/package-lock.json`
- Added a dedicated `Install JS dependencies` step:
  - `npm ci --prefer-offline --no-audit --no-fund`
- Removed the redundant per-step `npm install` from `Build WASM`, since dependencies are now installed once in a dedicated step.

### Expected impact
Repeated CI runs can reuse npm's package download cache, reducing network fetches during `npm ci` while preserving deterministic lockfile-based installs. This should improve npm install time without relying on a `node_modules` cache that `npm ci` would remove before installing.