### PR TITLE
refactor(homeserver): Bring auth revocation concern inside of AuthState 

### DIFF
--- a/pubky-homeserver/src/app_context.rs
+++ b/pubky-homeserver/src/app_context.rs
@@ -9,7 +9,7 @@ use crate::services::user_service::UserService;
 #[cfg(any(test, feature = "testing"))]
 use crate::MockDataDir;
 use crate::{
-    client_server::auth::AuthRevocationService,
+    client_server::auth::RevocationListener,
     observability::{Metrics, MetricsInitError},
     persistence::{
         files::{events::EventsService, FileIoError, FileService},
@@ -48,9 +48,9 @@ pub enum AppContextConversionError {
     /// Failed to start the Postgres event listener.
     #[error("Failed to start Postgres event listener: {0}")]
     PgEventListener(sqlx::Error),
-    /// Failed to start the auth-revocation service.
-    #[error("Failed to start the auth revocation service: {0}")]
-    AuthRevocationService(sqlx::Error),
+    /// Failed to start the auth revocation listener.
+    #[error("Failed to start the auth revocation listener: {0}")]
+    RevocationListener(sqlx::Error),
     /// Failed to initialize metrics.
     #[error("Failed to initialize metrics: {0}")]
     Metrics(MetricsInitError),
@@ -87,7 +87,7 @@ pub struct AppContext {
     _pg_event_listener: Arc<PgEventListener>,
     /// Auth revocations are forwarded to private SSE streams on this instance.
     /// Its Postgres listener stops once the last clone is dropped.
-    pub(crate) auth_revocation_service: AuthRevocationService,
+    pub(crate) revocation_listener: RevocationListener,
     /// User service for quota resolution and user creation with defaults.
     pub(crate) user_service: UserService,
 }
@@ -126,9 +126,9 @@ impl AppContext {
         let pg_event_listener = PgEventListener::start(sql_db.pool(), events_service.clone())
             .await
             .map_err(AppContextConversionError::PgEventListener)?;
-        let auth_revocation_service = AuthRevocationService::start(sql_db.pool())
+        let revocation_listener = RevocationListener::start(sql_db.pool())
             .await
-            .map_err(AppContextConversionError::AuthRevocationService)?;
+            .map_err(AppContextConversionError::RevocationListener)?;
 
         let user_service = UserService::new(sql_db.clone());
 
@@ -156,7 +156,7 @@ impl AppContext {
             events_service,
             metrics: Metrics::new().map_err(AppContextConversionError::Metrics)?,
             _pg_event_listener: Arc::new(pg_event_listener),
-            auth_revocation_service,
+            revocation_listener,
             user_service,
         })
     }

--- a/pubky-homeserver/src/client_server/app.rs
+++ b/pubky-homeserver/src/client_server/app.rs
@@ -114,7 +114,6 @@ impl ClientServer {
     ) -> std::result::Result<Router, ClientServerBuildError> {
         let state = AppState {
             auth_state: auth::AuthState::new(context),
-            auth_revocation_service: context.auth_revocation_service.clone(),
             sql_db: context.sql_db.clone(),
             file_service: context.file_service.clone(),
             signup_mode: context.config_toml.general.signup_mode.clone(),

--- a/pubky-homeserver/src/client_server/app_state.rs
+++ b/pubky-homeserver/src/client_server/app_state.rs
@@ -1,6 +1,5 @@
 use axum::extract::FromRef;
 
-use crate::client_server::auth::AuthRevocationService;
 use crate::client_server::auth::AuthState;
 use crate::observability::Metrics;
 use crate::persistence::files::events::EventsService;
@@ -13,8 +12,6 @@ use crate::SignupMode;
 pub(crate) struct AppState {
     /// Auth sub-state (extracted via `FromRef` by auth handlers).
     pub(crate) auth_state: AuthState,
-    /// Cross-instance signals that close private SSE streams after revocation.
-    pub(crate) auth_revocation_service: AuthRevocationService,
     /// The SQL database connection.
     pub(crate) sql_db: SqlDb,
     pub(crate) file_service: FileService,

--- a/pubky-homeserver/src/client_server/auth/mod.rs
+++ b/pubky-homeserver/src/client_server/auth/mod.rs
@@ -27,7 +27,7 @@ pub use authorization::{has_read_permission, has_write_permission};
 pub use middleware::authentication::AuthenticationLayer;
 
 pub use grant::service::GrantAuthService;
-pub(crate) use revocation::{AuthRevocation, AuthRevocationService};
+pub(crate) use revocation::{AuthRevocation, RevocationListener};
 pub use router::{base_router, tenant_router};
 pub use session::AuthSession;
 pub use signup_service::{SignupService, SignupServiceError};

--- a/pubky-homeserver/src/client_server/auth/revocation.rs
+++ b/pubky-homeserver/src/client_server/auth/revocation.rs
@@ -25,7 +25,7 @@ use super::AuthSession;
 
 mod listener;
 
-pub(crate) use listener::{AuthRevocationService, AuthRevocationUnavailable};
+pub(crate) use listener::{RevocationListener, RevocationUnavailable};
 
 /// Postgres channel used for committed authentication revocations.
 const PG_AUTH_REVOCATION_CHANNEL: &str = "auth_revocations";

--- a/pubky-homeserver/src/client_server/auth/revocation/listener.rs
+++ b/pubky-homeserver/src/client_server/auth/revocation/listener.rs
@@ -18,18 +18,18 @@ const REPLACEMENT_COOLDOWN: Duration = Duration::from_secs(1);
 /// The local listener is unavailable, so accepting a private long-lived stream
 /// could miss an already-committed revocation.
 #[derive(Debug)]
-pub(crate) struct AuthRevocationUnavailable;
+pub(crate) struct RevocationUnavailable;
 
 type RevocationReceiver = broadcast::Receiver<AuthRevocation>;
-type SubscriptionResult = Result<RevocationReceiver, AuthRevocationUnavailable>;
+type SubscriptionResult = Result<RevocationReceiver, RevocationUnavailable>;
 
-/// Local fan-out service for committed authentication revocations.
+/// Local fan-out for committed authentication revocations.
 #[derive(Clone, Debug)]
-pub(crate) struct AuthRevocationService {
+pub(crate) struct RevocationListener {
     supervisor: Arc<Mutex<Supervisor>>,
 }
 
-impl AuthRevocationService {
+impl RevocationListener {
     /// Start the supervisor with a listener already receiving, so the app never
     /// starts serving private streams without its revocation feed.
     pub(crate) async fn start(pool: &PgPool) -> Result<Self, sqlx::Error> {
@@ -89,14 +89,14 @@ impl Supervisor {
         }
     }
 
-    async fn replace(&mut self) -> Result<(), AuthRevocationUnavailable> {
+    async fn replace(&mut self) -> Result<(), RevocationUnavailable> {
         if !self.replacement_cooldown.try_start(Instant::now()) {
-            return Err(AuthRevocationUnavailable);
+            return Err(RevocationUnavailable);
         }
 
         let replacement = ListenerActor::spawn(&self.pool).await.map_err(|error| {
             tracing::error!(%error, "failed to start the auth revocation listener");
-            AuthRevocationUnavailable
+            RevocationUnavailable
         })?;
         tracing::info!("started a replacement auth revocation listener");
         self.actor = Some(replacement);
@@ -265,8 +265,8 @@ mod tests {
     #[pubky_test_utils::test]
     async fn listeners_on_two_instances_receive_the_same_revocation() {
         let db = SqlDb::test().await;
-        let service_a = AuthRevocationService::start(db.pool()).await.unwrap();
-        let service_b = AuthRevocationService::start(db.pool()).await.unwrap();
+        let service_a = RevocationListener::start(db.pool()).await.unwrap();
+        let service_b = RevocationListener::start(db.pool()).await.unwrap();
         let mut receiver_a = service_a.subscribe().await.unwrap();
         let mut receiver_b = service_b.subscribe().await.unwrap();
 
@@ -286,7 +286,7 @@ mod tests {
     #[pubky_test_utils::test]
     async fn a_lost_connection_closes_private_streams_until_a_replacement_listener_takes_over() {
         let db = SqlDb::test().await;
-        let service = AuthRevocationService::start(db.pool()).await.unwrap();
+        let service = RevocationListener::start(db.pool()).await.unwrap();
         let mut orphaned = service.subscribe().await.unwrap();
 
         let terminated: bool = sqlx::query_scalar("SELECT pg_terminate_backend($1)")
@@ -317,7 +317,7 @@ mod tests {
     #[pubky_test_utils::test]
     async fn an_invalid_notification_payload_closes_private_streams() {
         let db = SqlDb::test().await;
-        let service = AuthRevocationService::start(db.pool()).await.unwrap();
+        let service = RevocationListener::start(db.pool()).await.unwrap();
         let mut receiver = service.subscribe().await.unwrap();
 
         notify(db.pool(), "not-an-auth-revocation").await;
@@ -329,7 +329,7 @@ mod tests {
     #[pubky_test_utils::test]
     async fn dropping_the_last_service_clone_releases_the_postgres_listener() {
         let db = SqlDb::test().await;
-        let service = AuthRevocationService::start(db.pool()).await.unwrap();
+        let service = RevocationListener::start(db.pool()).await.unwrap();
         let spare = service.clone();
         let pid = listener_backend_pid(db.pool()).await;
 

--- a/pubky-homeserver/src/client_server/auth/revocation/listener.rs
+++ b/pubky-homeserver/src/client_server/auth/revocation/listener.rs
@@ -265,10 +265,10 @@ mod tests {
     #[pubky_test_utils::test]
     async fn listeners_on_two_instances_receive_the_same_revocation() {
         let db = SqlDb::test().await;
-        let service_a = RevocationListener::start(db.pool()).await.unwrap();
-        let service_b = RevocationListener::start(db.pool()).await.unwrap();
-        let mut receiver_a = service_a.subscribe().await.unwrap();
-        let mut receiver_b = service_b.subscribe().await.unwrap();
+        let listener_a = RevocationListener::start(db.pool()).await.unwrap();
+        let listener_b = RevocationListener::start(db.pool()).await.unwrap();
+        let mut receiver_a = listener_a.subscribe().await.unwrap();
+        let mut receiver_b = listener_b.subscribe().await.unwrap();
 
         notify_cookie_revocation(db.pool(), 42).await;
 
@@ -286,8 +286,8 @@ mod tests {
     #[pubky_test_utils::test]
     async fn a_lost_connection_closes_private_streams_until_a_replacement_listener_takes_over() {
         let db = SqlDb::test().await;
-        let service = RevocationListener::start(db.pool()).await.unwrap();
-        let mut orphaned = service.subscribe().await.unwrap();
+        let listener = RevocationListener::start(db.pool()).await.unwrap();
+        let mut orphaned = listener.subscribe().await.unwrap();
 
         let terminated: bool = sqlx::query_scalar("SELECT pg_terminate_backend($1)")
             .bind(listener_backend_pid(db.pool()).await)
@@ -301,7 +301,7 @@ mod tests {
 
         expect_closed(&mut orphaned).await;
 
-        let mut receiver = service
+        let mut receiver = listener
             .subscribe()
             .await
             .expect("a later subscription should start a replacement listener");
@@ -317,8 +317,8 @@ mod tests {
     #[pubky_test_utils::test]
     async fn an_invalid_notification_payload_closes_private_streams() {
         let db = SqlDb::test().await;
-        let service = RevocationListener::start(db.pool()).await.unwrap();
-        let mut receiver = service.subscribe().await.unwrap();
+        let listener = RevocationListener::start(db.pool()).await.unwrap();
+        let mut receiver = listener.subscribe().await.unwrap();
 
         notify(db.pool(), "not-an-auth-revocation").await;
 
@@ -329,11 +329,11 @@ mod tests {
     #[pubky_test_utils::test]
     async fn dropping_the_last_service_clone_releases_the_postgres_listener() {
         let db = SqlDb::test().await;
-        let service = RevocationListener::start(db.pool()).await.unwrap();
-        let spare = service.clone();
+        let listener = RevocationListener::start(db.pool()).await.unwrap();
+        let spare = listener.clone();
         let pid = listener_backend_pid(db.pool()).await;
 
-        drop(service);
+        drop(listener);
         let mut receiver = spare
             .subscribe()
             .await

--- a/pubky-homeserver/src/client_server/auth/revocation/mod.rs
+++ b/pubky-homeserver/src/client_server/auth/revocation/mod.rs
@@ -1,0 +1,26 @@
+//! Cross-instance notification of authentication revocations.
+//!
+//! A private SSE subscription authorizes once when it is opened, so a normal
+//! request-time auth check is not enough to stop it after its credential is
+//! revoked. This module forwards Postgres `LISTEN`/`NOTIFY` messages to a local
+//! broadcast channel that those subscriptions can observe.
+//!
+//! This listener intentionally has its own connection instead of sharing the
+//! file-event listener. File events have a durable database catch-up path;
+//! auth revocations do not, and therefore must fail closed on any listener
+//! gap. Sharing lifecycle and failure handling would make an event-listener
+//! disruption unnecessarily disconnect every private stream.
+//!
+//! The current listener actor holds the broadcast sender, so anything that
+//! ends that actor closes every stream it handed a receiver to. The supervisor
+//! starts a replacement for the next subscription, and a replacement can never
+//! revive its predecessor's receivers.
+
+mod listener;
+mod notification;
+
+pub(crate) use listener::{RevocationListener, RevocationUnavailable};
+pub(crate) use notification::AuthRevocation;
+
+/// Postgres channel used for committed authentication revocations.
+pub(super) const PG_AUTH_REVOCATION_CHANNEL: &str = "auth_revocations";

--- a/pubky-homeserver/src/client_server/auth/revocation/notification.rs
+++ b/pubky-homeserver/src/client_server/auth/revocation/notification.rs
@@ -1,34 +1,12 @@
-//! Cross-instance notification of authentication revocations.
-//!
-//! A private SSE subscription authorizes once when it is opened, so a normal
-//! request-time auth check is not enough to stop it after its credential is
-//! revoked. This module forwards Postgres `LISTEN`/`NOTIFY` messages to a local
-//! broadcast channel that those subscriptions can observe.
-//!
-//! This listener intentionally has its own connection instead of sharing the
-//! file-event listener. File events have a durable database catch-up path;
-//! auth revocations do not, and therefore must fail closed on any listener
-//! gap. Sharing lifecycle and failure handling would make an event-listener
-//! disruption unnecessarily disconnect every private stream.
-//!
-//! The current listener actor holds the broadcast sender, so anything that
-//! ends that actor closes every stream it handed a receiver to. The supervisor
-//! starts a replacement for the next subscription, and a replacement can never
-//! revive its predecessor's receivers.
+//! The revocation payload and transactional notify helpers.
 
 use pubky_common::auth::jws::GrantId;
 use serde::{Deserialize, Serialize};
 
+use crate::client_server::auth::AuthSession;
 use crate::persistence::sql::UnifiedExecutor;
 
-use super::AuthSession;
-
-mod listener;
-
-pub(crate) use listener::{RevocationListener, RevocationUnavailable};
-
-/// Postgres channel used for committed authentication revocations.
-const PG_AUTH_REVOCATION_CHANNEL: &str = "auth_revocations";
+use super::PG_AUTH_REVOCATION_CHANNEL;
 
 /// A committed authentication revocation forwarded to active private streams.
 ///

--- a/pubky-homeserver/src/client_server/auth/state.rs
+++ b/pubky-homeserver/src/client_server/auth/state.rs
@@ -6,7 +6,7 @@ use crate::observability::Metrics;
 use crate::shared::HttpResult;
 
 use super::cookie::service::CookieAuthService;
-use super::{AuthSession, GrantAuthService, SignupService};
+use super::{AuthSession, GrantAuthService, RevocationListener, SignupService};
 
 /// Auth-specific state. Auth route handlers extract this instead of the
 /// global `AppState`, keeping the auth module fully self-contained.
@@ -15,6 +15,8 @@ pub struct AuthState {
     pub(crate) grant_auth_service: GrantAuthService,
     pub(crate) cookie_auth_service: CookieAuthService,
     pub(crate) metrics: Metrics,
+    /// Cross-instance signals that close private SSE streams after revocation.
+    pub(crate) revocation_listener: RevocationListener,
 }
 
 impl AuthState {
@@ -37,6 +39,7 @@ impl AuthState {
                 signup_service,
             ),
             metrics: context.metrics.clone(),
+            revocation_listener: context.revocation_listener.clone(),
         }
     }
 

--- a/pubky-homeserver/src/client_server/auth/stream_auth.rs
+++ b/pubky-homeserver/src/client_server/auth/stream_auth.rs
@@ -6,10 +6,7 @@ use tokio::sync::broadcast;
 
 use crate::shared::{HttpError, HttpResult};
 
-use super::{
-    revocation::AuthRevocationUnavailable, AuthRevocation, AuthRevocationService, AuthSession,
-    AuthState,
-};
+use super::{revocation::RevocationUnavailable, AuthRevocation, AuthSession, AuthState};
 
 /// Subscription state acquired before final session validation.
 /// Revocations committed before subscribing are caught by validation; later
@@ -24,10 +21,12 @@ impl PendingStreamAuth {
     /// tied to a credential, so it never waits on the listener.
     pub(crate) async fn subscribe(
         is_private: bool,
-        service: &AuthRevocationService,
-    ) -> Result<Self, AuthRevocationUnavailable> {
+        auth_state: &AuthState,
+    ) -> Result<Self, RevocationUnavailable> {
         if is_private {
-            Ok(Self::Private(service.subscribe().await?))
+            Ok(Self::Private(
+                auth_state.revocation_listener.subscribe().await?,
+            ))
         } else {
             Ok(Self::Public)
         }

--- a/pubky-homeserver/src/client_server/routes/events.rs
+++ b/pubky-homeserver/src/client_server/routes/events.rs
@@ -373,7 +373,7 @@ pub async fn feed_stream(
     // the receiver catches anything committed after it.
     let pending_stream_auth = PendingStreamAuth::subscribe(
         matches!(tenant_scope, EventStreamTenantScope::PrivateSingleTenant(_)),
-        &state.auth_revocation_service,
+        &state.auth_state,
     )
     .await
     .map_err(|_| {


### PR DESCRIPTION
- Moves `AuthRevocationService` ownership from `AppState` into `AuthState` to make the auth module more self-contained
- Rename `AuthRevocationService` → `RevocationListener` and `AuthRevocationUnavailable` → `RevocationUnavailable`
- Move `revocation.rs` into the `revocation/` dir
