### PR TITLE
fix(homeserver): private events on session revocation

### DIFF
--- a/e2e/src/tests/events/stream_private.rs
+++ b/e2e/src/tests/events/stream_private.rs
@@ -3,7 +3,11 @@
 //! guarantee that private events never leak to unauthorized callers
 
 use super::*;
+use eventsource_stream::Event;
+use futures::{Stream, StreamExt};
 use pubky_testnet::pubky::ClientId;
+use std::{fmt::Debug, future::Future, time::Duration};
+use tokio::time::{sleep, timeout};
 
 /// Sign up a fresh user and return an authenticated grant session plus the
 /// bearer the homeserver minted for it (for raw, credentialed requests).
@@ -27,37 +31,41 @@ async fn signed_in_user(
     (signer.public_key(), session, bearer)
 }
 
-macro_rules! assert_revocation_closes_private_stream {
-    ($stream:ident, $writer:expr, $before_path:literal, $revoke:expr, $after_path:literal) => {{
-        sleep(Duration::from_millis(300)).await;
-        ($writer)
-            .storage()
-            .put($before_path, vec![1])
-            .await
-            .unwrap();
-        let before = timeout(Duration::from_secs(5), $stream.next())
-            .await
-            .expect("private stream should receive a live event")
-            .expect("private stream should not close before revocation")
-            .expect("private stream should decode its live event");
-        assert!(before.data.contains($before_path));
+async fn assert_revocation_closes_private_stream<StreamError, Revoke, RevokeError>(
+    stream: &mut (impl Stream<Item = Result<Event, StreamError>> + Unpin),
+    writer: &pubky_testnet::pubky::PubkySession,
+    before_path: &str,
+    revoke: Revoke,
+    after_path: &str,
+) where
+    StreamError: Debug,
+    Revoke: Future<Output = Result<(), RevokeError>>,
+    RevokeError: Debug,
+{
+    sleep(Duration::from_millis(300)).await;
+    writer.storage().put(before_path, vec![1]).await.unwrap();
+    let before = timeout(Duration::from_secs(5), stream.next())
+        .await
+        .expect("private stream should receive a live event")
+        .expect("private stream should not close before revocation")
+        .expect("private stream should decode its live event");
+    assert!(before.data.contains(before_path));
 
-        ($revoke).await.unwrap();
+    revoke.await.unwrap();
 
-        let closed = timeout(Duration::from_secs(5), $stream.next())
+    let closed = timeout(Duration::from_secs(5), stream.next())
+        .await
+        .expect("revocation should promptly close the private stream");
+    assert!(closed.is_none(), "revoked private stream should close");
+
+    writer.storage().put(after_path, vec![2]).await.unwrap();
+    assert!(
+        timeout(Duration::from_millis(500), stream.next())
             .await
-            .expect("revocation should promptly close the private stream");
-        assert!(closed.is_none(), "revoked private stream should close");
-
-        ($writer).storage().put($after_path, vec![2]).await.unwrap();
-        assert!(
-            timeout(Duration::from_millis(500), $stream.next())
-                .await
-                .expect("closed stream should stay closed")
-                .is_none(),
-            "revoked stream must not receive later private events"
-        );
-    }};
+            .expect("closed stream should stay closed")
+            .is_none(),
+        "revoked stream must not receive later private events"
+    );
 }
 
 /// Anonymous, unfiltered stream is public-only: a `/priv/` write must never
@@ -562,10 +570,7 @@ async fn events_stream_cookie_not_used_when_bearer_present() {
 #[pubky_testnet::test]
 async fn events_stream_live_closes_when_grant_is_revoked() {
     use eventsource_stream::Eventsource;
-    use futures::StreamExt;
     use pubky_testnet::pubky::GrantManager;
-    use std::time::Duration;
-    use tokio::time::{sleep, timeout};
 
     let testnet = build_full_testnet().await;
     let server = testnet.homeserver_app();
@@ -601,13 +606,14 @@ async fn events_stream_live_closes_when_grant_is_revoked() {
     let mut stream = response.bytes_stream().eventsource();
 
     let grant_id = streamed_session.as_grant().unwrap().grant_id().await;
-    assert_revocation_closes_private_stream!(
-        stream,
+    assert_revocation_closes_private_stream(
+        &mut stream,
         &root,
         "/priv/app/before-revoke.txt",
         GrantManager::new(&root).revoke(&grant_id),
-        "/priv/app/after-revoke.txt"
-    );
+        "/priv/app/after-revoke.txt",
+    )
+    .await;
 }
 
 /// Cookie signout invalidates only the cookie session used by the stream; a
@@ -618,9 +624,6 @@ async fn events_stream_live_closes_when_grant_is_revoked() {
 #[allow(deprecated, reason = "Test exercises the deprecated cookie auth flow")]
 async fn events_stream_live_closes_when_cookie_session_is_revoked() {
     use eventsource_stream::Eventsource;
-    use futures::StreamExt;
-    use std::time::Duration;
-    use tokio::time::{sleep, timeout};
 
     let testnet = build_full_testnet().await;
     let server = testnet.homeserver_app();
@@ -657,13 +660,14 @@ async fn events_stream_live_closes_when_cookie_session_is_revoked() {
     assert_eq!(response.status(), StatusCode::OK);
     let mut stream = response.bytes_stream().eventsource();
 
-    assert_revocation_closes_private_stream!(
-        stream,
+    assert_revocation_closes_private_stream(
+        &mut stream,
         &writer_session,
         "/priv/app/before-cookie-revoke.txt",
         streamed_session.signout(),
-        "/priv/app/after-cookie-revoke.txt"
-    );
+        "/priv/app/after-cookie-revoke.txt",
+    )
+    .await;
 }
 
 /// Public-only subscriptions remain anonymous and continue receiving public

--- a/e2e/src/tests/events/stream_private.rs
+++ b/e2e/src/tests/events/stream_private.rs
@@ -27,6 +27,39 @@ async fn signed_in_user(
     (signer.public_key(), session, bearer)
 }
 
+macro_rules! assert_revocation_closes_private_stream {
+    ($stream:ident, $writer:expr, $before_path:literal, $revoke:expr, $after_path:literal) => {{
+        sleep(Duration::from_millis(300)).await;
+        ($writer)
+            .storage()
+            .put($before_path, vec![1])
+            .await
+            .unwrap();
+        let before = timeout(Duration::from_secs(5), $stream.next())
+            .await
+            .expect("private stream should receive a live event")
+            .expect("private stream should not close before revocation")
+            .expect("private stream should decode its live event");
+        assert!(before.data.contains($before_path));
+
+        ($revoke).await.unwrap();
+
+        let closed = timeout(Duration::from_secs(5), $stream.next())
+            .await
+            .expect("revocation should promptly close the private stream");
+        assert!(closed.is_none(), "revoked private stream should close");
+
+        ($writer).storage().put($after_path, vec![2]).await.unwrap();
+        assert!(
+            timeout(Duration::from_millis(500), $stream.next())
+                .await
+                .expect("closed stream should stay closed")
+                .is_none(),
+            "revoked stream must not receive later private events"
+        );
+    }};
+}
+
 /// Anonymous, unfiltered stream is public-only: a `/priv/` write must never
 /// appear, even though the same user has public events.
 #[tokio::test]
@@ -520,4 +553,176 @@ async fn events_stream_cookie_not_used_when_bearer_present() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+/// A private stream is tied to the bearer grant that opened it. Revoking that
+/// grant from a second root session must close the SSE connection before a
+/// later private write can be observed.
+#[tokio::test]
+#[pubky_testnet::test]
+async fn events_stream_live_closes_when_grant_is_revoked() {
+    use eventsource_stream::Eventsource;
+    use futures::StreamExt;
+    use pubky_testnet::pubky::GrantManager;
+    use std::time::Duration;
+    use tokio::time::{sleep, timeout};
+
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+    let server_host = server.public_key().z32();
+
+    let signer = pubky.signer(Keypair::random());
+    signer.signup(&server.public_key(), None).await.unwrap();
+    let user = signer.public_key();
+    let root = signer
+        .signin(ClientId::new("stream-revoker.test").unwrap())
+        .await
+        .unwrap();
+    let streamed_session = signer
+        .signin(ClientId::new("stream-revoked.test").unwrap())
+        .await
+        .unwrap();
+    let streamed_bearer = streamed_session.as_grant().unwrap().current_bearer().await;
+
+    let url = format!(
+        "https://{}/events-stream?user={}&path=/priv/app/&live=true",
+        server_host,
+        user.z32()
+    );
+    let response = pubky
+        .client()
+        .request(Method::GET, &url)
+        .header("Authorization", format!("Bearer {streamed_bearer}"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let mut stream = response.bytes_stream().eventsource();
+
+    let grant_id = streamed_session.as_grant().unwrap().grant_id().await;
+    assert_revocation_closes_private_stream!(
+        stream,
+        &root,
+        "/priv/app/before-revoke.txt",
+        GrantManager::new(&root).revoke(&grant_id),
+        "/priv/app/after-revoke.txt"
+    );
+}
+
+/// Cookie signout invalidates only the cookie session used by the stream; a
+/// second session for the same user remains able to write the post-revocation
+/// event that the closed stream must not receive.
+#[tokio::test]
+#[pubky_testnet::test]
+#[allow(deprecated, reason = "Test exercises the deprecated cookie auth flow")]
+async fn events_stream_live_closes_when_cookie_session_is_revoked() {
+    use eventsource_stream::Eventsource;
+    use futures::StreamExt;
+    use std::time::Duration;
+    use tokio::time::{sleep, timeout};
+
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+    let server_host = server.public_key().z32();
+
+    let signer = pubky.signer(Keypair::random());
+    let streamed_session = signer
+        .signup_cookie(&server.public_key(), None)
+        .await
+        .unwrap();
+    let user = signer.public_key();
+    let token = streamed_session
+        .as_cookie()
+        .unwrap()
+        .export_secret()
+        .unwrap();
+    let (cookie_name, cookie_secret) = token.split_once(':').unwrap();
+    let streamed_cookie = format!("{cookie_name}={cookie_secret}");
+    let writer_session = signer.signin_cookie().await.unwrap();
+
+    let url = format!(
+        "https://{}/events-stream?user={}&path=/priv/app/&live=true",
+        server_host,
+        user.z32()
+    );
+    let response = pubky
+        .client()
+        .request(Method::GET, &url)
+        .header("Cookie", streamed_cookie)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let mut stream = response.bytes_stream().eventsource();
+
+    assert_revocation_closes_private_stream!(
+        stream,
+        &writer_session,
+        "/priv/app/before-cookie-revoke.txt",
+        streamed_session.signout(),
+        "/priv/app/after-cookie-revoke.txt"
+    );
+}
+
+/// Public-only subscriptions remain anonymous and continue receiving public
+/// events even when an unrelated authenticated session is revoked.
+#[tokio::test]
+#[pubky_testnet::test]
+async fn events_stream_live_public_remains_open_after_auth_revocation() {
+    use eventsource_stream::Eventsource;
+    use futures::StreamExt;
+    use pubky_testnet::pubky::GrantManager;
+    use std::time::Duration;
+    use tokio::time::{sleep, timeout};
+
+    let testnet = build_full_testnet().await;
+    let server = testnet.homeserver_app();
+    let pubky = testnet.sdk().unwrap();
+    let server_host = server.public_key().z32();
+
+    let signer = pubky.signer(Keypair::random());
+    signer.signup(&server.public_key(), None).await.unwrap();
+    let user = signer.public_key();
+    let root = signer
+        .signin(ClientId::new("public-stream-root.test").unwrap())
+        .await
+        .unwrap();
+    let revoked_session = signer
+        .signin(ClientId::new("public-stream-revoked.test").unwrap())
+        .await
+        .unwrap();
+
+    let url = format!(
+        "https://{}/events-stream?user={}&live=true",
+        server_host,
+        user.z32()
+    );
+    let response = pubky
+        .client()
+        .request(Method::GET, &url)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let mut stream = response.bytes_stream().eventsource();
+
+    sleep(Duration::from_millis(300)).await;
+    let revoked_grant = revoked_session.as_grant().unwrap().grant_id().await;
+    GrantManager::new(&root)
+        .revoke(&revoked_grant)
+        .await
+        .unwrap();
+    root.storage()
+        .put("/pub/after-auth-revoke.txt", vec![1])
+        .await
+        .unwrap();
+
+    let event = timeout(Duration::from_secs(5), stream.next())
+        .await
+        .expect("public stream should stay open")
+        .expect("public stream should emit an event")
+        .expect("public stream event should decode");
+    assert!(event.data.contains("/pub/after-auth-revoke.txt"));
 }

--- a/pubky-homeserver/src/app_context.rs
+++ b/pubky-homeserver/src/app_context.rs
@@ -9,7 +9,7 @@ use crate::services::user_service::UserService;
 #[cfg(any(test, feature = "testing"))]
 use crate::MockDataDir;
 use crate::{
-    client_server::auth::{AuthRevocationService, PgAuthRevocationListener},
+    client_server::auth::AuthRevocationService,
     observability::{Metrics, MetricsInitError},
     persistence::{
         files::{events::EventsService, FileIoError, FileService},
@@ -48,9 +48,9 @@ pub enum AppContextConversionError {
     /// Failed to start the Postgres event listener.
     #[error("Failed to start Postgres event listener: {0}")]
     PgEventListener(sqlx::Error),
-    /// Failed to start the Postgres auth-revocation listener.
-    #[error("Failed to start Postgres auth-revocation listener: {0}")]
-    PgAuthRevocationListener(sqlx::Error),
+    /// Failed to start the auth-revocation service.
+    #[error("Failed to start the auth revocation service: {0}")]
+    AuthRevocationService(sqlx::Error),
     /// Failed to initialize metrics.
     #[error("Failed to initialize metrics: {0}")]
     Metrics(MetricsInitError),
@@ -86,9 +86,8 @@ pub struct AppContext {
     /// Kept alive for the background task, not for direct access.
     _pg_event_listener: Arc<PgEventListener>,
     /// Auth revocations are forwarded to private SSE streams on this instance.
+    /// Its Postgres listener stops once the last clone is dropped.
     pub(crate) auth_revocation_service: AuthRevocationService,
-    /// Kept alive so the auth-revocation listener continues running.
-    _pg_auth_revocation_listener: Arc<PgAuthRevocationListener>,
     /// User service for quota resolution and user creation with defaults.
     pub(crate) user_service: UserService,
 }
@@ -127,11 +126,9 @@ impl AppContext {
         let pg_event_listener = PgEventListener::start(sql_db.pool(), events_service.clone())
             .await
             .map_err(AppContextConversionError::PgEventListener)?;
-        let auth_revocation_service = AuthRevocationService::new();
-        let pg_auth_revocation_listener =
-            PgAuthRevocationListener::start(sql_db.pool(), auth_revocation_service.clone())
-                .await
-                .map_err(AppContextConversionError::PgAuthRevocationListener)?;
+        let auth_revocation_service = AuthRevocationService::start(sql_db.pool())
+            .await
+            .map_err(AppContextConversionError::AuthRevocationService)?;
 
         let user_service = UserService::new(sql_db.clone());
 
@@ -160,7 +157,6 @@ impl AppContext {
             metrics: Metrics::new().map_err(AppContextConversionError::Metrics)?,
             _pg_event_listener: Arc::new(pg_event_listener),
             auth_revocation_service,
-            _pg_auth_revocation_listener: Arc::new(pg_auth_revocation_listener),
             user_service,
         })
     }

--- a/pubky-homeserver/src/app_context.rs
+++ b/pubky-homeserver/src/app_context.rs
@@ -9,6 +9,7 @@ use crate::services::user_service::UserService;
 #[cfg(any(test, feature = "testing"))]
 use crate::MockDataDir;
 use crate::{
+    client_server::auth::{AuthRevocationService, PgAuthRevocationListener},
     observability::{Metrics, MetricsInitError},
     persistence::{
         files::{events::EventsService, FileIoError, FileService},
@@ -47,6 +48,9 @@ pub enum AppContextConversionError {
     /// Failed to start the Postgres event listener.
     #[error("Failed to start Postgres event listener: {0}")]
     PgEventListener(sqlx::Error),
+    /// Failed to start the Postgres auth-revocation listener.
+    #[error("Failed to start Postgres auth-revocation listener: {0}")]
+    PgAuthRevocationListener(sqlx::Error),
     /// Failed to initialize metrics.
     #[error("Failed to initialize metrics: {0}")]
     Metrics(MetricsInitError),
@@ -81,6 +85,10 @@ pub struct AppContext {
     /// Enables cross-instance event propagation for /events-stream's SSE functionality.
     /// Kept alive for the background task, not for direct access.
     _pg_event_listener: Arc<PgEventListener>,
+    /// Auth revocations are forwarded to private SSE streams on this instance.
+    pub(crate) auth_revocation_service: AuthRevocationService,
+    /// Kept alive so the auth-revocation listener continues running.
+    _pg_auth_revocation_listener: Arc<PgAuthRevocationListener>,
     /// User service for quota resolution and user creation with defaults.
     pub(crate) user_service: UserService,
 }
@@ -119,6 +127,11 @@ impl AppContext {
         let pg_event_listener = PgEventListener::start(sql_db.pool(), events_service.clone())
             .await
             .map_err(AppContextConversionError::PgEventListener)?;
+        let auth_revocation_service = AuthRevocationService::new();
+        let pg_auth_revocation_listener =
+            PgAuthRevocationListener::start(sql_db.pool(), auth_revocation_service.clone())
+                .await
+                .map_err(AppContextConversionError::PgAuthRevocationListener)?;
 
         let user_service = UserService::new(sql_db.clone());
 
@@ -146,6 +159,8 @@ impl AppContext {
             events_service,
             metrics: Metrics::new().map_err(AppContextConversionError::Metrics)?,
             _pg_event_listener: Arc::new(pg_event_listener),
+            auth_revocation_service,
+            _pg_auth_revocation_listener: Arc::new(pg_auth_revocation_listener),
             user_service,
         })
     }

--- a/pubky-homeserver/src/client_server/app.rs
+++ b/pubky-homeserver/src/client_server/app.rs
@@ -114,6 +114,7 @@ impl ClientServer {
     ) -> std::result::Result<Router, ClientServerBuildError> {
         let state = AppState {
             auth_state: auth::AuthState::new(context),
+            auth_revocation_service: context.auth_revocation_service.clone(),
             sql_db: context.sql_db.clone(),
             file_service: context.file_service.clone(),
             signup_mode: context.config_toml.general.signup_mode.clone(),

--- a/pubky-homeserver/src/client_server/app_state.rs
+++ b/pubky-homeserver/src/client_server/app_state.rs
@@ -1,5 +1,6 @@
 use axum::extract::FromRef;
 
+use crate::client_server::auth::AuthRevocationService;
 use crate::client_server::auth::AuthState;
 use crate::observability::Metrics;
 use crate::persistence::files::events::EventsService;
@@ -12,6 +13,8 @@ use crate::SignupMode;
 pub(crate) struct AppState {
     /// Auth sub-state (extracted via `FromRef` by auth handlers).
     pub(crate) auth_state: AuthState,
+    /// Cross-instance signals that close private SSE streams after revocation.
+    pub(crate) auth_revocation_service: AuthRevocationService,
     /// The SQL database connection.
     pub(crate) sql_db: SqlDb,
     pub(crate) file_service: FileService,

--- a/pubky-homeserver/src/client_server/auth/authorization.rs
+++ b/pubky-homeserver/src/client_server/auth/authorization.rs
@@ -151,12 +151,12 @@ mod tests {
     }
 
     fn session_with_key(pk: PublicKey, capabilities: Capabilities) -> AuthSession {
-        AuthSession::Grant(GrantSession {
-            user_key: pk,
+        AuthSession::Grant(GrantSession::test(
+            pk,
             capabilities,
-            grant_id: GrantId::generate(),
-            token_expires_at: 9999999999,
-        })
+            GrantId::generate(),
+            9999999999,
+        ))
     }
 
     fn session_with_caps(capabilities: Capabilities) -> (AuthSession, PublicKey) {

--- a/pubky-homeserver/src/client_server/auth/cookie/service.rs
+++ b/pubky-homeserver/src/client_server/auth/cookie/service.rs
@@ -4,12 +4,12 @@ use pubky_common::{
     auth::AuthToken, capabilities::Capabilities, crypto::PublicKey, session::CookieSessionRecord,
 };
 
-use crate::persistence::sql::{signup_code::SignupCode, user::UserRepository, SqlDb};
+use crate::persistence::sql::{signup_code::SignupCode, uexecutor, user::UserRepository, SqlDb};
 use crate::shared::{HttpError, HttpResult};
 
 use super::persistence::{SessionEntity, SessionRepository, SessionSecret};
 use super::verifier::CookieAuthVerifier;
-use crate::client_server::auth::{AuthSession, SignupService};
+use crate::client_server::auth::{AuthRevocation, AuthSession, SignupService};
 
 #[derive(Clone, Debug)]
 pub(crate) struct CookieAuthService {
@@ -74,22 +74,39 @@ impl CookieAuthService {
         public_key: &PublicKey,
     ) -> Option<AuthSession> {
         let session_secret = SessionSecret::new(cookie_value?).ok()?;
-        let session = self.get_session(&session_secret).await.ok()?;
-
-        if &session.user_pubkey != public_key {
-            return None;
-        }
+        let session = self
+            .resolve_active_session_for_user(&session_secret, public_key)
+            .await
+            .ok()
+            .flatten()?;
 
         Some(AuthSession::Cookie(session))
     }
 
     pub(crate) async fn signout(&self, auth: Option<AuthSession>) -> HttpResult<()> {
         if let Some(AuthSession::Cookie(cookie_session)) = auth {
-            SessionRepository::delete(&cookie_session.secret, &mut self.sql_db.pool().into())
+            let mut tx = self.sql_db.pool().begin().await?;
+            SessionRepository::delete(&cookie_session.secret, uexecutor!(tx)).await?;
+            AuthRevocation::notify_cookie_session_in_transaction(cookie_session.id, uexecutor!(tx))
                 .await?;
+            tx.commit().await?;
         }
 
         Ok(())
+    }
+
+    /// Recheck that this exact session row still exists before opening a
+    /// private long-lived stream.
+    pub(crate) async fn validate_active_session(&self, session: &SessionEntity) -> HttpResult<()> {
+        match self
+            .resolve_active_session_for_user(&session.secret, &session.user_pubkey)
+            .await
+        {
+            Ok(Some(_)) => Ok(()),
+            Ok(None) => Err(HttpError::unauthorized()),
+            Err(sqlx::Error::RowNotFound) => Err(HttpError::unauthorized()),
+            Err(error) => Err(error.into()),
+        }
     }
 
     fn verify(&self, body: &[u8]) -> Result<AuthToken, pubky_common::auth::Error> {
@@ -106,6 +123,17 @@ impl CookieAuthService {
 
     async fn get_session(&self, secret: &SessionSecret) -> Result<SessionEntity, sqlx::Error> {
         SessionRepository::get_by_secret(secret, &mut self.sql_db.pool().into()).await
+    }
+
+    /// Resolve a cookie session through the same active-row and tenant checks
+    /// used by both normal cookie authentication and private stream setup.
+    async fn resolve_active_session_for_user(
+        &self,
+        secret: &SessionSecret,
+        public_key: &PublicKey,
+    ) -> Result<Option<SessionEntity>, sqlx::Error> {
+        let session = self.get_session(secret).await?;
+        Ok((&session.user_pubkey == public_key).then_some(session))
     }
 }
 

--- a/pubky-homeserver/src/client_server/auth/grant/routes.rs
+++ b/pubky-homeserver/src/client_server/auth/grant/routes.rs
@@ -176,12 +176,12 @@ mod tests {
 
     fn bearer_auth(caps: Capabilities) -> AuthSession {
         let now = chrono::Utc::now().timestamp() as u64;
-        AuthSession::Grant(GrantSession {
-            user_key: Keypair::random().public_key(),
-            capabilities: caps,
-            grant_id: GrantId::generate(),
-            token_expires_at: now + 3600,
-        })
+        AuthSession::Grant(GrantSession::test(
+            Keypair::random().public_key(),
+            caps,
+            GrantId::generate(),
+            now + 3600,
+        ))
     }
 
     #[test]

--- a/pubky-homeserver/src/client_server/auth/grant/service.rs
+++ b/pubky-homeserver/src/client_server/auth/grant/service.rs
@@ -162,17 +162,6 @@ impl GrantAuthService {
         self.revoke_grant(&session.grant_id).await
     }
 
-    /// Recheck the grant status immediately before a private long-lived stream
-    /// starts. Subsequent revocation is handled by the notification listener.
-    pub(crate) async fn validate_active_session(
-        &self,
-        session: &GrantSession,
-    ) -> Result<(), AuthServiceError> {
-        self.validate_active_grant_session(session.token_expires_at, &session.grant_id)
-            .await?;
-        Ok(())
-    }
-
     /// Resolve an opaque bearer into a `GrantSession`.
     ///
     /// Hashes the bearer, looks up the matching session row, loads the
@@ -222,9 +211,11 @@ impl GrantAuthService {
 
     // ── Private helpers ─────────────────────────────────────────────────
 
-    /// Shared active-session validation used both when resolving a bearer and
-    /// immediately before a long-lived private stream begins.
-    async fn validate_active_grant_session(
+    /// Validate a grant session and return its active backing grant.
+    ///
+    /// Used both when resolving a bearer and immediately before a private
+    /// long-lived stream begins.
+    pub(crate) async fn validate_active_grant_session(
         &self,
         token_expires_at: u64,
         grant_id: &GrantId,

--- a/pubky-homeserver/src/client_server/auth/grant/service.rs
+++ b/pubky-homeserver/src/client_server/auth/grant/service.rs
@@ -27,7 +27,7 @@ use super::crypto::{
 };
 use super::persistence::{
     grant::{GrantEntity, GrantRepository, NewGrant},
-    grant_session::{GrantSessionRepository, NewGrantSession},
+    grant_session::{GrantSessionEntity, GrantSessionRepository, NewGrantSession},
     pop_nonce::{PopNonceError, PopNonceRepository},
 };
 use super::service_error::AuthServiceError;
@@ -177,15 +177,14 @@ impl GrantAuthService {
             AuthServiceError::SessionNotFound,
         )?;
 
-        let grant = self
-            .validate_active_grant_session(session.expires_at as u64, &session.grant_id)
-            .await?;
+        let grant = self.validate_active_grant_session_entity(&session).await?;
 
         Ok(GrantSession {
             user_key: grant.user_pubkey.clone(),
             capabilities: grant.capabilities,
             grant_id: session.grant_id,
             token_expires_at: session.expires_at as u64,
+            token_hash: session.token_hash,
         })
     }
 
@@ -211,21 +210,38 @@ impl GrantAuthService {
 
     // ── Private helpers ─────────────────────────────────────────────────
 
-    /// Validate a grant session and return its active backing grant.
-    ///
-    /// Used both when resolving a bearer and immediately before a private
-    /// long-lived stream begins.
+    /// Recheck that this exact bearer session row still exists before opening
+    /// a private long-lived stream.
     pub(crate) async fn validate_active_grant_session(
         &self,
-        token_expires_at: u64,
-        grant_id: &GrantId,
+        session: &GrantSession,
+    ) -> Result<GrantEntity, AuthServiceError> {
+        let persisted = map_not_found(
+            GrantSessionRepository::get_by_token_hash(
+                &session.token_hash,
+                &mut self.sql_db.pool().into(),
+            )
+            .await,
+            AuthServiceError::SessionNotFound,
+        )?;
+
+        if persisted.grant_id != session.grant_id {
+            return Err(AuthServiceError::SessionNotFound);
+        }
+
+        self.validate_active_grant_session_entity(&persisted).await
+    }
+
+    async fn validate_active_grant_session_entity(
+        &self,
+        session: &GrantSessionEntity,
     ) -> Result<GrantEntity, AuthServiceError> {
         let now = Utc::now().timestamp();
-        if token_expires_at <= now as u64 {
+        if session.expires_at <= now {
             return Err(AuthServiceError::SessionExpired);
         }
 
-        let grant = self.get_grant(grant_id).await?;
+        let grant = self.get_grant(&session.grant_id).await?;
         grant.require_active(now)?;
         Ok(grant)
     }
@@ -864,6 +880,41 @@ mod tests {
 
     #[tokio::test]
     #[pubky_test_utils::test]
+    async fn validate_active_grant_session_rejects_rotated_bearer() {
+        let service = test_service().await;
+        let (user_kp, _) = create_test_user(&service).await;
+        let client_kp = Keypair::random();
+        let (grant_jws, pop_jws, raw_grant) =
+            sign_grant(&user_kp, &client_kp, &service.homeserver_public_key());
+
+        let response = service
+            .create_grant_session(&grant_jws, &pop_jws)
+            .await
+            .unwrap();
+        let session = service
+            .resolve_grant_session_by_bearer(&SessionBearer::parse(&response.token).unwrap())
+            .await
+            .unwrap();
+
+        service
+            .validate_active_grant_session(&session)
+            .await
+            .unwrap();
+
+        service
+            .mint_session(&raw_grant, &mut service.sql_db.pool().into())
+            .await
+            .unwrap();
+
+        let err = service
+            .validate_active_grant_session(&session)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AuthServiceError::SessionNotFound));
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
     async fn resolve_grant_session_after_revoke() {
         let service = test_service().await;
         let (user_kp, _) = create_test_user(&service).await;
@@ -1079,23 +1130,23 @@ mod tests {
 
     #[test]
     fn require_root_capability_passes_with_root() {
-        let session = GrantSession {
-            user_key: Keypair::random().public_key(),
-            capabilities: Capabilities::builder().cap(Capability::root()).finish(),
-            grant_id: GrantId::generate(),
-            token_expires_at: 0,
-        };
+        let session = GrantSession::test(
+            Keypair::random().public_key(),
+            Capabilities::builder().cap(Capability::root()).finish(),
+            GrantId::generate(),
+            0,
+        );
         assert!(GrantAuthService::require_root_capability(&AuthSession::Grant(session)).is_ok());
     }
 
     #[test]
     fn require_root_capability_fails_without_root() {
-        let session = GrantSession {
-            user_key: Keypair::random().public_key(),
-            capabilities: Capabilities::builder().cap(Capability::read("/")).finish(),
-            grant_id: GrantId::generate(),
-            token_expires_at: 0,
-        };
+        let session = GrantSession::test(
+            Keypair::random().public_key(),
+            Capabilities::builder().cap(Capability::read("/")).finish(),
+            GrantId::generate(),
+            0,
+        );
         let err =
             GrantAuthService::require_root_capability(&AuthSession::Grant(session)).unwrap_err();
         assert!(matches!(err, AuthServiceError::RootCapabilityRequired));

--- a/pubky-homeserver/src/client_server/auth/grant/service.rs
+++ b/pubky-homeserver/src/client_server/auth/grant/service.rs
@@ -32,8 +32,7 @@ use super::persistence::{
 };
 use super::service_error::AuthServiceError;
 use super::session::GrantSession;
-use crate::client_server::auth::AuthSession;
-use crate::client_server::auth::SignupService;
+use crate::client_server::auth::{AuthRevocation, AuthSession, SignupService};
 
 /// Default session bearer lifetime: 1 hour.
 const DEFAULT_SESSION_TOKEN_LIFETIME_SECS: u64 = 3600;
@@ -123,6 +122,7 @@ impl GrantAuthService {
         let mut tx = self.sql_db.pool().begin().await?;
         GrantRepository::revoke(grant_id, uexecutor!(tx)).await?;
         GrantSessionRepository::delete_all_for_grant(grant_id, uexecutor!(tx)).await?;
+        AuthRevocation::notify_grant_in_transaction(grant_id, uexecutor!(tx)).await?;
         tx.commit().await?;
         Ok(())
     }
@@ -162,6 +162,17 @@ impl GrantAuthService {
         self.revoke_grant(&session.grant_id).await
     }
 
+    /// Recheck the grant status immediately before a private long-lived stream
+    /// starts. Subsequent revocation is handled by the notification listener.
+    pub(crate) async fn validate_active_session(
+        &self,
+        session: &GrantSession,
+    ) -> Result<(), AuthServiceError> {
+        self.validate_active_grant_session(session.token_expires_at, &session.grant_id)
+            .await?;
+        Ok(())
+    }
+
     /// Resolve an opaque bearer into a `GrantSession`.
     ///
     /// Hashes the bearer, looks up the matching session row, loads the
@@ -177,13 +188,9 @@ impl GrantAuthService {
             AuthServiceError::SessionNotFound,
         )?;
 
-        let now = Utc::now().timestamp();
-        if session.expires_at <= now {
-            return Err(AuthServiceError::SessionExpired);
-        }
-
-        let grant = self.get_grant(&session.grant_id).await?;
-        grant.require_active(now)?;
+        let grant = self
+            .validate_active_grant_session(session.expires_at as u64, &session.grant_id)
+            .await?;
 
         Ok(GrantSession {
             user_key: grant.user_pubkey.clone(),
@@ -214,6 +221,23 @@ impl GrantAuthService {
     }
 
     // ── Private helpers ─────────────────────────────────────────────────
+
+    /// Shared active-session validation used both when resolving a bearer and
+    /// immediately before a long-lived private stream begins.
+    async fn validate_active_grant_session(
+        &self,
+        token_expires_at: u64,
+        grant_id: &GrantId,
+    ) -> Result<GrantEntity, AuthServiceError> {
+        let now = Utc::now().timestamp();
+        if token_expires_at <= now as u64 {
+            return Err(AuthServiceError::SessionExpired);
+        }
+
+        let grant = self.get_grant(grant_id).await?;
+        grant.require_active(now)?;
+        Ok(grant)
+    }
 
     /// Shared verification pipeline: verify grant → check revocation → verify PoP → check nonce.
     async fn verify_grant_and_pop(

--- a/pubky-homeserver/src/client_server/auth/grant/session.rs
+++ b/pubky-homeserver/src/client_server/auth/grant/session.rs
@@ -4,6 +4,10 @@ use pubky_common::auth::jws::GrantId;
 use pubky_common::capabilities::Capabilities;
 use pubky_common::crypto::PublicKey;
 
+#[cfg(test)]
+use super::crypto::session_token::SessionBearer;
+use super::crypto::session_token::SessionTokenHash;
+
 /// Grant-based session data.
 ///
 /// Constructed by [`AuthService::resolve_grant_session_by_bearer`](super::service::AuthService::resolve_grant_session_by_bearer)
@@ -19,4 +23,24 @@ pub struct GrantSession {
     pub grant_id: GrantId,
     /// When the bearer expires (Unix seconds).
     pub token_expires_at: u64,
+    /// Hash identifying the exact persisted bearer session.
+    pub(super) token_hash: SessionTokenHash,
+}
+
+#[cfg(test)]
+impl GrantSession {
+    pub(crate) fn test(
+        user_key: PublicKey,
+        capabilities: Capabilities,
+        grant_id: GrantId,
+        token_expires_at: u64,
+    ) -> Self {
+        Self {
+            user_key,
+            capabilities,
+            grant_id,
+            token_expires_at,
+            token_hash: SessionBearer::generate().hash(),
+        }
+    }
 }

--- a/pubky-homeserver/src/client_server/auth/mod.rs
+++ b/pubky-homeserver/src/client_server/auth/mod.rs
@@ -32,4 +32,4 @@ pub use router::{base_router, tenant_router};
 pub use session::AuthSession;
 pub use signup_service::{SignupService, SignupServiceError};
 pub use state::AuthState;
-pub(crate) use stream_auth::PendingStreamAuth;
+pub(crate) use stream_auth::{PendingStreamAuth, RevocationSignal};

--- a/pubky-homeserver/src/client_server/auth/mod.rs
+++ b/pubky-homeserver/src/client_server/auth/mod.rs
@@ -20,6 +20,7 @@ mod router;
 mod session;
 mod signup_service;
 mod state;
+mod stream_auth;
 mod user_error_mapping;
 
 pub use authorization::{has_read_permission, has_write_permission};
@@ -31,3 +32,4 @@ pub use router::{base_router, tenant_router};
 pub use session::AuthSession;
 pub use signup_service::{SignupService, SignupServiceError};
 pub use state::AuthState;
+pub(crate) use stream_auth::PendingStreamAuth;

--- a/pubky-homeserver/src/client_server/auth/mod.rs
+++ b/pubky-homeserver/src/client_server/auth/mod.rs
@@ -32,4 +32,4 @@ pub use router::{base_router, tenant_router};
 pub use session::AuthSession;
 pub use signup_service::{SignupService, SignupServiceError};
 pub use state::AuthState;
-pub(crate) use stream_auth::{PendingStreamAuth, RevocationSignal};
+pub(crate) use stream_auth::PendingStreamAuth;

--- a/pubky-homeserver/src/client_server/auth/mod.rs
+++ b/pubky-homeserver/src/client_server/auth/mod.rs
@@ -27,7 +27,7 @@ pub use authorization::{has_read_permission, has_write_permission};
 pub use middleware::authentication::AuthenticationLayer;
 
 pub use grant::service::GrantAuthService;
-pub(crate) use revocation::{AuthRevocation, AuthRevocationService, PgAuthRevocationListener};
+pub(crate) use revocation::{AuthRevocation, AuthRevocationService};
 pub use router::{base_router, tenant_router};
 pub use session::AuthSession;
 pub use signup_service::{SignupService, SignupServiceError};

--- a/pubky-homeserver/src/client_server/auth/mod.rs
+++ b/pubky-homeserver/src/client_server/auth/mod.rs
@@ -15,6 +15,7 @@ pub mod authorization;
 pub mod cookie;
 pub mod grant;
 pub mod middleware;
+pub(crate) mod revocation;
 mod router;
 mod session;
 mod signup_service;
@@ -25,6 +26,7 @@ pub use authorization::{has_read_permission, has_write_permission};
 pub use middleware::authentication::AuthenticationLayer;
 
 pub use grant::service::GrantAuthService;
+pub(crate) use revocation::{AuthRevocation, AuthRevocationService, PgAuthRevocationListener};
 pub use router::{base_router, tenant_router};
 pub use session::AuthSession;
 pub use signup_service::{SignupService, SignupServiceError};

--- a/pubky-homeserver/src/client_server/auth/revocation.rs
+++ b/pubky-homeserver/src/client_server/auth/revocation.rs
@@ -1,0 +1,453 @@
+//! Cross-instance notification of authentication revocations.
+//!
+//! A private SSE subscription authorizes once when it is opened, so a normal
+//! request-time auth check is not enough to stop it after its credential is
+//! revoked. This module forwards Postgres `LISTEN`/`NOTIFY` messages to a local
+//! broadcast channel that those subscriptions can observe.
+//!
+//! This listener intentionally has its own connection instead of sharing the
+//! file-event listener. File events have a durable database catch-up path;
+//! auth revocations do not, and therefore must fail closed on any listener
+//! gap. Sharing lifecycle and failure handling would make an event-listener
+//! disruption unnecessarily disconnect every private stream.
+
+use std::{
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use pubky_common::auth::jws::GrantId;
+use serde::{Deserialize, Serialize};
+use sqlx::{postgres::PgListener, PgPool};
+use tokio::{sync::broadcast, task::JoinHandle};
+use tokio_util::sync::CancellationToken;
+
+use crate::persistence::sql::UnifiedExecutor;
+
+use super::AuthSession;
+
+/// Postgres channel used for committed authentication revocations.
+const PG_AUTH_REVOCATION_CHANNEL: &str = "auth_revocations";
+/// Sized to absorb short revocation bursts without forcing unrelated streams
+/// through a database revalidation round-trip.
+const AUTH_REVOCATION_CHANNEL_CAPACITY: usize = 1024;
+
+/// A local revocation signal for an active private stream.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum AuthRevocation {
+    /// A deprecated cookie session row was deleted.
+    CookieSession(i32),
+    /// A grant and all of its bearer sessions were revoked.
+    Grant(GrantId),
+    /// The listener cannot guarantee that no notification was missed.
+    ///
+    /// This is intentionally local-only and never sent over Postgres.
+    All,
+}
+
+impl AuthRevocation {
+    /// Return whether this signal invalidates `session`.
+    pub(crate) fn matches(&self, session: &AuthSession) -> bool {
+        match (self, session) {
+            (Self::All, _) => true,
+            (Self::CookieSession(id), AuthSession::Cookie(cookie)) => id == &cookie.id,
+            (Self::Grant(id), AuthSession::Grant(grant)) => id == &grant.grant_id,
+            _ => false,
+        }
+    }
+
+    /// Queue a cookie-session revocation in the caller's transaction.
+    pub(crate) async fn notify_cookie_session_in_transaction<'a>(
+        id: i32,
+        executor: &mut UnifiedExecutor<'a>,
+    ) -> Result<(), sqlx::Error> {
+        WireAuthRevocation::CookieSession(id)
+            .notify_in_transaction(executor)
+            .await
+    }
+
+    /// Queue a grant revocation in the caller's transaction.
+    pub(crate) async fn notify_grant_in_transaction<'a>(
+        id: &GrantId,
+        executor: &mut UnifiedExecutor<'a>,
+    ) -> Result<(), sqlx::Error> {
+        WireAuthRevocation::Grant(id.clone())
+            .notify_in_transaction(executor)
+            .await
+    }
+}
+
+/// Serializable form of an authentication revocation.
+///
+/// Cookie secrets and bearer tokens are deliberately not present in this
+/// payload. Postgres channel consumers only need stable database identifiers.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "id", rename_all = "snake_case")]
+enum WireAuthRevocation {
+    CookieSession(i32),
+    Grant(GrantId),
+}
+
+impl WireAuthRevocation {
+    /// Queue this notification in the caller's transaction.
+    ///
+    /// Postgres only delivers a `NOTIFY` at commit. Keeping this alongside the
+    /// database mutation means a revocation cannot commit without its shutdown
+    /// signal, and a rolled-back mutation never closes streams.
+    async fn notify_in_transaction<'a>(
+        &self,
+        executor: &mut UnifiedExecutor<'a>,
+    ) -> Result<(), sqlx::Error> {
+        let payload =
+            serde_json::to_string(self).expect("auth revocation payload is always serializable");
+        let con = executor.get_con().await?;
+        sqlx::query("SELECT pg_notify($1, $2)")
+            .bind(PG_AUTH_REVOCATION_CHANNEL)
+            .bind(payload)
+            .execute(con)
+            .await?;
+        Ok(())
+    }
+}
+
+impl From<WireAuthRevocation> for AuthRevocation {
+    fn from(value: WireAuthRevocation) -> Self {
+        match value {
+            WireAuthRevocation::CookieSession(id) => Self::CookieSession(id),
+            WireAuthRevocation::Grant(id) => Self::Grant(id),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct AuthRevocationInner {
+    sender: broadcast::Sender<AuthRevocation>,
+    listener_healthy: AtomicBool,
+}
+
+/// Local fan-out service for committed authentication revocations.
+#[derive(Clone, Debug)]
+pub(crate) struct AuthRevocationService {
+    inner: Arc<AuthRevocationInner>,
+}
+
+impl AuthRevocationService {
+    pub(crate) fn new() -> Self {
+        let (sender, _) = broadcast::channel(AUTH_REVOCATION_CHANNEL_CAPACITY);
+        Self {
+            inner: Arc::new(AuthRevocationInner {
+                sender,
+                listener_healthy: AtomicBool::new(false),
+            }),
+        }
+    }
+
+    /// Subscribe before checking health so a listener failure cannot be missed
+    /// in the gap between the two operations.
+    pub(crate) fn subscribe(
+        &self,
+    ) -> Result<broadcast::Receiver<AuthRevocation>, AuthRevocationUnavailable> {
+        let receiver = self.inner.sender.subscribe();
+        if self.inner.listener_healthy.load(Ordering::Acquire) {
+            Ok(receiver)
+        } else {
+            Err(AuthRevocationUnavailable)
+        }
+    }
+
+    fn broadcast(&self, revocation: AuthRevocation) {
+        // No receivers is normal when no private streams are connected.
+        let _ = self.inner.sender.send(revocation);
+    }
+
+    fn mark_healthy(&self) {
+        self.inner.listener_healthy.store(true, Ordering::Release);
+    }
+
+    /// Stop all existing private streams before reconnecting. New private
+    /// streams are rejected until the next successful `LISTEN`.
+    fn mark_unhealthy(&self) {
+        self.inner.listener_healthy.store(false, Ordering::Release);
+        self.broadcast(AuthRevocation::All);
+    }
+}
+
+/// The local listener is unavailable, so accepting a private long-lived stream
+/// could miss an already-committed revocation.
+#[derive(Debug)]
+pub(crate) struct AuthRevocationUnavailable;
+
+/// Background Postgres listener for [`AuthRevocationService`].
+pub(crate) struct PgAuthRevocationListener {
+    handle: Option<JoinHandle<()>>,
+    cancel: CancellationToken,
+}
+
+impl PgAuthRevocationListener {
+    /// Connect and issue `LISTEN` before returning so the app never starts
+    /// serving private streams without its revocation feed.
+    pub(crate) async fn start(
+        pool: &PgPool,
+        service: AuthRevocationService,
+    ) -> Result<Self, sqlx::Error> {
+        let listener = Self::connect(pool).await?;
+        service.mark_healthy();
+
+        let cancel = CancellationToken::new();
+        let handle = {
+            let pool = pool.clone();
+            let cancel = cancel.clone();
+            tokio::spawn(async move {
+                Self::listen_loop(pool, service, listener, cancel).await;
+            })
+        };
+
+        Ok(Self {
+            handle: Some(handle),
+            cancel,
+        })
+    }
+
+    async fn connect(pool: &PgPool) -> Result<PgListener, sqlx::Error> {
+        let mut listener = PgListener::connect_with(pool).await?;
+        // `try_recv` must report a lost connection before sqlx reconnects, so
+        // existing private streams can be closed before a notification gap is
+        // silently accepted.
+        listener.eager_reconnect(false);
+        listener.listen(PG_AUTH_REVOCATION_CHANNEL).await?;
+        Ok(listener)
+    }
+
+    async fn listen_loop(
+        pool: PgPool,
+        service: AuthRevocationService,
+        mut listener: PgListener,
+        cancel: CancellationToken,
+    ) {
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => return,
+                notification = listener.try_recv() => match notification {
+                    Ok(Some(notification)) => {
+                        match serde_json::from_str::<WireAuthRevocation>(notification.payload()) {
+                            Ok(revocation) => service.broadcast(revocation.into()),
+                            Err(error) => {
+                                tracing::error!(%error, "invalid auth revocation notification; closing private streams");
+                                service.broadcast(AuthRevocation::All);
+                            }
+                        }
+                    }
+                    Ok(None) => {
+                        tracing::error!("auth revocation listener connection was lost; closing private streams");
+                        service.mark_unhealthy();
+                        listener = match Self::reconnect(&pool, &service, &cancel).await {
+                            Some(listener) => listener,
+                            None => return,
+                        };
+                    }
+                    Err(error) => {
+                        tracing::error!(%error, "auth revocation listener failed; closing private streams");
+                        service.mark_unhealthy();
+                        listener = match Self::reconnect(&pool, &service, &cancel).await {
+                            Some(listener) => listener,
+                            None => return,
+                        };
+                    }
+                }
+            }
+        }
+    }
+
+    async fn reconnect(
+        pool: &PgPool,
+        service: &AuthRevocationService,
+        cancel: &CancellationToken,
+    ) -> Option<PgListener> {
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => return None,
+                result = Self::connect(pool) => match result {
+                    Ok(listener) => {
+                        tracing::info!("auth revocation listener reconnected");
+                        service.mark_healthy();
+                        return Some(listener);
+                    }
+                    Err(error) => {
+                        tracing::error!(%error, "failed to reconnect auth revocation listener; retrying in 1s");
+                    }
+                }
+            }
+
+            tokio::select! {
+                _ = cancel.cancelled() => return None,
+                _ = tokio::time::sleep(Duration::from_secs(1)) => {}
+            }
+        }
+    }
+}
+
+impl Drop for PgAuthRevocationListener {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client_server::auth::{
+        cookie::persistence::{SessionEntity, SessionSecret},
+        grant::session::GrantSession,
+    };
+    use crate::persistence::sql::SqlDb;
+    use pubky_common::{capabilities::Capabilities, crypto::Keypair};
+    use std::time::Duration;
+    use tokio::time::{sleep, timeout};
+
+    fn cookie_session(id: i32) -> AuthSession {
+        AuthSession::Cookie(SessionEntity {
+            id,
+            secret: SessionSecret::random(),
+            user_id: 1,
+            user_pubkey: Keypair::random().public_key(),
+            capabilities: Capabilities::default(),
+            created_at: chrono::Utc::now().naive_utc(),
+        })
+    }
+
+    fn grant_session(id: GrantId) -> AuthSession {
+        AuthSession::Grant(GrantSession {
+            user_key: Keypair::random().public_key(),
+            capabilities: Capabilities::default(),
+            grant_id: id,
+            token_expires_at: u64::MAX,
+        })
+    }
+
+    #[test]
+    fn revocations_match_only_their_own_authentication_method() {
+        let grant_id = GrantId::generate();
+        assert!(AuthRevocation::CookieSession(7).matches(&cookie_session(7)));
+        assert!(!AuthRevocation::CookieSession(8).matches(&cookie_session(7)));
+        assert!(AuthRevocation::Grant(grant_id.clone()).matches(&grant_session(grant_id)));
+        assert!(!AuthRevocation::CookieSession(7).matches(&grant_session(GrantId::generate())));
+        assert!(AuthRevocation::All.matches(&cookie_session(7)));
+    }
+
+    #[test]
+    fn wire_payload_has_no_all_streams_variant() {
+        let json = serde_json::to_string(&WireAuthRevocation::Grant(GrantId::generate())).unwrap();
+        assert!(json.contains("grant"));
+        assert!(!json.contains("all"));
+    }
+
+    async fn receive_revocation(
+        receiver: &mut broadcast::Receiver<AuthRevocation>,
+    ) -> AuthRevocation {
+        timeout(Duration::from_secs(5), receiver.recv())
+            .await
+            .expect("timed out waiting for auth revocation")
+            .expect("auth revocation channel unexpectedly closed")
+    }
+
+    async fn listener_backend_pid(pool: &PgPool) -> i32 {
+        timeout(Duration::from_secs(5), async {
+            loop {
+                let pid = sqlx::query_scalar::<_, i32>(
+                    "SELECT pid FROM pg_stat_activity \
+                     WHERE datname = current_database() \
+                       AND pid <> pg_backend_pid() \
+                       AND query = $1",
+                )
+                .bind(format!("LISTEN \"{PG_AUTH_REVOCATION_CHANNEL}\""))
+                .fetch_optional(pool)
+                .await
+                .expect("query listener backend");
+
+                if let Some(pid) = pid {
+                    return pid;
+                }
+
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("timed out waiting for listener backend")
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn listeners_on_two_instances_receive_the_same_revocation() {
+        let db = SqlDb::test().await;
+        let service_a = AuthRevocationService::new();
+        let _listener_a = PgAuthRevocationListener::start(db.pool(), service_a.clone())
+            .await
+            .unwrap();
+        let service_b = AuthRevocationService::new();
+        let _listener_b = PgAuthRevocationListener::start(db.pool(), service_b.clone())
+            .await
+            .unwrap();
+        let mut receiver_a = service_a.subscribe().unwrap();
+        let mut receiver_b = service_b.subscribe().unwrap();
+
+        let payload = serde_json::to_string(&WireAuthRevocation::CookieSession(42)).unwrap();
+        sqlx::query("SELECT pg_notify($1, $2)")
+            .bind(PG_AUTH_REVOCATION_CHANNEL)
+            .bind(payload)
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        assert_eq!(
+            receive_revocation(&mut receiver_a).await,
+            AuthRevocation::CookieSession(42)
+        );
+        assert_eq!(
+            receive_revocation(&mut receiver_b).await,
+            AuthRevocation::CookieSession(42)
+        );
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn listener_disconnect_closes_all_private_streams_before_reconnect() {
+        let db = SqlDb::test().await;
+        let service = AuthRevocationService::new();
+        let _listener = PgAuthRevocationListener::start(db.pool(), service.clone())
+            .await
+            .unwrap();
+        let mut receiver = service.subscribe().unwrap();
+
+        let listener_pid = listener_backend_pid(db.pool()).await;
+        let terminated: bool = sqlx::query_scalar("SELECT pg_terminate_backend($1)")
+            .bind(listener_pid)
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert!(
+            terminated,
+            "Postgres should terminate the listener connection"
+        );
+
+        assert_eq!(receive_revocation(&mut receiver).await, AuthRevocation::All);
+
+        // The listener reconnects asynchronously; accepting a new subscription
+        // only after that succeeds keeps the failure window fail-closed.
+        timeout(Duration::from_secs(5), async {
+            loop {
+                if service.subscribe().is_ok() {
+                    return;
+                }
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("listener should reconnect");
+    }
+}

--- a/pubky-homeserver/src/client_server/auth/revocation.rs
+++ b/pubky-homeserver/src/client_server/auth/revocation.rs
@@ -30,8 +30,12 @@ pub(crate) use listener::{AuthRevocationService, AuthRevocationUnavailable};
 /// Postgres channel used for committed authentication revocations.
 const PG_AUTH_REVOCATION_CHANNEL: &str = "auth_revocations";
 
-/// A local revocation signal for an active private stream.
-#[derive(Clone, Debug, PartialEq, Eq)]
+/// A committed authentication revocation forwarded to active private streams.
+///
+/// Cookie secrets and bearer tokens are deliberately not present in this
+/// payload. Postgres channel consumers only need stable database identifiers.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "id", rename_all = "snake_case")]
 pub(crate) enum AuthRevocation {
     /// A deprecated cookie session row was deleted.
     CookieSession(i32),
@@ -54,7 +58,7 @@ impl AuthRevocation {
         id: i32,
         executor: &mut UnifiedExecutor<'a>,
     ) -> Result<(), sqlx::Error> {
-        WireAuthRevocation::CookieSession(id)
+        Self::CookieSession(id)
             .notify_in_transaction(executor)
             .await
     }
@@ -64,24 +68,11 @@ impl AuthRevocation {
         id: &GrantId,
         executor: &mut UnifiedExecutor<'a>,
     ) -> Result<(), sqlx::Error> {
-        WireAuthRevocation::Grant(id.clone())
+        Self::Grant(id.clone())
             .notify_in_transaction(executor)
             .await
     }
-}
 
-/// Serializable form of an authentication revocation.
-///
-/// Cookie secrets and bearer tokens are deliberately not present in this
-/// payload. Postgres channel consumers only need stable database identifiers.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-#[serde(tag = "kind", content = "id", rename_all = "snake_case")]
-enum WireAuthRevocation {
-    CookieSession(i32),
-    Grant(GrantId),
-}
-
-impl WireAuthRevocation {
     /// Queue this notification in the caller's transaction.
     ///
     /// Postgres only delivers a `NOTIFY` at commit. Keeping this alongside the
@@ -100,15 +91,6 @@ impl WireAuthRevocation {
             .execute(con)
             .await?;
         Ok(())
-    }
-}
-
-impl From<WireAuthRevocation> for AuthRevocation {
-    fn from(value: WireAuthRevocation) -> Self {
-        match value {
-            WireAuthRevocation::CookieSession(id) => Self::CookieSession(id),
-            WireAuthRevocation::Grant(id) => Self::Grant(id),
-        }
     }
 }
 
@@ -148,5 +130,28 @@ mod tests {
         assert!(!AuthRevocation::CookieSession(8).matches(&cookie_session(7)));
         assert!(AuthRevocation::Grant(grant_id.clone()).matches(&grant_session(grant_id)));
         assert!(!AuthRevocation::CookieSession(7).matches(&grant_session(GrantId::generate())));
+    }
+
+    #[test]
+    fn revocations_have_a_stable_wire_format() {
+        let cases = [
+            (
+                AuthRevocation::CookieSession(7),
+                serde_json::json!({"kind": "cookie_session", "id": 7}),
+            ),
+            (
+                AuthRevocation::Grant(GrantId::parse("grant-id").unwrap()),
+                serde_json::json!({"kind": "grant", "id": "grant-id"}),
+            ),
+        ];
+
+        for (revocation, expected) in cases {
+            let serialized = serde_json::to_value(&revocation).unwrap();
+            assert_eq!(serialized, expected);
+            assert_eq!(
+                serde_json::from_value::<AuthRevocation>(serialized).unwrap(),
+                revocation
+            );
+        }
     }
 }

--- a/pubky-homeserver/src/client_server/auth/revocation.rs
+++ b/pubky-homeserver/src/client_server/auth/revocation.rs
@@ -10,30 +10,25 @@
 //! auth revocations do not, and therefore must fail closed on any listener
 //! gap. Sharing lifecycle and failure handling would make an event-listener
 //! disruption unnecessarily disconnect every private stream.
-
-use std::{
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-    time::Duration,
-};
+//!
+//! The current listener actor holds the broadcast sender, so anything that
+//! ends that actor closes every stream it handed a receiver to. The supervisor
+//! starts a replacement for the next subscription, and a replacement can never
+//! revive its predecessor's receivers.
 
 use pubky_common::auth::jws::GrantId;
 use serde::{Deserialize, Serialize};
-use sqlx::{postgres::PgListener, PgPool};
-use tokio::sync::broadcast;
-use tokio_util::sync::CancellationToken;
 
 use crate::persistence::sql::UnifiedExecutor;
 
 use super::AuthSession;
 
+mod listener;
+
+pub(crate) use listener::{AuthRevocationService, AuthRevocationUnavailable};
+
 /// Postgres channel used for committed authentication revocations.
 const PG_AUTH_REVOCATION_CHANNEL: &str = "auth_revocations";
-/// Sized to absorb short revocation bursts without forcing unrelated streams
-/// through a database revalidation round-trip.
-const AUTH_REVOCATION_CHANNEL_CAPACITY: usize = 1024;
 
 /// A local revocation signal for an active private stream.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -42,17 +37,12 @@ pub(crate) enum AuthRevocation {
     CookieSession(i32),
     /// A grant and all of its bearer sessions were revoked.
     Grant(GrantId),
-    /// The listener cannot guarantee that no notification was missed.
-    ///
-    /// This is intentionally local-only and never sent over Postgres.
-    All,
 }
 
 impl AuthRevocation {
     /// Return whether this signal invalidates `session`.
     pub(crate) fn matches(&self, session: &AuthSession) -> bool {
         match (self, session) {
-            (Self::All, _) => true,
             (Self::CookieSession(id), AuthSession::Cookie(cookie)) => id == &cookie.id,
             (Self::Grant(id), AuthSession::Grant(grant)) => id == &grant.grant_id,
             _ => false,
@@ -122,167 +112,6 @@ impl From<WireAuthRevocation> for AuthRevocation {
     }
 }
 
-/// Local fan-out service for committed authentication revocations.
-#[derive(Clone, Debug)]
-pub(crate) struct AuthRevocationService {
-    notifications: broadcast::Sender<AuthRevocation>,
-    listener_healthy: Arc<AtomicBool>,
-}
-
-impl AuthRevocationService {
-    pub(crate) fn new() -> Self {
-        let (sender, _) = broadcast::channel(AUTH_REVOCATION_CHANNEL_CAPACITY);
-        Self {
-            notifications: sender,
-            listener_healthy: Arc::new(AtomicBool::new(false)),
-        }
-    }
-
-    /// Subscribe before checking health so a listener failure cannot be missed
-    /// in the gap between the two operations.
-    pub(crate) fn subscribe(
-        &self,
-    ) -> Result<broadcast::Receiver<AuthRevocation>, AuthRevocationUnavailable> {
-        let receiver = self.notifications.subscribe();
-        if self.listener_healthy.load(Ordering::Acquire) {
-            Ok(receiver)
-        } else {
-            Err(AuthRevocationUnavailable)
-        }
-    }
-
-    fn broadcast(&self, revocation: AuthRevocation) {
-        // No receivers is normal when no private streams are connected.
-        let _ = self.notifications.send(revocation);
-    }
-
-    fn mark_healthy(&self) {
-        self.listener_healthy.store(true, Ordering::Release);
-    }
-
-    /// Stop all existing private streams before reconnecting. New private
-    /// streams are rejected until the next successful `LISTEN`.
-    fn mark_unhealthy(&self) {
-        self.listener_healthy.store(false, Ordering::Release);
-        self.broadcast(AuthRevocation::All);
-    }
-}
-
-/// The local listener is unavailable, so accepting a private long-lived stream
-/// could miss an already-committed revocation.
-#[derive(Debug)]
-pub(crate) struct AuthRevocationUnavailable;
-
-/// Background Postgres listener for [`AuthRevocationService`].
-pub(crate) struct PgAuthRevocationListener {
-    cancel: CancellationToken,
-}
-
-impl PgAuthRevocationListener {
-    /// Connect and issue `LISTEN` before returning so the app never starts
-    /// serving private streams without its revocation feed.
-    pub(crate) async fn start(
-        pool: &PgPool,
-        service: AuthRevocationService,
-    ) -> Result<Self, sqlx::Error> {
-        let listener = Self::connect(pool).await?;
-        service.mark_healthy();
-
-        let cancel = CancellationToken::new();
-        drop(tokio::spawn(Self::listen_loop(
-            pool.clone(),
-            service,
-            listener,
-            cancel.clone(),
-        )));
-
-        Ok(Self { cancel })
-    }
-
-    async fn connect(pool: &PgPool) -> Result<PgListener, sqlx::Error> {
-        let mut listener = PgListener::connect_with(pool).await?;
-        // `try_recv` must report a lost connection before sqlx reconnects, so
-        // existing private streams can be closed before a notification gap is
-        // silently accepted.
-        listener.eager_reconnect(false);
-        listener.listen(PG_AUTH_REVOCATION_CHANNEL).await?;
-        Ok(listener)
-    }
-
-    async fn listen_loop(
-        pool: PgPool,
-        service: AuthRevocationService,
-        mut listener: PgListener,
-        cancel: CancellationToken,
-    ) {
-        loop {
-            tokio::select! {
-                _ = cancel.cancelled() => return,
-                notification = listener.try_recv() => match notification {
-                    Ok(Some(notification)) => {
-                        match serde_json::from_str::<WireAuthRevocation>(notification.payload()) {
-                            Ok(revocation) => service.broadcast(revocation.into()),
-                            Err(error) => {
-                                tracing::error!(%error, "invalid auth revocation notification; closing private streams");
-                                service.broadcast(AuthRevocation::All);
-                            }
-                        }
-                    }
-                    Ok(None) => {
-                        tracing::error!("auth revocation listener connection was lost; closing private streams");
-                        service.mark_unhealthy();
-                        listener = match Self::reconnect(&pool, &service, &cancel).await {
-                            Some(listener) => listener,
-                            None => return,
-                        };
-                    }
-                    Err(error) => {
-                        tracing::error!(%error, "auth revocation listener failed; closing private streams");
-                        service.mark_unhealthy();
-                        listener = match Self::reconnect(&pool, &service, &cancel).await {
-                            Some(listener) => listener,
-                            None => return,
-                        };
-                    }
-                }
-            }
-        }
-    }
-
-    async fn reconnect(
-        pool: &PgPool,
-        service: &AuthRevocationService,
-        cancel: &CancellationToken,
-    ) -> Option<PgListener> {
-        loop {
-            tokio::select! {
-                _ = cancel.cancelled() => return None,
-                result = Self::connect(pool) => match result {
-                    Ok(listener) => {
-                        tracing::info!("auth revocation listener reconnected");
-                        service.mark_healthy();
-                        return Some(listener);
-                    }
-                    Err(error) => {
-                        tracing::error!(%error, "failed to reconnect auth revocation listener; retrying in 1s");
-                    }
-                }
-            }
-
-            tokio::select! {
-                _ = cancel.cancelled() => return None,
-                _ = tokio::time::sleep(Duration::from_secs(1)) => {}
-            }
-        }
-    }
-}
-
-impl Drop for PgAuthRevocationListener {
-    fn drop(&mut self) {
-        self.cancel.cancel();
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -290,10 +119,7 @@ mod tests {
         cookie::persistence::{SessionEntity, SessionSecret},
         grant::session::GrantSession,
     };
-    use crate::persistence::sql::SqlDb;
     use pubky_common::{capabilities::Capabilities, crypto::Keypair};
-    use std::time::Duration;
-    use tokio::time::{sleep, timeout};
 
     fn cookie_session(id: i32) -> AuthSession {
         AuthSession::Cookie(SessionEntity {
@@ -316,134 +142,11 @@ mod tests {
     }
 
     #[test]
-    fn dropping_listener_cancels_its_worker() {
-        let cancel = CancellationToken::new();
-        let worker_cancel = cancel.clone();
-        let listener = PgAuthRevocationListener { cancel };
-
-        drop(listener);
-
-        assert!(worker_cancel.is_cancelled());
-    }
-
-    #[test]
     fn revocations_match_only_their_own_authentication_method() {
         let grant_id = GrantId::generate();
         assert!(AuthRevocation::CookieSession(7).matches(&cookie_session(7)));
         assert!(!AuthRevocation::CookieSession(8).matches(&cookie_session(7)));
         assert!(AuthRevocation::Grant(grant_id.clone()).matches(&grant_session(grant_id)));
         assert!(!AuthRevocation::CookieSession(7).matches(&grant_session(GrantId::generate())));
-        assert!(AuthRevocation::All.matches(&cookie_session(7)));
-    }
-
-    #[test]
-    fn wire_payload_has_no_all_streams_variant() {
-        let json = serde_json::to_string(&WireAuthRevocation::Grant(GrantId::generate())).unwrap();
-        assert!(json.contains("grant"));
-        assert!(!json.contains("all"));
-    }
-
-    async fn receive_revocation(
-        receiver: &mut broadcast::Receiver<AuthRevocation>,
-    ) -> AuthRevocation {
-        timeout(Duration::from_secs(5), receiver.recv())
-            .await
-            .expect("timed out waiting for auth revocation")
-            .expect("auth revocation channel unexpectedly closed")
-    }
-
-    async fn listener_backend_pid(pool: &PgPool) -> i32 {
-        timeout(Duration::from_secs(5), async {
-            loop {
-                let pid = sqlx::query_scalar::<_, i32>(
-                    "SELECT pid FROM pg_stat_activity \
-                     WHERE datname = current_database() \
-                       AND pid <> pg_backend_pid() \
-                       AND query = $1",
-                )
-                .bind(format!("LISTEN \"{PG_AUTH_REVOCATION_CHANNEL}\""))
-                .fetch_optional(pool)
-                .await
-                .expect("query listener backend");
-
-                if let Some(pid) = pid {
-                    return pid;
-                }
-
-                sleep(Duration::from_millis(10)).await;
-            }
-        })
-        .await
-        .expect("timed out waiting for listener backend")
-    }
-
-    #[tokio::test]
-    #[pubky_test_utils::test]
-    async fn listeners_on_two_instances_receive_the_same_revocation() {
-        let db = SqlDb::test().await;
-        let service_a = AuthRevocationService::new();
-        let _listener_a = PgAuthRevocationListener::start(db.pool(), service_a.clone())
-            .await
-            .unwrap();
-        let service_b = AuthRevocationService::new();
-        let _listener_b = PgAuthRevocationListener::start(db.pool(), service_b.clone())
-            .await
-            .unwrap();
-        let mut receiver_a = service_a.subscribe().unwrap();
-        let mut receiver_b = service_b.subscribe().unwrap();
-
-        let payload = serde_json::to_string(&WireAuthRevocation::CookieSession(42)).unwrap();
-        sqlx::query("SELECT pg_notify($1, $2)")
-            .bind(PG_AUTH_REVOCATION_CHANNEL)
-            .bind(payload)
-            .execute(db.pool())
-            .await
-            .unwrap();
-
-        assert_eq!(
-            receive_revocation(&mut receiver_a).await,
-            AuthRevocation::CookieSession(42)
-        );
-        assert_eq!(
-            receive_revocation(&mut receiver_b).await,
-            AuthRevocation::CookieSession(42)
-        );
-    }
-
-    #[tokio::test]
-    #[pubky_test_utils::test]
-    async fn listener_disconnect_closes_all_private_streams_before_reconnect() {
-        let db = SqlDb::test().await;
-        let service = AuthRevocationService::new();
-        let _listener = PgAuthRevocationListener::start(db.pool(), service.clone())
-            .await
-            .unwrap();
-        let mut receiver = service.subscribe().unwrap();
-
-        let listener_pid = listener_backend_pid(db.pool()).await;
-        let terminated: bool = sqlx::query_scalar("SELECT pg_terminate_backend($1)")
-            .bind(listener_pid)
-            .fetch_one(db.pool())
-            .await
-            .unwrap();
-        assert!(
-            terminated,
-            "Postgres should terminate the listener connection"
-        );
-
-        assert_eq!(receive_revocation(&mut receiver).await, AuthRevocation::All);
-
-        // The listener reconnects asynchronously; accepting a new subscription
-        // only after that succeeds keeps the failure window fail-closed.
-        timeout(Duration::from_secs(5), async {
-            loop {
-                if service.subscribe().is_ok() {
-                    return;
-                }
-                sleep(Duration::from_millis(10)).await;
-            }
-        })
-        .await
-        .expect("listener should reconnect");
     }
 }

--- a/pubky-homeserver/src/client_server/auth/revocation.rs
+++ b/pubky-homeserver/src/client_server/auth/revocation.rs
@@ -22,7 +22,7 @@ use std::{
 use pubky_common::auth::jws::GrantId;
 use serde::{Deserialize, Serialize};
 use sqlx::{postgres::PgListener, PgPool};
-use tokio::{sync::broadcast, task::JoinHandle};
+use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 
 use crate::persistence::sql::UnifiedExecutor;
@@ -175,7 +175,6 @@ pub(crate) struct AuthRevocationUnavailable;
 
 /// Background Postgres listener for [`AuthRevocationService`].
 pub(crate) struct PgAuthRevocationListener {
-    handle: Option<JoinHandle<()>>,
     cancel: CancellationToken,
 }
 
@@ -190,18 +189,14 @@ impl PgAuthRevocationListener {
         service.mark_healthy();
 
         let cancel = CancellationToken::new();
-        let handle = {
-            let pool = pool.clone();
-            let cancel = cancel.clone();
-            tokio::spawn(async move {
-                Self::listen_loop(pool, service, listener, cancel).await;
-            })
-        };
+        drop(tokio::spawn(Self::listen_loop(
+            pool.clone(),
+            service,
+            listener,
+            cancel.clone(),
+        )));
 
-        Ok(Self {
-            handle: Some(handle),
-            cancel,
-        })
+        Ok(Self { cancel })
     }
 
     async fn connect(pool: &PgPool) -> Result<PgListener, sqlx::Error> {
@@ -285,9 +280,6 @@ impl PgAuthRevocationListener {
 impl Drop for PgAuthRevocationListener {
     fn drop(&mut self) {
         self.cancel.cancel();
-        if let Some(handle) = self.handle.take() {
-            handle.abort();
-        }
     }
 }
 
@@ -321,6 +313,17 @@ mod tests {
             grant_id: id,
             token_expires_at: u64::MAX,
         })
+    }
+
+    #[test]
+    fn dropping_listener_cancels_its_worker() {
+        let cancel = CancellationToken::new();
+        let worker_cancel = cancel.clone();
+        let listener = PgAuthRevocationListener { cancel };
+
+        drop(listener);
+
+        assert!(worker_cancel.is_cancelled());
     }
 
     #[test]

--- a/pubky-homeserver/src/client_server/auth/revocation.rs
+++ b/pubky-homeserver/src/client_server/auth/revocation.rs
@@ -122,26 +122,19 @@ impl From<WireAuthRevocation> for AuthRevocation {
     }
 }
 
-#[derive(Debug)]
-struct AuthRevocationInner {
-    sender: broadcast::Sender<AuthRevocation>,
-    listener_healthy: AtomicBool,
-}
-
 /// Local fan-out service for committed authentication revocations.
 #[derive(Clone, Debug)]
 pub(crate) struct AuthRevocationService {
-    inner: Arc<AuthRevocationInner>,
+    notifications: broadcast::Sender<AuthRevocation>,
+    listener_healthy: Arc<AtomicBool>,
 }
 
 impl AuthRevocationService {
     pub(crate) fn new() -> Self {
         let (sender, _) = broadcast::channel(AUTH_REVOCATION_CHANNEL_CAPACITY);
         Self {
-            inner: Arc::new(AuthRevocationInner {
-                sender,
-                listener_healthy: AtomicBool::new(false),
-            }),
+            notifications: sender,
+            listener_healthy: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -150,8 +143,8 @@ impl AuthRevocationService {
     pub(crate) fn subscribe(
         &self,
     ) -> Result<broadcast::Receiver<AuthRevocation>, AuthRevocationUnavailable> {
-        let receiver = self.inner.sender.subscribe();
-        if self.inner.listener_healthy.load(Ordering::Acquire) {
+        let receiver = self.notifications.subscribe();
+        if self.listener_healthy.load(Ordering::Acquire) {
             Ok(receiver)
         } else {
             Err(AuthRevocationUnavailable)
@@ -160,17 +153,17 @@ impl AuthRevocationService {
 
     fn broadcast(&self, revocation: AuthRevocation) {
         // No receivers is normal when no private streams are connected.
-        let _ = self.inner.sender.send(revocation);
+        let _ = self.notifications.send(revocation);
     }
 
     fn mark_healthy(&self) {
-        self.inner.listener_healthy.store(true, Ordering::Release);
+        self.listener_healthy.store(true, Ordering::Release);
     }
 
     /// Stop all existing private streams before reconnecting. New private
     /// streams are rejected until the next successful `LISTEN`.
     fn mark_unhealthy(&self) {
-        self.inner.listener_healthy.store(false, Ordering::Release);
+        self.listener_healthy.store(false, Ordering::Release);
         self.broadcast(AuthRevocation::All);
     }
 }

--- a/pubky-homeserver/src/client_server/auth/revocation.rs
+++ b/pubky-homeserver/src/client_server/auth/revocation.rs
@@ -115,12 +115,12 @@ mod tests {
     }
 
     fn grant_session(id: GrantId) -> AuthSession {
-        AuthSession::Grant(GrantSession {
-            user_key: Keypair::random().public_key(),
-            capabilities: Capabilities::default(),
-            grant_id: id,
-            token_expires_at: u64::MAX,
-        })
+        AuthSession::Grant(GrantSession::test(
+            Keypair::random().public_key(),
+            Capabilities::default(),
+            id,
+            u64::MAX,
+        ))
     }
 
     #[test]

--- a/pubky-homeserver/src/client_server/auth/revocation/listener.rs
+++ b/pubky-homeserver/src/client_server/auth/revocation/listener.rs
@@ -6,7 +6,7 @@ use tokio::{
     time::Instant,
 };
 
-use super::{AuthRevocation, WireAuthRevocation, PG_AUTH_REVOCATION_CHANNEL};
+use super::{AuthRevocation, PG_AUTH_REVOCATION_CHANNEL};
 
 /// Sized to absorb short revocation bursts without forcing unrelated streams
 /// through a database revalidation round-trip.
@@ -173,10 +173,10 @@ impl ListenerActor {
                 },
                 notification = self.listener.try_recv() => match notification {
                     Ok(Some(notification)) => {
-                        match serde_json::from_str::<WireAuthRevocation>(notification.payload()) {
+                        match serde_json::from_str::<AuthRevocation>(notification.payload()) {
                             Ok(revocation) => {
                                 // No receivers is normal when no private streams are connected.
-                                let _ = self.notifications.send(revocation.into());
+                                let _ = self.notifications.send(revocation);
                             }
                             // The payload could be a revocation this instance would
                             // otherwise ignore, so it is not safe to skip.
@@ -245,7 +245,7 @@ mod tests {
     }
 
     async fn notify_cookie_revocation(pool: &PgPool, id: i32) {
-        let payload = serde_json::to_string(&WireAuthRevocation::CookieSession(id))
+        let payload = serde_json::to_string(&AuthRevocation::CookieSession(id))
             .expect("serialize revocation");
         notify(pool, &payload).await;
     }

--- a/pubky-homeserver/src/client_server/auth/revocation/listener.rs
+++ b/pubky-homeserver/src/client_server/auth/revocation/listener.rs
@@ -106,8 +106,8 @@ impl Supervisor {
 
 struct ListenerActor {
     listener: PgListener,
-    notifications: broadcast::Sender<AuthRevocation>,
-    lifetime: oneshot::Receiver<()>,
+    notifications_tx: broadcast::Sender<AuthRevocation>,
+    lifetime_rx: oneshot::Receiver<()>,
 }
 
 impl ListenerActor {
@@ -121,16 +121,16 @@ impl ListenerActor {
         listener.eager_reconnect(false);
         listener.listen(PG_AUTH_REVOCATION_CHANNEL).await?;
 
-        let (notifications, _) = broadcast::channel(AUTH_REVOCATION_CHANNEL_CAPACITY);
-        let (lifetime, actor_lifetime) = oneshot::channel();
+        let (notifications_tx, _) = broadcast::channel(AUTH_REVOCATION_CHANNEL_CAPACITY);
+        let (lifetime_tx, lifetime_rx) = oneshot::channel();
         let handle = ListenerActorHandle {
-            notifications: notifications.downgrade(),
-            _lifetime: lifetime,
+            notifications_tx: notifications_tx.downgrade(),
+            _lifetime_tx: lifetime_tx,
         };
         let actor = Self {
             listener,
-            notifications,
-            lifetime: actor_lifetime,
+            notifications_tx,
+            lifetime_rx,
         };
         drop(tokio::spawn(actor.run()));
 
@@ -142,13 +142,13 @@ impl ListenerActor {
     async fn run(mut self) {
         loop {
             tokio::select! {
-                _ = &mut self.lifetime => return,
+                _ = &mut self.lifetime_rx => return,
                 notification = self.listener.try_recv() => match notification {
                     Ok(Some(notification)) => {
                         match serde_json::from_str::<AuthRevocation>(notification.payload()) {
                             Ok(revocation) => {
                                 // No receivers is normal when no private streams are connected.
-                                let _ = self.notifications.send(revocation);
+                                let _ = self.notifications_tx.send(revocation);
                             }
                             // The payload could be a revocation this instance would
                             // otherwise ignore, so it is not safe to skip.
@@ -174,15 +174,15 @@ impl ListenerActor {
 
 #[derive(Debug)]
 struct ListenerActorHandle {
-    notifications: broadcast::WeakSender<AuthRevocation>,
-    _lifetime: oneshot::Sender<()>,
+    notifications_tx: broadcast::WeakSender<AuthRevocation>,
+    _lifetime_tx: oneshot::Sender<()>,
 }
 
 impl ListenerActorHandle {
     fn subscribe(&self) -> Option<RevocationReceiver> {
-        self.notifications
+        self.notifications_tx
             .upgrade()
-            .map(|notifications| notifications.subscribe())
+            .map(|notifications_tx| notifications_tx.subscribe())
     }
 }
 

--- a/pubky-homeserver/src/client_server/auth/revocation/listener.rs
+++ b/pubky-homeserver/src/client_server/auth/revocation/listener.rs
@@ -1,8 +1,8 @@
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use sqlx::{postgres::PgListener, PgPool};
 use tokio::{
-    sync::{broadcast, mpsc, oneshot},
+    sync::{broadcast, oneshot, Mutex},
     time::Instant,
 };
 
@@ -11,8 +11,6 @@ use super::{AuthRevocation, PG_AUTH_REVOCATION_CHANNEL};
 /// Sized to absorb short revocation bursts without forcing unrelated streams
 /// through a database revalidation round-trip.
 const AUTH_REVOCATION_CHANNEL_CAPACITY: usize = 1024;
-/// Bounds pre-auth subscription work while the supervisor attempts recovery.
-const SUPERVISOR_MAILBOX_CAPACITY: usize = 64;
 /// This keeps a Postgres outage from turning request rate into connection-attempt rate:
 /// one attempt per window, and everyone else is told the listener is unavailable.
 const REPLACEMENT_COOLDOWN: Duration = Duration::from_secs(1);
@@ -28,7 +26,7 @@ type SubscriptionResult = Result<RevocationReceiver, AuthRevocationUnavailable>;
 /// Local fan-out service for committed authentication revocations.
 #[derive(Clone, Debug)]
 pub(crate) struct AuthRevocationService {
-    requests: mpsc::Sender<SupervisorRequest>,
+    supervisor: Arc<Mutex<Supervisor>>,
 }
 
 impl AuthRevocationService {
@@ -40,38 +38,25 @@ impl AuthRevocationService {
             actor: Some(ListenerActor::spawn(pool).await?),
             replacement_cooldown: ReplacementCooldown::default(),
         };
-        let (requests, mailbox) = mpsc::channel(SUPERVISOR_MAILBOX_CAPACITY);
-        // The supervisor deliberately holds no clone of this service: its
-        // mailbox closing is what shuts the whole chain down.
-        drop(tokio::spawn(supervisor.run(mailbox)));
-        Ok(Self { requests })
+        Ok(Self {
+            supervisor: Arc::new(Mutex::new(supervisor)),
+        })
     }
 
     pub(crate) async fn subscribe(&self) -> SubscriptionResult {
-        let (reply, response) = oneshot::channel();
-        self.requests
-            .try_send(SupervisorRequest { reply })
-            .map_err(|_| AuthRevocationUnavailable)?;
-        response.await.map_err(|_| AuthRevocationUnavailable)?
+        self.supervisor.lock().await.subscribe().await
     }
 }
 
-struct SupervisorRequest {
-    reply: oneshot::Sender<SubscriptionResult>,
-}
-
-struct ActorRequest {
-    reply: oneshot::Sender<RevocationReceiver>,
-}
-
 /// Serves subscriptions from one listener actor at a time.
+#[derive(Debug)]
 struct Supervisor {
     pool: PgPool,
     actor: Option<ListenerActorHandle>,
     replacement_cooldown: ReplacementCooldown,
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct ReplacementCooldown {
     last_attempt: Option<Instant>,
 }
@@ -93,25 +78,18 @@ impl ReplacementCooldown {
 }
 
 impl Supervisor {
-    async fn run(mut self, mut mailbox: mpsc::Receiver<SupervisorRequest>) {
-        while let Some(request) = mailbox.recv().await {
-            // Retaining the reply covers an actor that exits after accepting
-            // the subscription but before answering it.
-            let _ = request.reply.send(self.subscribe().await);
-        }
-    }
-
     async fn subscribe(&mut self) -> SubscriptionResult {
-        if let Some(handle) = self.actor.as_ref() {
-            if let Some(receiver) = handle.subscribe().await {
+        loop {
+            if let Some(receiver) = self.actor.as_ref().and_then(ListenerActorHandle::subscribe) {
                 return Ok(receiver);
             }
+
             self.actor = None;
+            self.replace().await?;
         }
-        self.replace().await
     }
 
-    async fn replace(&mut self) -> SubscriptionResult {
+    async fn replace(&mut self) -> Result<(), AuthRevocationUnavailable> {
         if !self.replacement_cooldown.try_start(Instant::now()) {
             return Err(AuthRevocationUnavailable);
         }
@@ -120,20 +98,16 @@ impl Supervisor {
             tracing::error!(%error, "failed to start the auth revocation listener");
             AuthRevocationUnavailable
         })?;
-        let receiver = replacement
-            .subscribe()
-            .await
-            .ok_or(AuthRevocationUnavailable)?;
         tracing::info!("started a replacement auth revocation listener");
         self.actor = Some(replacement);
-        Ok(receiver)
+        Ok(())
     }
 }
 
 struct ListenerActor {
     listener: PgListener,
     notifications: broadcast::Sender<AuthRevocation>,
-    mailbox: mpsc::Receiver<ActorRequest>,
+    lifetime: oneshot::Receiver<()>,
 }
 
 impl ListenerActor {
@@ -148,16 +122,19 @@ impl ListenerActor {
         listener.listen(PG_AUTH_REVOCATION_CHANNEL).await?;
 
         let (notifications, _) = broadcast::channel(AUTH_REVOCATION_CHANNEL_CAPACITY);
-        // The supervisor permits only one in-flight actor request.
-        let (requests, mailbox) = mpsc::channel(1);
+        let (lifetime, actor_lifetime) = oneshot::channel();
+        let handle = ListenerActorHandle {
+            notifications: notifications.downgrade(),
+            _lifetime: lifetime,
+        };
         let actor = Self {
             listener,
             notifications,
-            mailbox,
+            lifetime: actor_lifetime,
         };
         drop(tokio::spawn(actor.run()));
 
-        Ok(ListenerActorHandle { requests })
+        Ok(handle)
     }
 
     /// Forward notifications to this actor's subscribers until any gap makes
@@ -165,12 +142,7 @@ impl ListenerActor {
     async fn run(mut self) {
         loop {
             tokio::select! {
-                request = self.mailbox.recv() => match request {
-                    Some(ActorRequest { reply }) => {
-                        let _ = reply.send(self.notifications.subscribe());
-                    }
-                    None => return,
-                },
+                _ = &mut self.lifetime => return,
                 notification = self.listener.try_recv() => match notification {
                     Ok(Some(notification)) => {
                         match serde_json::from_str::<AuthRevocation>(notification.payload()) {
@@ -200,15 +172,17 @@ impl ListenerActor {
     }
 }
 
+#[derive(Debug)]
 struct ListenerActorHandle {
-    requests: mpsc::Sender<ActorRequest>,
+    notifications: broadcast::WeakSender<AuthRevocation>,
+    _lifetime: oneshot::Sender<()>,
 }
 
 impl ListenerActorHandle {
-    async fn subscribe(&self) -> Option<RevocationReceiver> {
-        let (reply, response) = oneshot::channel();
-        self.requests.send(ActorRequest { reply }).await.ok()?;
-        response.await.ok()
+    fn subscribe(&self) -> Option<RevocationReceiver> {
+        self.notifications
+            .upgrade()
+            .map(|notifications| notifications.subscribe())
     }
 }
 
@@ -360,12 +334,13 @@ mod tests {
         let pid = listener_backend_pid(db.pool()).await;
 
         drop(service);
-        assert!(
-            spare.subscribe().await.is_ok(),
-            "a remaining clone keeps the listener alive"
-        );
+        let mut receiver = spare
+            .subscribe()
+            .await
+            .expect("a remaining clone keeps the listener alive");
 
         drop(spare);
+        expect_closed(&mut receiver).await;
 
         timeout(Duration::from_secs(5), async {
             while listener_backend_pids(db.pool()).await.contains(&pid) {

--- a/pubky-homeserver/src/client_server/auth/revocation/listener.rs
+++ b/pubky-homeserver/src/client_server/auth/revocation/listener.rs
@@ -1,0 +1,378 @@
+use std::time::Duration;
+
+use sqlx::{postgres::PgListener, PgPool};
+use tokio::{
+    sync::{broadcast, mpsc, oneshot},
+    time::Instant,
+};
+
+use super::{AuthRevocation, WireAuthRevocation, PG_AUTH_REVOCATION_CHANNEL};
+
+/// Sized to absorb short revocation bursts without forcing unrelated streams
+/// through a database revalidation round-trip.
+const AUTH_REVOCATION_CHANNEL_CAPACITY: usize = 1024;
+/// Bounds pre-auth subscription work while the supervisor attempts recovery.
+const SUPERVISOR_MAILBOX_CAPACITY: usize = 64;
+/// This keeps a Postgres outage from turning request rate into connection-attempt rate:
+/// one attempt per window, and everyone else is told the listener is unavailable.
+const REPLACEMENT_COOLDOWN: Duration = Duration::from_secs(1);
+
+/// The local listener is unavailable, so accepting a private long-lived stream
+/// could miss an already-committed revocation.
+#[derive(Debug)]
+pub(crate) struct AuthRevocationUnavailable;
+
+type RevocationReceiver = broadcast::Receiver<AuthRevocation>;
+type SubscriptionResult = Result<RevocationReceiver, AuthRevocationUnavailable>;
+
+/// Local fan-out service for committed authentication revocations.
+#[derive(Clone, Debug)]
+pub(crate) struct AuthRevocationService {
+    requests: mpsc::Sender<SupervisorRequest>,
+}
+
+impl AuthRevocationService {
+    /// Start the supervisor with a listener already receiving, so the app never
+    /// starts serving private streams without its revocation feed.
+    pub(crate) async fn start(pool: &PgPool) -> Result<Self, sqlx::Error> {
+        let supervisor = Supervisor {
+            pool: pool.clone(),
+            actor: Some(ListenerActor::spawn(pool).await?),
+            replacement_cooldown: ReplacementCooldown::default(),
+        };
+        let (requests, mailbox) = mpsc::channel(SUPERVISOR_MAILBOX_CAPACITY);
+        // The supervisor deliberately holds no clone of this service: its
+        // mailbox closing is what shuts the whole chain down.
+        drop(tokio::spawn(supervisor.run(mailbox)));
+        Ok(Self { requests })
+    }
+
+    pub(crate) async fn subscribe(&self) -> SubscriptionResult {
+        let (reply, response) = oneshot::channel();
+        self.requests
+            .try_send(SupervisorRequest { reply })
+            .map_err(|_| AuthRevocationUnavailable)?;
+        response.await.map_err(|_| AuthRevocationUnavailable)?
+    }
+}
+
+struct SupervisorRequest {
+    reply: oneshot::Sender<SubscriptionResult>,
+}
+
+struct ActorRequest {
+    reply: oneshot::Sender<RevocationReceiver>,
+}
+
+/// Serves subscriptions from one listener actor at a time.
+struct Supervisor {
+    pool: PgPool,
+    actor: Option<ListenerActorHandle>,
+    replacement_cooldown: ReplacementCooldown,
+}
+
+#[derive(Default)]
+struct ReplacementCooldown {
+    last_attempt: Option<Instant>,
+}
+
+impl ReplacementCooldown {
+    /// Return whether a replacement may start now. Refused attempts do not
+    /// extend the current cooldown window.
+    fn try_start(&mut self, now: Instant) -> bool {
+        if self
+            .last_attempt
+            .is_some_and(|started| now.duration_since(started) < REPLACEMENT_COOLDOWN)
+        {
+            return false;
+        }
+
+        self.last_attempt = Some(now);
+        true
+    }
+}
+
+impl Supervisor {
+    async fn run(mut self, mut mailbox: mpsc::Receiver<SupervisorRequest>) {
+        while let Some(request) = mailbox.recv().await {
+            // Retaining the reply covers an actor that exits after accepting
+            // the subscription but before answering it.
+            let _ = request.reply.send(self.subscribe().await);
+        }
+    }
+
+    async fn subscribe(&mut self) -> SubscriptionResult {
+        if let Some(handle) = self.actor.as_ref() {
+            if let Some(receiver) = handle.subscribe().await {
+                return Ok(receiver);
+            }
+            self.actor = None;
+        }
+        self.replace().await
+    }
+
+    async fn replace(&mut self) -> SubscriptionResult {
+        if !self.replacement_cooldown.try_start(Instant::now()) {
+            return Err(AuthRevocationUnavailable);
+        }
+
+        let replacement = ListenerActor::spawn(&self.pool).await.map_err(|error| {
+            tracing::error!(%error, "failed to start the auth revocation listener");
+            AuthRevocationUnavailable
+        })?;
+        let receiver = replacement
+            .subscribe()
+            .await
+            .ok_or(AuthRevocationUnavailable)?;
+        tracing::info!("started a replacement auth revocation listener");
+        self.actor = Some(replacement);
+        Ok(receiver)
+    }
+}
+
+struct ListenerActor {
+    listener: PgListener,
+    notifications: broadcast::Sender<AuthRevocation>,
+    mailbox: mpsc::Receiver<ActorRequest>,
+}
+
+impl ListenerActor {
+    /// Connect and `LISTEN` before spawning, so a failure surfaces to the
+    /// caller instead of to a stream that already believes it is protected.
+    async fn spawn(pool: &PgPool) -> Result<ListenerActorHandle, sqlx::Error> {
+        let mut listener = PgListener::connect_with(pool).await?;
+        // `try_recv` must report a lost connection before sqlx reconnects, so
+        // existing private streams can be closed before a notification gap is
+        // silently accepted.
+        listener.eager_reconnect(false);
+        listener.listen(PG_AUTH_REVOCATION_CHANNEL).await?;
+
+        let (notifications, _) = broadcast::channel(AUTH_REVOCATION_CHANNEL_CAPACITY);
+        // The supervisor permits only one in-flight actor request.
+        let (requests, mailbox) = mpsc::channel(1);
+        let actor = Self {
+            listener,
+            notifications,
+            mailbox,
+        };
+        drop(tokio::spawn(actor.run()));
+
+        Ok(ListenerActorHandle { requests })
+    }
+
+    /// Forward notifications to this actor's subscribers until any gap makes
+    /// the feed unsafe. Dropping the actor closes all of its receivers.
+    async fn run(mut self) {
+        loop {
+            tokio::select! {
+                request = self.mailbox.recv() => match request {
+                    Some(ActorRequest { reply }) => {
+                        let _ = reply.send(self.notifications.subscribe());
+                    }
+                    None => return,
+                },
+                notification = self.listener.try_recv() => match notification {
+                    Ok(Some(notification)) => {
+                        match serde_json::from_str::<WireAuthRevocation>(notification.payload()) {
+                            Ok(revocation) => {
+                                // No receivers is normal when no private streams are connected.
+                                let _ = self.notifications.send(revocation.into());
+                            }
+                            // The payload could be a revocation this instance would
+                            // otherwise ignore, so it is not safe to skip.
+                            Err(error) => {
+                                tracing::error!(%error, "invalid auth revocation notification; closing private streams");
+                                return;
+                            }
+                        }
+                    }
+                    Ok(None) => {
+                        tracing::error!("auth revocation listener connection was lost; closing private streams");
+                        return;
+                    }
+                    Err(error) => {
+                        tracing::error!(%error, "auth revocation listener failed; closing private streams");
+                        return;
+                    }
+                },
+            }
+        }
+    }
+}
+
+struct ListenerActorHandle {
+    requests: mpsc::Sender<ActorRequest>,
+}
+
+impl ListenerActorHandle {
+    async fn subscribe(&self) -> Option<RevocationReceiver> {
+        let (reply, response) = oneshot::channel();
+        self.requests.send(ActorRequest { reply }).await.ok()?;
+        response.await.ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::persistence::sql::SqlDb;
+    use tokio::time::{sleep, timeout};
+
+    async fn receive_revocation(receiver: &mut RevocationReceiver) -> AuthRevocation {
+        timeout(Duration::from_secs(5), receiver.recv())
+            .await
+            .expect("timed out waiting for auth revocation")
+            .expect("auth revocation channel unexpectedly closed")
+    }
+
+    async fn expect_closed(receiver: &mut RevocationReceiver) {
+        let result = timeout(Duration::from_secs(5), receiver.recv())
+            .await
+            .expect("timed out waiting for the revocation channel to close");
+        assert!(
+            matches!(result, Err(broadcast::error::RecvError::Closed)),
+            "expected a closed revocation channel, got {result:?}"
+        );
+    }
+
+    async fn notify(pool: &PgPool, payload: &str) {
+        sqlx::query("SELECT pg_notify($1, $2)")
+            .bind(PG_AUTH_REVOCATION_CHANNEL)
+            .bind(payload)
+            .execute(pool)
+            .await
+            .expect("send notification");
+    }
+
+    async fn notify_cookie_revocation(pool: &PgPool, id: i32) {
+        let payload = serde_json::to_string(&WireAuthRevocation::CookieSession(id))
+            .expect("serialize revocation");
+        notify(pool, &payload).await;
+    }
+
+    async fn listener_backend_pids(pool: &PgPool) -> Vec<i32> {
+        sqlx::query_scalar::<_, i32>(
+            "SELECT pid FROM pg_stat_activity \
+             WHERE datname = current_database() \
+               AND pid <> pg_backend_pid() \
+               AND query = $1",
+        )
+        .bind(format!("LISTEN \"{PG_AUTH_REVOCATION_CHANNEL}\""))
+        .fetch_all(pool)
+        .await
+        .expect("query listener backends")
+    }
+
+    async fn listener_backend_pid(pool: &PgPool) -> i32 {
+        timeout(Duration::from_secs(5), async {
+            loop {
+                if let Some(pid) = listener_backend_pids(pool).await.first() {
+                    return *pid;
+                }
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("timed out waiting for listener backend")
+    }
+
+    #[test]
+    fn replacement_cooldown_throttles_without_extending_the_window() {
+        let mut cooldown = ReplacementCooldown::default();
+        let first_attempt = Instant::now();
+
+        assert!(cooldown.try_start(first_attempt));
+        assert!(!cooldown.try_start(first_attempt + REPLACEMENT_COOLDOWN - Duration::from_nanos(1)));
+        assert!(cooldown.try_start(first_attempt + REPLACEMENT_COOLDOWN));
+        assert!(!cooldown.try_start(first_attempt + REPLACEMENT_COOLDOWN));
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn listeners_on_two_instances_receive_the_same_revocation() {
+        let db = SqlDb::test().await;
+        let service_a = AuthRevocationService::start(db.pool()).await.unwrap();
+        let service_b = AuthRevocationService::start(db.pool()).await.unwrap();
+        let mut receiver_a = service_a.subscribe().await.unwrap();
+        let mut receiver_b = service_b.subscribe().await.unwrap();
+
+        notify_cookie_revocation(db.pool(), 42).await;
+
+        assert_eq!(
+            receive_revocation(&mut receiver_a).await,
+            AuthRevocation::CookieSession(42)
+        );
+        assert_eq!(
+            receive_revocation(&mut receiver_b).await,
+            AuthRevocation::CookieSession(42)
+        );
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn a_lost_connection_closes_private_streams_until_a_replacement_listener_takes_over() {
+        let db = SqlDb::test().await;
+        let service = AuthRevocationService::start(db.pool()).await.unwrap();
+        let mut orphaned = service.subscribe().await.unwrap();
+
+        let terminated: bool = sqlx::query_scalar("SELECT pg_terminate_backend($1)")
+            .bind(listener_backend_pid(db.pool()).await)
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert!(
+            terminated,
+            "Postgres should terminate the listener connection"
+        );
+
+        expect_closed(&mut orphaned).await;
+
+        let mut receiver = service
+            .subscribe()
+            .await
+            .expect("a later subscription should start a replacement listener");
+
+        notify_cookie_revocation(db.pool(), 42).await;
+        assert_eq!(
+            receive_revocation(&mut receiver).await,
+            AuthRevocation::CookieSession(42)
+        );
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn an_invalid_notification_payload_closes_private_streams() {
+        let db = SqlDb::test().await;
+        let service = AuthRevocationService::start(db.pool()).await.unwrap();
+        let mut receiver = service.subscribe().await.unwrap();
+
+        notify(db.pool(), "not-an-auth-revocation").await;
+
+        expect_closed(&mut receiver).await;
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn dropping_the_last_service_clone_releases_the_postgres_listener() {
+        let db = SqlDb::test().await;
+        let service = AuthRevocationService::start(db.pool()).await.unwrap();
+        let spare = service.clone();
+        let pid = listener_backend_pid(db.pool()).await;
+
+        drop(service);
+        assert!(
+            spare.subscribe().await.is_ok(),
+            "a remaining clone keeps the listener alive"
+        );
+
+        drop(spare);
+
+        timeout(Duration::from_secs(5), async {
+            while listener_backend_pids(db.pool()).await.contains(&pid) {
+                sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("timed out waiting for the listener connection to be released");
+    }
+}

--- a/pubky-homeserver/src/client_server/auth/state.rs
+++ b/pubky-homeserver/src/client_server/auth/state.rs
@@ -54,7 +54,7 @@ impl AuthState {
             }
             AuthSession::Grant(grant) => self
                 .grant_auth_service
-                .validate_active_grant_session(grant.token_expires_at, &grant.grant_id)
+                .validate_active_grant_session(grant)
                 .await
                 .map(|_| ())
                 .map_err(Into::into),

--- a/pubky-homeserver/src/client_server/auth/state.rs
+++ b/pubky-homeserver/src/client_server/auth/state.rs
@@ -54,8 +54,9 @@ impl AuthState {
             }
             AuthSession::Grant(grant) => self
                 .grant_auth_service
-                .validate_active_session(grant)
+                .validate_active_grant_session(grant.token_expires_at, &grant.grant_id)
                 .await
+                .map(|_| ())
                 .map_err(Into::into),
         }
     }

--- a/pubky-homeserver/src/client_server/auth/state.rs
+++ b/pubky-homeserver/src/client_server/auth/state.rs
@@ -3,9 +3,10 @@
 use super::cookie::verifier::CookieAuthVerifier;
 use crate::app_context::AppContext;
 use crate::observability::Metrics;
+use crate::shared::HttpResult;
 
 use super::cookie::service::CookieAuthService;
-use super::{GrantAuthService, SignupService};
+use super::{AuthSession, GrantAuthService, SignupService};
 
 /// Auth-specific state. Auth route handlers extract this instead of the
 /// global `AppState`, keeping the auth module fully self-contained.
@@ -36,6 +37,26 @@ impl AuthState {
                 signup_service,
             ),
             metrics: context.metrics.clone(),
+        }
+    }
+
+    /// Confirm that a session resolved by middleware is still valid immediately
+    /// before it authorizes a private long-lived stream.
+    pub(crate) async fn validate_private_stream_session(
+        &self,
+        session: &AuthSession,
+    ) -> HttpResult<()> {
+        match session {
+            AuthSession::Cookie(cookie) => {
+                self.cookie_auth_service
+                    .validate_active_session(cookie)
+                    .await
+            }
+            AuthSession::Grant(grant) => self
+                .grant_auth_service
+                .validate_active_session(grant)
+                .await
+                .map_err(Into::into),
         }
     }
 }

--- a/pubky-homeserver/src/client_server/auth/stream_auth.rs
+++ b/pubky-homeserver/src/client_server/auth/stream_auth.rs
@@ -1,6 +1,6 @@
 //! Authentication state and revocation handling for private event streams.
 
-use std::future;
+use std::future::{self, Future};
 
 use tokio::sync::broadcast;
 
@@ -71,7 +71,7 @@ pub(crate) enum StreamAuth {
 }
 
 #[derive(Debug, PartialEq, Eq)]
-pub(crate) enum RevocationSignal {
+enum RevocationSignal {
     Continue,
     Close,
     Revalidate,
@@ -118,16 +118,19 @@ impl StreamAuth {
         }
     }
 
-    /// Wait only for the next auth-revocation signal. Any database revalidation
-    /// happens after this future wins `select!`, so it cannot be cancelled by a
-    /// concurrently ready file event.
-    pub(crate) async fn next_revocation_signal(&mut self) -> RevocationSignal {
+    /// Wait for the next auth-revocation signal, then return the check that must
+    /// complete after this future wins `select!`. Keeping database revalidation
+    /// in the returned future prevents a ready file event from cancelling it.
+    pub(crate) async fn next_check<'a>(
+        &'a mut self,
+        auth_state: &'a AuthState,
+    ) -> impl Future<Output = bool> + 'a {
         let received = match self {
             Self::Private { revocation_rx, .. } => revocation_rx.recv().await,
             Self::Public => future::pending().await,
         };
 
-        match received {
+        let signal = match received {
             Ok(revocation) if self.matches(&revocation) => {
                 tracing::debug!("closing private event stream after auth revocation");
                 RevocationSignal::Close
@@ -137,6 +140,14 @@ impl StreamAuth {
             Err(broadcast::error::RecvError::Closed) => {
                 tracing::warn!("auth revocation receiver closed; closing private event stream");
                 RevocationSignal::Close
+            }
+        };
+
+        async move {
+            match signal {
+                RevocationSignal::Continue => true,
+                RevocationSignal::Close => false,
+                RevocationSignal::Revalidate => self.revalidate_session(auth_state).await,
             }
         }
     }
@@ -148,7 +159,7 @@ impl StreamAuth {
         }
     }
 
-    pub(crate) async fn revalidate_session(&self, auth_state: &AuthState) -> bool {
+    async fn revalidate_session(&self, auth_state: &AuthState) -> bool {
         let Self::Private { session, .. } = self else {
             return true;
         };
@@ -233,14 +244,13 @@ mod tests {
             .await
             .unwrap();
 
-        let signal = tokio::select! {
+        let check = tokio::select! {
             biased;
-            signal = stream_auth.next_revocation_signal() => signal,
+            check = stream_auth.next_check(&auth_state) => check,
             _ = future::ready(()) => panic!("ready event bypassed the lag signal"),
         };
 
-        assert_eq!(signal, RevocationSignal::Revalidate);
         lock.rollback().await.unwrap();
-        assert!(!stream_auth.revalidate_session(&auth_state).await);
+        assert!(!check.await);
     }
 }

--- a/pubky-homeserver/src/client_server/auth/stream_auth.rs
+++ b/pubky-homeserver/src/client_server/auth/stream_auth.rs
@@ -95,7 +95,8 @@ impl StreamAuth {
                 // Revalidate this stream's own credential instead of
                 // disconnecting every private stream after an unrelated burst.
                 Err(broadcast::error::TryRecvError::Lagged(_)) => {
-                    return RevocationSignal::Revalidate
+                    *revocation_rx = revocation_rx.resubscribe();
+                    return RevocationSignal::Revalidate;
                 }
                 Err(broadcast::error::TryRecvError::Closed) => return RevocationSignal::Close,
             }
@@ -136,7 +137,13 @@ impl StreamAuth {
                 RevocationSignal::Close
             }
             Ok(_) => RevocationSignal::Continue,
-            Err(broadcast::error::RecvError::Lagged(_)) => RevocationSignal::Revalidate,
+            Err(broadcast::error::RecvError::Lagged(_)) => {
+                let Self::Private { revocation_rx, .. } = self else {
+                    unreachable!("public streams never receive revocation signals")
+                };
+                *revocation_rx = revocation_rx.resubscribe();
+                RevocationSignal::Revalidate
+            }
             Err(broadcast::error::RecvError::Closed) => {
                 tracing::warn!("auth revocation receiver closed; closing private event stream");
                 RevocationSignal::Close
@@ -210,10 +217,10 @@ mod tests {
     }
 
     #[test]
-    fn lagged_revocation_receiver_requests_revalidation() {
+    fn lagged_revocation_receiver_resubscribes_before_revalidation() {
         let (sender, receiver) = broadcast::channel(1);
         sender.send(AuthRevocation::CookieSession(2)).unwrap();
-        sender.send(AuthRevocation::CookieSession(3)).unwrap();
+        sender.send(AuthRevocation::CookieSession(1)).unwrap();
         let mut stream_auth = StreamAuth::Private {
             session: Box::new(cookie_session()),
             revocation_rx: receiver,
@@ -222,6 +229,17 @@ mod tests {
         assert!(matches!(
             stream_auth.pending_revocation(),
             RevocationSignal::Revalidate
+        ));
+
+        let StreamAuth::Private { revocation_rx, .. } = &stream_auth else {
+            unreachable!()
+        };
+        assert!(revocation_rx.is_empty());
+
+        sender.send(AuthRevocation::CookieSession(1)).unwrap();
+        assert!(matches!(
+            stream_auth.pending_revocation(),
+            RevocationSignal::Close
         ));
     }
 
@@ -252,5 +270,10 @@ mod tests {
 
         lock.rollback().await.unwrap();
         assert!(!check.await);
+
+        let StreamAuth::Private { revocation_rx, .. } = &stream_auth else {
+            unreachable!()
+        };
+        assert!(revocation_rx.is_empty());
     }
 }

--- a/pubky-homeserver/src/client_server/auth/stream_auth.rs
+++ b/pubky-homeserver/src/client_server/auth/stream_auth.rs
@@ -11,8 +11,9 @@ use super::{
     AuthState,
 };
 
-/// Subscription state acquired before resolving middleware authentication.
-/// Subscribing first ensures a revocation cannot be missed in that gap.
+/// Subscription state acquired before final session validation.
+/// Revocations committed before subscribing are caught by validation; later
+/// ones are buffered by the receiver.
 pub(crate) enum PendingStreamAuth {
     Public,
     Private(broadcast::Receiver<AuthRevocation>),
@@ -69,33 +70,34 @@ pub(crate) enum StreamAuth {
     },
 }
 
-enum RevocationCheck {
-    Clear,
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum RevocationSignal {
+    Continue,
     Close,
     Revalidate,
 }
 
 impl StreamAuth {
-    fn pending_revocation(&mut self) -> RevocationCheck {
+    fn pending_revocation(&mut self) -> RevocationSignal {
         let Self::Private {
             session,
             revocation_rx,
         } = self
         else {
-            return RevocationCheck::Clear;
+            return RevocationSignal::Continue;
         };
 
         loop {
             match revocation_rx.try_recv() {
-                Ok(revocation) if revocation.matches(session) => return RevocationCheck::Close,
+                Ok(revocation) if revocation.matches(session) => return RevocationSignal::Close,
                 Ok(_) => continue,
-                Err(broadcast::error::TryRecvError::Empty) => return RevocationCheck::Clear,
+                Err(broadcast::error::TryRecvError::Empty) => return RevocationSignal::Continue,
                 // Revalidate this stream's own credential instead of
                 // disconnecting every private stream after an unrelated burst.
                 Err(broadcast::error::TryRecvError::Lagged(_)) => {
-                    return RevocationCheck::Revalidate
+                    return RevocationSignal::Revalidate
                 }
-                Err(broadcast::error::TryRecvError::Closed) => return RevocationCheck::Close,
+                Err(broadcast::error::TryRecvError::Closed) => return RevocationSignal::Close,
             }
         }
     }
@@ -105,9 +107,9 @@ impl StreamAuth {
     pub(crate) async fn is_valid(&mut self, auth_state: &AuthState) -> bool {
         loop {
             match self.pending_revocation() {
-                RevocationCheck::Clear => return true,
-                RevocationCheck::Close => return false,
-                RevocationCheck::Revalidate => {
+                RevocationSignal::Continue => return true,
+                RevocationSignal::Close => return false,
+                RevocationSignal::Revalidate => {
                     if !self.revalidate_session(auth_state).await {
                         return false;
                     }
@@ -116,9 +118,10 @@ impl StreamAuth {
         }
     }
 
-    /// Wait for the next auth-revocation signal and return whether the stream
-    /// must close. Public streams wait forever because they are unaffected.
-    pub(crate) async fn handle_next_revocation(&mut self, auth_state: &AuthState) -> bool {
+    /// Wait only for the next auth-revocation signal. Any database revalidation
+    /// happens after this future wins `select!`, so it cannot be cancelled by a
+    /// concurrently ready file event.
+    pub(crate) async fn next_revocation_signal(&mut self) -> RevocationSignal {
         let received = match self {
             Self::Private { revocation_rx, .. } => revocation_rx.recv().await,
             Self::Public => future::pending().await,
@@ -127,15 +130,13 @@ impl StreamAuth {
         match received {
             Ok(revocation) if self.matches(&revocation) => {
                 tracing::debug!("closing private event stream after auth revocation");
-                true
+                RevocationSignal::Close
             }
-            Ok(_) => false,
-            Err(broadcast::error::RecvError::Lagged(_)) => {
-                !self.revalidate_session(auth_state).await
-            }
+            Ok(_) => RevocationSignal::Continue,
+            Err(broadcast::error::RecvError::Lagged(_)) => RevocationSignal::Revalidate,
             Err(broadcast::error::RecvError::Closed) => {
                 tracing::warn!("auth revocation receiver closed; closing private event stream");
-                true
+                RevocationSignal::Close
             }
         }
     }
@@ -147,7 +148,7 @@ impl StreamAuth {
         }
     }
 
-    async fn revalidate_session(&self, auth_state: &AuthState) -> bool {
+    pub(crate) async fn revalidate_session(&self, auth_state: &AuthState) -> bool {
         let Self::Private { session, .. } = self else {
             return true;
         };
@@ -193,7 +194,7 @@ mod tests {
 
         assert!(matches!(
             stream_auth.pending_revocation(),
-            RevocationCheck::Close
+            RevocationSignal::Close
         ));
     }
 
@@ -209,14 +210,15 @@ mod tests {
 
         assert!(matches!(
             stream_auth.pending_revocation(),
-            RevocationCheck::Revalidate
+            RevocationSignal::Revalidate
         ));
     }
 
     #[tokio::test]
     #[pubky_test_utils::test]
-    async fn live_lag_revalidates_when_matching_revocation_was_evicted() {
-        let auth_state = AuthState::new(&AppContext::test().await);
+    async fn live_lag_revalidation_is_not_cancelled_by_a_ready_event() {
+        let context = AppContext::test().await;
+        let auth_state = AuthState::new(&context);
         let (sender, receiver) = broadcast::channel(1);
         sender.send(AuthRevocation::CookieSession(1)).unwrap();
         sender.send(AuthRevocation::CookieSession(2)).unwrap();
@@ -225,6 +227,20 @@ mod tests {
             revocation_rx: receiver,
         };
 
-        assert!(stream_auth.handle_next_revocation(&auth_state).await);
+        let mut lock = context.sql_db.pool().begin().await.unwrap();
+        sqlx::query("LOCK TABLE sessions IN ACCESS EXCLUSIVE MODE")
+            .execute(&mut *lock)
+            .await
+            .unwrap();
+
+        let signal = tokio::select! {
+            biased;
+            signal = stream_auth.next_revocation_signal() => signal,
+            _ = future::ready(()) => panic!("ready event bypassed the lag signal"),
+        };
+
+        assert_eq!(signal, RevocationSignal::Revalidate);
+        lock.rollback().await.unwrap();
+        assert!(!stream_auth.revalidate_session(&auth_state).await);
     }
 }

--- a/pubky-homeserver/src/client_server/auth/stream_auth.rs
+++ b/pubky-homeserver/src/client_server/auth/stream_auth.rs
@@ -19,12 +19,14 @@ pub(crate) enum PendingStreamAuth {
 }
 
 impl PendingStreamAuth {
-    pub(crate) fn subscribe(
+    /// Take a revocation receiver for a private stream. A public stream is not
+    /// tied to a credential, so it never waits on the listener.
+    pub(crate) async fn subscribe(
         is_private: bool,
         service: &AuthRevocationService,
     ) -> Result<Self, AuthRevocationUnavailable> {
         if is_private {
-            Ok(Self::Private(service.subscribe()?))
+            Ok(Self::Private(service.subscribe().await?))
         } else {
             Ok(Self::Public)
         }

--- a/pubky-homeserver/src/client_server/auth/stream_auth.rs
+++ b/pubky-homeserver/src/client_server/auth/stream_auth.rs
@@ -1,0 +1,209 @@
+//! Authentication state and revocation handling for private event streams.
+
+use std::future;
+
+use tokio::sync::broadcast;
+
+use crate::shared::{HttpError, HttpResult};
+
+use super::{
+    revocation::AuthRevocationUnavailable, AuthRevocation, AuthRevocationService, AuthSession,
+    AuthState,
+};
+
+/// Subscription state acquired before resolving middleware authentication.
+/// Subscribing first ensures a revocation cannot be missed in that gap.
+pub(crate) enum PendingStreamAuth {
+    Public,
+    Private(broadcast::Receiver<AuthRevocation>),
+}
+
+impl PendingStreamAuth {
+    pub(crate) fn subscribe(
+        is_private: bool,
+        service: &AuthRevocationService,
+    ) -> Result<Self, AuthRevocationUnavailable> {
+        if is_private {
+            Ok(Self::Private(service.subscribe()?))
+        } else {
+            Ok(Self::Public)
+        }
+    }
+
+    pub(crate) async fn authorize(
+        self,
+        session: Option<AuthSession>,
+        auth_state: &AuthState,
+    ) -> HttpResult<StreamAuth> {
+        let mut stream_auth = match (self, session) {
+            (Self::Private(revocation_rx), Some(session)) => {
+                auth_state.validate_private_stream_session(&session).await?;
+                StreamAuth::Private {
+                    session: Box::new(session),
+                    revocation_rx,
+                }
+            }
+            (Self::Private(_), None) => return Err(HttpError::unauthorized()),
+            (Self::Public, _) => StreamAuth::Public,
+        };
+
+        if stream_auth.is_valid(auth_state).await {
+            Ok(stream_auth)
+        } else {
+            Err(HttpError::unauthorized())
+        }
+    }
+}
+
+/// Authentication state held for the lifetime of an event stream.
+///
+/// Public streams do not wait for auth revocations. Private streams hold the
+/// credential that authorized them and their local revocation receiver.
+pub(crate) enum StreamAuth {
+    Public,
+    Private {
+        session: Box<AuthSession>,
+        revocation_rx: broadcast::Receiver<AuthRevocation>,
+    },
+}
+
+enum RevocationCheck {
+    Clear,
+    Close,
+    Revalidate,
+}
+
+impl StreamAuth {
+    fn pending_revocation(&mut self) -> RevocationCheck {
+        let Self::Private {
+            session,
+            revocation_rx,
+        } = self
+        else {
+            return RevocationCheck::Clear;
+        };
+
+        loop {
+            match revocation_rx.try_recv() {
+                Ok(revocation) if revocation.matches(session) => return RevocationCheck::Close,
+                Ok(_) => continue,
+                Err(broadcast::error::TryRecvError::Empty) => return RevocationCheck::Clear,
+                // Revalidate this stream's own credential instead of
+                // disconnecting every private stream after an unrelated burst.
+                Err(broadcast::error::TryRecvError::Lagged(_)) => {
+                    return RevocationCheck::Revalidate
+                }
+                Err(broadcast::error::TryRecvError::Closed) => return RevocationCheck::Close,
+            }
+        }
+    }
+
+    /// Drain buffered revocations before another event is emitted. A lagged
+    /// receiver only closes this stream when its own credential is invalid.
+    pub(crate) async fn is_valid(&mut self, auth_state: &AuthState) -> bool {
+        loop {
+            match self.pending_revocation() {
+                RevocationCheck::Clear => return true,
+                RevocationCheck::Close => return false,
+                RevocationCheck::Revalidate => {
+                    let Self::Private { session, .. } = self else {
+                        unreachable!("public streams cannot require revalidation");
+                    };
+
+                    if let Err(error) = auth_state.validate_private_stream_session(session).await {
+                        tracing::warn!(
+                            ?error,
+                            "auth revocation receiver lagged and private stream validation failed"
+                        );
+                        return false;
+                    }
+                }
+            }
+        }
+    }
+
+    /// Wait for the next auth-revocation signal and return whether the stream
+    /// must close. Public streams wait forever because they are unaffected.
+    pub(crate) async fn handle_next_revocation(&mut self, auth_state: &AuthState) -> bool {
+        let received = match self {
+            Self::Private { revocation_rx, .. } => revocation_rx.recv().await,
+            Self::Public => future::pending().await,
+        };
+
+        match received {
+            Ok(revocation) if self.matches(&revocation) => {
+                tracing::debug!("closing private event stream after auth revocation");
+                true
+            }
+            Ok(_) => false,
+            Err(broadcast::error::RecvError::Lagged(_)) => {
+                if self.is_valid(auth_state).await {
+                    false
+                } else {
+                    tracing::warn!("auth revocation receiver lagged and stream session is no longer valid; closing private event stream");
+                    true
+                }
+            }
+            Err(broadcast::error::RecvError::Closed) => {
+                tracing::warn!("auth revocation receiver closed; closing private event stream");
+                true
+            }
+        }
+    }
+
+    fn matches(&self, revocation: &AuthRevocation) -> bool {
+        match self {
+            Self::Private { session, .. } => revocation.matches(session),
+            Self::Public => false,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client_server::auth::cookie::persistence::{SessionEntity, SessionSecret};
+    use pubky_common::{capabilities::Capabilities, crypto::Keypair};
+
+    fn cookie_session() -> AuthSession {
+        AuthSession::Cookie(SessionEntity {
+            id: 1,
+            secret: SessionSecret::random(),
+            user_id: 1,
+            user_pubkey: Keypair::random().public_key(),
+            capabilities: Capabilities::default(),
+            created_at: chrono::Utc::now().naive_utc(),
+        })
+    }
+
+    #[test]
+    fn buffered_revocation_closes_a_private_stream_before_historical_replay() {
+        let (sender, receiver) = broadcast::channel(1);
+        sender.send(AuthRevocation::CookieSession(1)).unwrap();
+        let mut stream_auth = StreamAuth::Private {
+            session: Box::new(cookie_session()),
+            revocation_rx: receiver,
+        };
+
+        assert!(matches!(
+            stream_auth.pending_revocation(),
+            RevocationCheck::Close
+        ));
+    }
+
+    #[test]
+    fn lagged_revocation_receiver_requests_revalidation() {
+        let (sender, receiver) = broadcast::channel(1);
+        sender.send(AuthRevocation::CookieSession(2)).unwrap();
+        sender.send(AuthRevocation::CookieSession(3)).unwrap();
+        let mut stream_auth = StreamAuth::Private {
+            session: Box::new(cookie_session()),
+            revocation_rx: receiver,
+        };
+
+        assert!(matches!(
+            stream_auth.pending_revocation(),
+            RevocationCheck::Revalidate
+        ));
+    }
+}

--- a/pubky-homeserver/src/client_server/auth/stream_auth.rs
+++ b/pubky-homeserver/src/client_server/auth/stream_auth.rs
@@ -108,15 +108,7 @@ impl StreamAuth {
                 RevocationCheck::Clear => return true,
                 RevocationCheck::Close => return false,
                 RevocationCheck::Revalidate => {
-                    let Self::Private { session, .. } = self else {
-                        unreachable!("public streams cannot require revalidation");
-                    };
-
-                    if let Err(error) = auth_state.validate_private_stream_session(session).await {
-                        tracing::warn!(
-                            ?error,
-                            "auth revocation receiver lagged and private stream validation failed"
-                        );
+                    if !self.revalidate_session(auth_state).await {
                         return false;
                     }
                 }
@@ -139,12 +131,7 @@ impl StreamAuth {
             }
             Ok(_) => false,
             Err(broadcast::error::RecvError::Lagged(_)) => {
-                if self.is_valid(auth_state).await {
-                    false
-                } else {
-                    tracing::warn!("auth revocation receiver lagged and stream session is no longer valid; closing private event stream");
-                    true
-                }
+                !self.revalidate_session(auth_state).await
             }
             Err(broadcast::error::RecvError::Closed) => {
                 tracing::warn!("auth revocation receiver closed; closing private event stream");
@@ -159,11 +146,28 @@ impl StreamAuth {
             Self::Public => false,
         }
     }
+
+    async fn revalidate_session(&self, auth_state: &AuthState) -> bool {
+        let Self::Private { session, .. } = self else {
+            return true;
+        };
+
+        if let Err(error) = auth_state.validate_private_stream_session(session).await {
+            tracing::warn!(
+                ?error,
+                "auth revocation receiver lagged and private stream validation failed"
+            );
+            return false;
+        }
+
+        true
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::app_context::AppContext;
     use crate::client_server::auth::cookie::persistence::{SessionEntity, SessionSecret};
     use pubky_common::{capabilities::Capabilities, crypto::Keypair};
 
@@ -207,5 +211,20 @@ mod tests {
             stream_auth.pending_revocation(),
             RevocationCheck::Revalidate
         ));
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn live_lag_revalidates_when_matching_revocation_was_evicted() {
+        let auth_state = AuthState::new(&AppContext::test().await);
+        let (sender, receiver) = broadcast::channel(1);
+        sender.send(AuthRevocation::CookieSession(1)).unwrap();
+        sender.send(AuthRevocation::CookieSession(2)).unwrap();
+        let mut stream_auth = StreamAuth::Private {
+            session: Box::new(cookie_session()),
+            revocation_rx: receiver,
+        };
+
+        assert!(stream_auth.handle_next_revocation(&auth_state).await);
     }
 }

--- a/pubky-homeserver/src/client_server/middleware/rate_limiter/bandwidth_rate_limit.rs
+++ b/pubky-homeserver/src/client_server/middleware/rate_limiter/bandwidth_rate_limit.rs
@@ -324,12 +324,12 @@ mod tests {
     }
 
     fn auth_session(public_key: PublicKey) -> AuthSession {
-        AuthSession::Grant(GrantSession {
-            user_key: public_key,
-            capabilities: Capabilities::builder().cap(Capability::root()).finish(),
-            grant_id: GrantId::generate(),
-            token_expires_at: chrono::Utc::now().timestamp() as u64 + 3600,
-        })
+        AuthSession::Grant(GrantSession::test(
+            public_key,
+            Capabilities::builder().cap(Capability::root()).finish(),
+            GrantId::generate(),
+            chrono::Utc::now().timestamp() as u64 + 3600,
+        ))
     }
 
     #[tokio::test]

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -357,6 +357,7 @@ pub async fn feed_stream(
         matches!(tenant_scope, EventStreamTenantScope::PrivateSingleTenant(_)),
         &state.auth_revocation_service,
     )
+    .await
     .map_err(|_| {
         HttpError::new_with_message(
             StatusCode::SERVICE_UNAVAILABLE,

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -18,16 +18,15 @@ use axum::{
 use futures_util::stream::Stream;
 use pubky_common::{crypto::PublicKey, storage};
 use serde::Deserialize;
-use std::{collections::HashMap, convert::Infallible, future, time::Instant};
-use tokio::sync::broadcast;
+use std::{collections::HashMap, convert::Infallible, time::Instant};
 use tower_cookies::Cookies;
 use url::form_urlencoded;
 
 use crate::{
     client_server::{
         auth::{
-            grant::bearer::extract_bearer_token, has_read_permission, AuthRevocation, AuthSession,
-            AuthState,
+            grant::bearer::extract_bearer_token, has_read_permission, AuthSession,
+            PendingStreamAuth,
         },
         query_params::ListQueryParams,
         AppState,
@@ -92,33 +91,6 @@ enum EventStreamTenantScope<'a> {
     PublicOnly,
     PrivateSingleTenant(&'a PublicKey),
     PrivateUnsupported,
-}
-
-/// Authentication state held for the lifetime of a private event stream.
-struct PrivateStreamAuth {
-    session: AuthSession,
-    revocation_rx: broadcast::Receiver<AuthRevocation>,
-}
-
-/// A stream is either public or carries the state needed to enforce private
-/// stream revocation. This keeps those two cases disjoint rather than relying
-/// on correlated optional values.
-enum StreamAuth {
-    Public,
-    Private(Box<PrivateStreamAuth>),
-}
-
-/// Subscription state acquired before resolving middleware authentication.
-/// Subscribing first ensures a revocation cannot be missed in that gap.
-enum PendingStreamAuth {
-    Public,
-    Private(broadcast::Receiver<AuthRevocation>),
-}
-
-enum RevocationCheck {
-    Clear,
-    Close,
-    Revalidate,
 }
 
 impl<'a> EventStreamTenantScope<'a> {
@@ -381,19 +353,16 @@ pub async fn feed_stream(
 
     // Subscribe before resolving the auth context. A final DB validation below
     // closes the remaining middleware-to-subscription race for bearer auth.
-    let pending_stream_auth = match tenant_scope {
-        EventStreamTenantScope::PrivateSingleTenant(_) => {
-            PendingStreamAuth::Private(state.auth_revocation_service.subscribe().map_err(|_| {
-                HttpError::new_with_message(
-                    StatusCode::SERVICE_UNAVAILABLE,
-                    "Private event streams are temporarily unavailable",
-                )
-            })?)
-        }
-        EventStreamTenantScope::PublicOnly | EventStreamTenantScope::PrivateUnsupported => {
-            PendingStreamAuth::Public
-        }
-    };
+    let pending_stream_auth = PendingStreamAuth::subscribe(
+        matches!(tenant_scope, EventStreamTenantScope::PrivateSingleTenant(_)),
+        &state.auth_revocation_service,
+    )
+    .map_err(|_| {
+        HttpError::new_with_message(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Private event streams are temporarily unavailable",
+        )
+    })?;
 
     // Bearer auth disables the homeserver-addressed cookie fallback.
     let session = match session {
@@ -406,23 +375,9 @@ pub async fn feed_stream(
 
     let allowed_paths = authorized_paths(&params.paths, tenant_scope, session.as_ref())?;
 
-    let mut stream_auth = match (pending_stream_auth, session) {
-        (PendingStreamAuth::Private(revocation_rx), Some(session)) => {
-            state
-                .auth_state
-                .validate_private_stream_session(&session)
-                .await?;
-            StreamAuth::Private(Box::new(PrivateStreamAuth {
-                session,
-                revocation_rx,
-            }))
-        }
-        (PendingStreamAuth::Private(_), None) => return Err(HttpError::unauthorized()),
-        (PendingStreamAuth::Public, _) => StreamAuth::Public,
-    };
-    if !stream_auth_is_valid(&state.auth_state, &mut stream_auth).await {
-        return Err(HttpError::unauthorized());
-    }
+    let mut stream_auth = pending_stream_auth
+        .authorize(session, &state.auth_state)
+        .await?;
 
     let mut user_cursor_map =
         resolve_user_cursors(&params.user_cursors, &state.events_service, &state.sql_db)
@@ -440,7 +395,7 @@ pub async fn feed_stream(
 
         // Phase 1: Batch Mode
         loop {
-            if !stream_auth_is_valid(&state.auth_state, &mut stream_auth).await {
+            if !stream_auth.is_valid(&state.auth_state).await {
                 return;
             }
 
@@ -473,7 +428,7 @@ pub async fn feed_stream(
 
             // Stream each historical event
             for event in events {
-                if !stream_auth_is_valid(&state.auth_state, &mut stream_auth).await {
+                if !stream_auth.is_valid(&state.auth_state).await {
                     return;
                 }
 
@@ -516,27 +471,9 @@ pub async fn feed_stream(
             loop {
                 tokio::select! {
                     biased;
-                    revocation = next_revocation(&mut stream_auth) => {
-                        match revocation {
-                            Ok(revocation) => match &stream_auth {
-                                StreamAuth::Private(private) if revocation.matches(&private.session) => {
-                                    tracing::debug!("closing private event stream after auth revocation");
-                                    return;
-                                }
-                                StreamAuth::Private(_) => continue,
-                                StreamAuth::Public => unreachable!("public streams never wait for auth revocations"),
-                            }
-                            Err(broadcast::error::RecvError::Lagged(_)) => {
-                                if stream_auth_is_valid(&state.auth_state, &mut stream_auth).await {
-                                    continue;
-                                }
-                                tracing::warn!("auth revocation receiver lagged and stream session is no longer valid; closing private event stream");
-                                return;
-                            }
-                            Err(broadcast::error::RecvError::Closed) => {
-                                tracing::warn!("auth revocation receiver closed; closing private event stream");
-                                return;
-                            }
+                    should_close = stream_auth.handle_next_revocation(&state.auth_state) => {
+                        if should_close {
+                            return;
                         }
                     }
                     event = rx.recv() => match event {
@@ -627,58 +564,6 @@ async fn resolve_user_cursors(
 
 fn has_bearer_auth(headers: &HeaderMap) -> bool {
     extract_bearer_token(headers).has_bearer_scheme()
-}
-
-fn pending_revocation(private: &mut PrivateStreamAuth) -> RevocationCheck {
-    loop {
-        match private.revocation_rx.try_recv() {
-            Ok(revocation) if revocation.matches(&private.session) => {
-                return RevocationCheck::Close
-            }
-            Ok(_) => continue,
-            Err(broadcast::error::TryRecvError::Empty) => return RevocationCheck::Clear,
-            // Revalidate the stream's own credential instead of disconnecting
-            // every private stream after an unrelated revocation burst.
-            Err(broadcast::error::TryRecvError::Lagged(_)) => return RevocationCheck::Revalidate,
-            Err(broadcast::error::TryRecvError::Closed) => return RevocationCheck::Close,
-        }
-    }
-}
-
-/// Drain buffered revocations before emitting another event. A receiver lag
-/// only closes this stream when its own credential no longer validates.
-async fn stream_auth_is_valid(auth_state: &AuthState, stream_auth: &mut StreamAuth) -> bool {
-    let StreamAuth::Private(private) = stream_auth else {
-        return true;
-    };
-
-    loop {
-        match pending_revocation(private) {
-            RevocationCheck::Clear => return true,
-            RevocationCheck::Close => return false,
-            RevocationCheck::Revalidate => {
-                if let Err(error) = auth_state
-                    .validate_private_stream_session(&private.session)
-                    .await
-                {
-                    tracing::warn!(
-                        ?error,
-                        "auth revocation receiver lagged and private stream validation failed"
-                    );
-                    return false;
-                }
-            }
-        }
-    }
-}
-
-async fn next_revocation(
-    stream_auth: &mut StreamAuth,
-) -> Result<AuthRevocation, broadcast::error::RecvError> {
-    match stream_auth {
-        StreamAuth::Private(private) => private.revocation_rx.recv().await,
-        StreamAuth::Public => future::pending().await,
-    }
 }
 
 async fn resolve_tenant_cookie_session(
@@ -826,41 +711,6 @@ mod tests {
             );
             assert_eq!(has_bearer_auth(&headers), expected, "{value:?}");
         }
-    }
-
-    #[test]
-    fn buffered_revocation_closes_a_private_stream_before_historical_replay() {
-        let session = cookie_session(pk(), Capabilities::default());
-        let (sender, receiver) = broadcast::channel(1);
-        sender.send(AuthRevocation::CookieSession(1)).unwrap();
-        let mut private = PrivateStreamAuth {
-            session,
-            revocation_rx: receiver,
-        };
-
-        // Models a revocation that arrives after the endpoint subscribes but
-        // before its final session validation and historical replay begin.
-        assert!(matches!(
-            pending_revocation(&mut private),
-            RevocationCheck::Close
-        ));
-    }
-
-    #[test]
-    fn lagged_revocation_receiver_requests_revalidation() {
-        let session = cookie_session(pk(), Capabilities::default());
-        let (sender, receiver) = broadcast::channel(1);
-        sender.send(AuthRevocation::CookieSession(2)).unwrap();
-        sender.send(AuthRevocation::CookieSession(3)).unwrap();
-        let mut private = PrivateStreamAuth {
-            session,
-            revocation_rx: receiver,
-        };
-
-        assert!(matches!(
-            pending_revocation(&mut private),
-            RevocationCheck::Revalidate
-        ));
     }
 
     #[test]

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -26,7 +26,7 @@ use crate::{
     client_server::{
         auth::{
             grant::bearer::extract_bearer_token, has_read_permission, AuthSession,
-            PendingStreamAuth, RevocationSignal,
+            PendingStreamAuth,
         },
         query_params::ListQueryParams,
         AppState,
@@ -473,15 +473,9 @@ pub async fn feed_stream(
             loop {
                 tokio::select! {
                     biased;
-                    signal = stream_auth.next_revocation_signal() => {
-                        match signal {
-                            RevocationSignal::Continue => {}
-                            RevocationSignal::Close => return,
-                            RevocationSignal::Revalidate => {
-                                if !stream_auth.revalidate_session(&state.auth_state).await {
-                                    return;
-                                }
-                            }
+                    check = stream_auth.next_check(&state.auth_state) => {
+                        if !check.await {
+                            return;
                         }
                     }
                     event = rx.recv() => match event {

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -26,7 +26,7 @@ use crate::{
     client_server::{
         auth::{
             grant::bearer::extract_bearer_token, has_read_permission, AuthSession,
-            PendingStreamAuth,
+            PendingStreamAuth, RevocationSignal,
         },
         query_params::ListQueryParams,
         AppState,
@@ -351,8 +351,20 @@ pub async fn feed_stream(
         parse_query_params(raw_query.0.as_deref().unwrap_or("")).map_err(HttpError::from)?;
     let tenant_scope = EventStreamTenantScope::from_query(&params.paths, &params.user_cursors);
 
-    // Subscribe before resolving the auth context. A final DB validation below
-    // closes the remaining middleware-to-subscription race for bearer auth.
+    // Bearer auth disables the homeserver-addressed cookie fallback.
+    let session = match session {
+        Some(session) => Some(session),
+        None if !has_bearer_auth(&headers) => {
+            resolve_tenant_cookie_session(&state, &cookies, tenant_scope).await
+        }
+        None => None,
+    };
+
+    let allowed_paths = authorized_paths(&params.paths, tenant_scope, session.as_ref())?;
+
+    // Subscribe after path authorization but before the final DB validation.
+    // The validation catches revocations committed before this subscription;
+    // the receiver catches anything committed after it.
     let pending_stream_auth = PendingStreamAuth::subscribe(
         matches!(tenant_scope, EventStreamTenantScope::PrivateSingleTenant(_)),
         &state.auth_revocation_service,
@@ -364,17 +376,6 @@ pub async fn feed_stream(
             "Private event streams are temporarily unavailable",
         )
     })?;
-
-    // Bearer auth disables the homeserver-addressed cookie fallback.
-    let session = match session {
-        Some(session) => Some(session),
-        None if !has_bearer_auth(&headers) => {
-            resolve_tenant_cookie_session(&state, &cookies, tenant_scope).await
-        }
-        None => None,
-    };
-
-    let allowed_paths = authorized_paths(&params.paths, tenant_scope, session.as_ref())?;
 
     let mut stream_auth = pending_stream_auth
         .authorize(session, &state.auth_state)
@@ -472,9 +473,15 @@ pub async fn feed_stream(
             loop {
                 tokio::select! {
                     biased;
-                    should_close = stream_auth.handle_next_revocation(&state.auth_state) => {
-                        if should_close {
-                            return;
+                    signal = stream_auth.next_revocation_signal() => {
+                        match signal {
+                            RevocationSignal::Continue => {}
+                            RevocationSignal::Close => return,
+                            RevocationSignal::Revalidate => {
+                                if !stream_auth.revalidate_session(&state.auth_state).await {
+                                    return;
+                                }
+                            }
                         }
                     }
                     event = rx.recv() => match event {

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -18,13 +18,17 @@ use axum::{
 use futures_util::stream::Stream;
 use pubky_common::{crypto::PublicKey, storage};
 use serde::Deserialize;
-use std::{collections::HashMap, convert::Infallible, time::Instant};
+use std::{collections::HashMap, convert::Infallible, future, time::Instant};
+use tokio::sync::broadcast;
 use tower_cookies::Cookies;
 use url::form_urlencoded;
 
 use crate::{
     client_server::{
-        auth::{grant::bearer::extract_bearer_token, has_read_permission, AuthSession},
+        auth::{
+            grant::bearer::extract_bearer_token, has_read_permission, AuthRevocation, AuthSession,
+            AuthState,
+        },
         query_params::ListQueryParams,
         AppState,
     },
@@ -88,6 +92,33 @@ enum EventStreamTenantScope<'a> {
     PublicOnly,
     PrivateSingleTenant(&'a PublicKey),
     PrivateUnsupported,
+}
+
+/// Authentication state held for the lifetime of a private event stream.
+struct PrivateStreamAuth {
+    session: AuthSession,
+    revocation_rx: broadcast::Receiver<AuthRevocation>,
+}
+
+/// A stream is either public or carries the state needed to enforce private
+/// stream revocation. This keeps those two cases disjoint rather than relying
+/// on correlated optional values.
+enum StreamAuth {
+    Public,
+    Private(Box<PrivateStreamAuth>),
+}
+
+/// Subscription state acquired before resolving middleware authentication.
+/// Subscribing first ensures a revocation cannot be missed in that gap.
+enum PendingStreamAuth {
+    Public,
+    Private(broadcast::Receiver<AuthRevocation>),
+}
+
+enum RevocationCheck {
+    Clear,
+    Close,
+    Revalidate,
 }
 
 impl<'a> EventStreamTenantScope<'a> {
@@ -321,6 +352,14 @@ pub async fn feed(
 /// If a client cannot consume events fast enough in live mode, the broadcast channel will lag and the connection will be closed.
 /// It is recommended that low memory clients poll this endpoint: Ie `live=true` with a low `limit`
 ///
+/// ## Revocation Behavior
+/// A stream that includes a private path is bound to the cookie or grant that
+/// authorized it. It closes promptly when that credential is revoked. A mixed
+/// public/private subscription closes as a whole; public-only streams are not
+/// tied to authentication and remain unaffected. Credential expiry and bearer
+/// token rotation are enforced when opening a stream and do not terminate an
+/// already-open stream.
+///
 /// ## Response Format
 /// Each event is sent as an SSE message with the event type and multiline data:
 /// ```text
@@ -340,6 +379,22 @@ pub async fn feed_stream(
         parse_query_params(raw_query.0.as_deref().unwrap_or("")).map_err(HttpError::from)?;
     let tenant_scope = EventStreamTenantScope::from_query(&params.paths, &params.user_cursors);
 
+    // Subscribe before resolving the auth context. A final DB validation below
+    // closes the remaining middleware-to-subscription race for bearer auth.
+    let pending_stream_auth = match tenant_scope {
+        EventStreamTenantScope::PrivateSingleTenant(_) => {
+            PendingStreamAuth::Private(state.auth_revocation_service.subscribe().map_err(|_| {
+                HttpError::new_with_message(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "Private event streams are temporarily unavailable",
+                )
+            })?)
+        }
+        EventStreamTenantScope::PublicOnly | EventStreamTenantScope::PrivateUnsupported => {
+            PendingStreamAuth::Public
+        }
+    };
+
     // Bearer auth disables the homeserver-addressed cookie fallback.
     let session = match session {
         Some(session) => Some(session),
@@ -350,6 +405,24 @@ pub async fn feed_stream(
     };
 
     let allowed_paths = authorized_paths(&params.paths, tenant_scope, session.as_ref())?;
+
+    let mut stream_auth = match (pending_stream_auth, session) {
+        (PendingStreamAuth::Private(revocation_rx), Some(session)) => {
+            state
+                .auth_state
+                .validate_private_stream_session(&session)
+                .await?;
+            StreamAuth::Private(Box::new(PrivateStreamAuth {
+                session,
+                revocation_rx,
+            }))
+        }
+        (PendingStreamAuth::Private(_), None) => return Err(HttpError::unauthorized()),
+        (PendingStreamAuth::Public, _) => StreamAuth::Public,
+    };
+    if !stream_auth_is_valid(&state.auth_state, &mut stream_auth).await {
+        return Err(HttpError::unauthorized());
+    }
 
     let mut user_cursor_map =
         resolve_user_cursors(&params.user_cursors, &state.events_service, &state.sql_db)
@@ -367,6 +440,10 @@ pub async fn feed_stream(
 
         // Phase 1: Batch Mode
         loop {
+            if !stream_auth_is_valid(&state.auth_state, &mut stream_auth).await {
+                return;
+            }
+
             // Drain any buffered events before querying as they'll be included in this or a future database query
             while rx.try_recv().is_ok() {}
 
@@ -396,6 +473,10 @@ pub async fn feed_stream(
 
             // Stream each historical event
             for event in events {
+                if !stream_auth_is_valid(&state.auth_state, &mut stream_auth).await {
+                    return;
+                }
+
                 // Update the cursor for this specific user
                 user_cursor_map.insert(event.user_id, Some(event.cursor()));
 
@@ -433,8 +514,33 @@ pub async fn feed_stream(
             let half_capacity = state.events_service.channel_capacity() / 2;
 
             loop {
-                match rx.recv().await {
-                    Ok(event) => {
+                tokio::select! {
+                    biased;
+                    revocation = next_revocation(&mut stream_auth) => {
+                        match revocation {
+                            Ok(revocation) => match &stream_auth {
+                                StreamAuth::Private(private) if revocation.matches(&private.session) => {
+                                    tracing::debug!("closing private event stream after auth revocation");
+                                    return;
+                                }
+                                StreamAuth::Private(_) => continue,
+                                StreamAuth::Public => unreachable!("public streams never wait for auth revocations"),
+                            }
+                            Err(broadcast::error::RecvError::Lagged(_)) => {
+                                if stream_auth_is_valid(&state.auth_state, &mut stream_auth).await {
+                                    continue;
+                                }
+                                tracing::warn!("auth revocation receiver lagged and stream session is no longer valid; closing private event stream");
+                                return;
+                            }
+                            Err(broadcast::error::RecvError::Closed) => {
+                                tracing::warn!("auth revocation receiver closed; closing private event stream");
+                                return;
+                            }
+                        }
+                    }
+                    event = rx.recv() => match event {
+                        Ok(event) => {
                         // Check if receiver queue is at half capacity (early warning of slow clients)
                         if rx.len() >= half_capacity {
                             state.metrics.record_broadcast_half_full();
@@ -460,15 +566,16 @@ pub async fn feed_stream(
                             }
                         }
                     }
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
-                        state.metrics.record_broadcast_lagged();
-                        tracing::warn!(
-                            "Slow client detected: broadcast channel lagged by {} events. Closing connection.",
-                            skipped
-                        );
-                        return;
+                        Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                            state.metrics.record_broadcast_lagged();
+                            tracing::warn!(
+                                "Slow client detected: broadcast channel lagged by {} events. Closing connection.",
+                                skipped
+                            );
+                            return;
+                        }
+                        Err(_) => break, // Channel closed
                     }
-                    Err(_) => break, // Channel closed
                 }
             }
         }
@@ -520,6 +627,58 @@ async fn resolve_user_cursors(
 
 fn has_bearer_auth(headers: &HeaderMap) -> bool {
     extract_bearer_token(headers).has_bearer_scheme()
+}
+
+fn pending_revocation(private: &mut PrivateStreamAuth) -> RevocationCheck {
+    loop {
+        match private.revocation_rx.try_recv() {
+            Ok(revocation) if revocation.matches(&private.session) => {
+                return RevocationCheck::Close
+            }
+            Ok(_) => continue,
+            Err(broadcast::error::TryRecvError::Empty) => return RevocationCheck::Clear,
+            // Revalidate the stream's own credential instead of disconnecting
+            // every private stream after an unrelated revocation burst.
+            Err(broadcast::error::TryRecvError::Lagged(_)) => return RevocationCheck::Revalidate,
+            Err(broadcast::error::TryRecvError::Closed) => return RevocationCheck::Close,
+        }
+    }
+}
+
+/// Drain buffered revocations before emitting another event. A receiver lag
+/// only closes this stream when its own credential no longer validates.
+async fn stream_auth_is_valid(auth_state: &AuthState, stream_auth: &mut StreamAuth) -> bool {
+    let StreamAuth::Private(private) = stream_auth else {
+        return true;
+    };
+
+    loop {
+        match pending_revocation(private) {
+            RevocationCheck::Clear => return true,
+            RevocationCheck::Close => return false,
+            RevocationCheck::Revalidate => {
+                if let Err(error) = auth_state
+                    .validate_private_stream_session(&private.session)
+                    .await
+                {
+                    tracing::warn!(
+                        ?error,
+                        "auth revocation receiver lagged and private stream validation failed"
+                    );
+                    return false;
+                }
+            }
+        }
+    }
+}
+
+async fn next_revocation(
+    stream_auth: &mut StreamAuth,
+) -> Result<AuthRevocation, broadcast::error::RecvError> {
+    match stream_auth {
+        StreamAuth::Private(private) => private.revocation_rx.recv().await,
+        StreamAuth::Public => future::pending().await,
+    }
 }
 
 async fn resolve_tenant_cookie_session(
@@ -667,6 +826,41 @@ mod tests {
             );
             assert_eq!(has_bearer_auth(&headers), expected, "{value:?}");
         }
+    }
+
+    #[test]
+    fn buffered_revocation_closes_a_private_stream_before_historical_replay() {
+        let session = cookie_session(pk(), Capabilities::default());
+        let (sender, receiver) = broadcast::channel(1);
+        sender.send(AuthRevocation::CookieSession(1)).unwrap();
+        let mut private = PrivateStreamAuth {
+            session,
+            revocation_rx: receiver,
+        };
+
+        // Models a revocation that arrives after the endpoint subscribes but
+        // before its final session validation and historical replay begin.
+        assert!(matches!(
+            pending_revocation(&mut private),
+            RevocationCheck::Close
+        ));
+    }
+
+    #[test]
+    fn lagged_revocation_receiver_requests_revalidation() {
+        let session = cookie_session(pk(), Capabilities::default());
+        let (sender, receiver) = broadcast::channel(1);
+        sender.send(AuthRevocation::CookieSession(2)).unwrap();
+        sender.send(AuthRevocation::CookieSession(3)).unwrap();
+        let mut private = PrivateStreamAuth {
+            session,
+            revocation_rx: receiver,
+        };
+
+        assert!(matches!(
+            pending_revocation(&mut private),
+            RevocationCheck::Revalidate
+        ));
     }
 
     #[test]

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -649,12 +649,12 @@ mod tests {
     }
 
     fn grant_session(user_key: PublicKey, capabilities: Capabilities) -> AuthSession {
-        AuthSession::Grant(GrantSession {
+        AuthSession::Grant(GrantSession::test(
             user_key,
             capabilities,
-            grant_id: GrantId::generate(),
-            token_expires_at: 9999999999,
-        })
+            GrantId::generate(),
+            9999999999,
+        ))
     }
 
     fn cookie_session(user_key: PublicKey, capabilities: Capabilities) -> AuthSession {


### PR DESCRIPTION
Closes #492.

### Summary

Private `/events-stream` subscriptions authorize their private paths when the connection opens, then keep using that authorization for the lifetime of the SSE stream. Before this change, revoking the cookie session or grant that opened the stream did not stop an already open connection from receiving subsequent private events.

This adds committed postgresql revocation notifications (thru LISTEN/NOTIFY) and local SSE signal so every homeserver instance closes affected private streams promptly after cookie signout or grant revocation.

Behavior:

- Cookie signout and grant revocation publish a Postgres `NOTIFY` in the same transaction as the database mutation.
- Each homeserver instance listens for revocations and forwards them to its local private SSE streams.
- A matching revocation closes the private stream before it can receive later matching events.
- If the auth listener disconnects or cannot guarantee no notification was missed, all local private streams close and new private subscriptions are rejected until reconnection succeeds.
- A lagged local revocation receiver revalidates only its own credential instead of disconnecting unrelated private streams.
- Public only streams do not subscribe to auth revocations and remain unaffected.
- Private stream path authorization remains fixed at subscription time, this does not widen access beyond the originally authorized paths.
- Credential expiry and bearer rotation are enforced when opening or reconnecting a stream, they do not terminate an open stream.

### Acceptance criteria

- [x] A live private stream opened with a grant closes after that grant is revoked and does not receive a later matching private event.
- [x] A live private stream opened with a cookie closes after that cookie session signs out and does not receive a later matching private event.
- [x] Cookie and grant revocations propagate across homeserver instances through PostgreSQL.
- [x] Auth-listener disconnection fails closed for existing and new private streams until reconnection.
- [x] Public event streams remain open and anonymous after unrelated auth revocations.
- [x] Private path access remains limited to the paths authorized when the subscription opened.
- [x] The long-lived SSE revocation and reconnect behavior is documented.