### PR TITLE
ci: use rust-cache in `build-artifacts` job

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -10,6 +10,9 @@ on:
   push:
     branches: [main]
 
+env:
+  CROSS_REV: 51f46f296253d8122c927c5bb933e3c4f27cc317
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -26,14 +29,22 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
         with:
           # Cache Cargo downloads and installed tools, but exclude target artifacts.
           # Cross images tagged :latest may change and make restored artifacts incompatible.
           cache-targets: false
+
+          # Cache the installed cross executable by its pinned source revision.
+          # Changing CROSS_REV therefore creates a fresh cache entry.
+          # Include ImageOS to avoid runner glibc incompatibilities.
+          key: cross-${{ env.CROSS_REV }}
+          env-vars: ImageOS
+
       - name: Install cross # Tool to cross-compile the binaries
-        run: cargo install cross --locked --git https://github.com/cross-rs/cross --rev 51f46f296253d8122c927c5bb933e3c4f27cc317
+        run: cargo install cross --locked --git https://github.com/cross-rs/cross --rev "$CROSS_REV"
 
 
       # Build artifacts

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -28,6 +28,10 @@ jobs:
           toolchain: stable
       - name: Cache Rust
         uses: Swatinem/rust-cache@v2
+        with:
+          # Cache Cargo downloads and installed tools, but exclude target artifacts.
+          # Cross images tagged :latest may change and make restored artifacts incompatible.
+          cache-targets: false
       - name: Install cross # Tool to cross-compile the binaries
         run: cargo install cross --locked --git https://github.com/cross-rs/cross --rev 51f46f296253d8122c927c5bb933e3c4f27cc317
 
@@ -46,5 +50,3 @@ jobs:
           path: target/github-release.tar.gz
           if-no-files-found: error
           overwrite: true
-
-

--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -26,6 +26,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
       - name: Install cross # Tool to cross-compile the binaries
         run: cargo install cross --locked --git https://github.com/cross-rs/cross --rev 51f46f296253d8122c927c5bb933e3c4f27cc317
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -345,5 +345,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
       - name: Build Docker image
         run: docker build .

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -137,7 +137,7 @@ jobs:
         run: |
           set -e
           # nextest does not support doctests yet.
-          cargo test --doc -p ${{ matrix.crate }} --all-features 
+          cargo test --doc -p ${{ matrix.crate }} --all-features
 
           if cargo nextest run \
             -p ${{ matrix.crate }} \
@@ -345,7 +345,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
       - name: Build Docker image
         run: docker build .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,8 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
       - name: Install cross
         run: cargo install cross --locked --git https://github.com/cross-rs/cross --rev 51f46f296253d8122c927c5bb933e3c4f27cc317
       - name: Build Artifacts
@@ -101,6 +103,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
       - name: Install cargo-workspaces
@@ -121,6 +125,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@v2
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,6 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
       - name: Install cross
         run: cargo install cross --locked --git https://github.com/cross-rs/cross --rev 51f46f296253d8122c927c5bb933e3c4f27cc317
       - name: Build Artifacts
@@ -103,8 +101,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
       - uses: rust-lang/crates-io-auth-action@v1
         id: auth
       - name: Install cargo-workspaces
@@ -125,8 +121,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-      - name: Cache Rust
-        uses: Swatinem/rust-cache@v2
       - uses: actions/setup-node@v4
         with:
           node-version: '20'

--- a/.scripts/build-artifacts.sh
+++ b/.scripts/build-artifacts.sh
@@ -64,7 +64,7 @@ build_target() {
     # (build.rs) in a shared directory. Reusing a build script compiled in a
     # newer-glibc image inside an older-glibc image fails with
     # "GLIBC_X.YY not found".
-    TARGET_DIR="target/cross-$TARGET"
+    TARGET_DIR="target/cross/$TARGET"
 
     for ARTIFACT in "${ARTIFACTS[@]}"; do
         echo "- Build $ARTIFACT with $TARGET"

--- a/.scripts/build-artifacts.sh
+++ b/.scripts/build-artifacts.sh
@@ -38,7 +38,7 @@ TARGETS=(
 "aarch64-unknown-linux-musl,linux-arm64"
 "x86_64-unknown-linux-musl,linux-amd64"
 "x86_64-pc-windows-gnu,windows-amd64"
-"aarch64-apple-darwin,osx-arm64" 
+"aarch64-apple-darwin,osx-arm64"
 "x86_64-apple-darwin,osx-amd64"
 )
 
@@ -64,7 +64,7 @@ build_target() {
     # (build.rs) in a shared directory. Reusing a build script compiled in a
     # newer-glibc image inside an older-glibc image fails with
     # "GLIBC_X.YY not found".
-    TARGET_DIR="target/cross/$TARGET"
+    TARGET_DIR="target/cross-$TARGET"
 
     for ARTIFACT in "${ARTIFACTS[@]}"; do
         echo "- Build $ARTIFACT with $TARGET"


### PR DESCRIPTION
This PR partially addresses #486 by adding `Swatinem/rust-cache@v2` to the `build-artifacts` workflow, which runs on pushes to `main`.

### Cache scope

`rust-cache` caches Cargo registry data and installed tools, including the `cross` executable and Cargo installation metadata. On a warm cache hit, Cargo still resolves the pinned Git source but avoids recompiling and reinstalling `cross`.

The pinned `cross` revision is defined once as `CROSS_REV` and included in the cache key. Because GitHub cache entries are immutable, changing the revision creates a fresh cache instead of repeatedly restoring an outdated installation.

`ImageOS` is also included in the cache environment hash so the host-side `cross` executable is not shared across different Ubuntu runner generations and potentially incompatible glibc versions.

Workspace target-directory caching remains disabled. The Cross Docker images use mutable tags, so restored build scripts or artifacts may have been compiled against a different container image and glibc version. All five cross targets will therefore rebuild on each run, while Cargo downloads and the installed `cross` tool can still be reused.

The existing per-target build-directory layout is unchanged.