### PR TITLE
ci: update dependabot rust interval to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,15 @@ updates:
   - package-ecosystem: "cargo"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
       time: "08:00"
       day: "tuesday"
     commit-message:
       prefix: "deps"
     rebase-strategy: "auto"
+    # Cover both direct and transitive deps
+    allow:
+      - dependency-type: "all"
     groups:
       cargo-dependencies:
         patterns:


### PR DESCRIPTION
This PR updates the dependabot interval to weekly and also configures it to check and bump transitive dependencies.