### PR TITLE
docs(testnet): README to prioritise instructions for persisted static testnet setup

### DIFF
--- a/pubky-testnet/README.md
+++ b/pubky-testnet/README.md
@@ -27,8 +27,6 @@ The data directory is auto-initialized on first run with a `config.toml` and ser
 
 The `TEST_PUBKY_CONNECTION_STRING` environment variable is read on every startup and overrides the `database_url` in the on-disk config.
 
-> **Warning**: Do not use `?pubky-test=true` in the connection string with `persist` — it causes the database to be deleted on shutdown.
-
 To seed a custom homeserver config on first run (errors if `config.toml` already exists):
 
 ```bash

--- a/pubky-testnet/README.md
+++ b/pubky-testnet/README.md
@@ -14,6 +14,8 @@ docker run --name pubky-postgres \
   -d postgres:18
 ```
 
+> For more Postgres setup options see the [Install Guide — Set Up PostgreSQL](../docs/INSTALL.md#set-up-postgresql).
+
 Run a local testnet with persistent state:
 
 ```bash

--- a/pubky-testnet/README.md
+++ b/pubky-testnet/README.md
@@ -2,22 +2,11 @@
 
 A local test network for developing Pubky Core or applications depending on it.
 
-Two testnet types are provided:
+## Quick start
 
-| Type | Ports | Storage | Use case |
-|------|-------|---------|----------|
-| [`EphemeralTestnet`] | Random | In-memory | Automated tests (`#[tokio::test]`) - parallel-safe, no port conflicts |
-| [`StaticTestnet`] | Fixed, well-known | In-memory or persistent | Interactive / CLI use - browser tests, mobile apps, manual debugging |
-
-## Prerequisites
-
-All testnet modes require a PostgreSQL database. You can either:
-
-- **Use Docker Postgres** (recommended for tests) — enable the `docker-postgres` feature, no external setup needed.
-- **Run your own Postgres** - set the `TEST_PUBKY_CONNECTION_STRING` environment variable.
+Start Postgres if you don't already have one running:
 
 ```bash
-# Example: start a local Postgres container
 docker run --name pubky-postgres \
   -e POSTGRES_USER=postgres \
   -e POSTGRES_PASSWORD=postgres \
@@ -25,13 +14,51 @@ docker run --name pubky-postgres \
   -d postgres:18
 ```
 
-The `TEST_PUBKY_CONNECTION_STRING` environment variable is used by both testnet types to configure the database connection.
+Run a local testnet with persistent state:
 
-## EphemeralTestnet (Automated Tests)
+```bash
+TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres' \
+  cargo run -p pubky-testnet -- persist ./my-testnet-data
+```
 
-All ports are random, all state is in-memory. Each instance gets its own isolated DHT and homeserver, so tests run in parallel without conflicts.
+The data directory is auto-initialized on first run with a `config.toml` and server keypair. On subsequent runs, the existing state is picked up and the homeserver keeps the same identity.
 
-### Writing Tests
+The `TEST_PUBKY_CONNECTION_STRING` environment variable is read on every startup and overrides the `database_url` in the on-disk config.
+
+> **Warning**: Do not use `?pubky-test=true` in the connection string with `persist` — it causes the database to be deleted on shutdown.
+
+To seed a custom homeserver config on first run (errors if `config.toml` already exists):
+
+```bash
+TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres' \
+  cargo run -p pubky-testnet -- --homeserver-config my-config.toml persist ./my-testnet-data
+```
+
+If you don't need persistent state, omit the `persist` subcommand and add `?pubky-test=true` to the connection string. The database is auto-created on startup and cleaned up on shutdown:
+
+```bash
+TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres?pubky-test=true' \
+  cargo run -p pubky-testnet
+```
+
+### Ports and addresses
+
+| Component | Port |
+|-----------|------|
+| DHT bootstrap node | `6881` |
+| Pkarr relay | `15411` |
+| HTTP relay | `15412` |
+| Homeserver ICANN HTTP | `6286` |
+| Homeserver Pubky HTTPS | `6287` |
+| Homeserver admin | `6288` |
+
+Homeserver address: `8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo`
+
+The CLI uses [`StaticTestnet`] under the hood — see the type's rustdoc for programmatic use.
+
+## Writing tests (EphemeralTestnet)
+
+For automated Rust tests, use [`EphemeralTestnet`]. Each instance gets its own isolated DHT and homeserver with random ports, so tests run in parallel without conflicts.
 
 ```rust,no_run
 use pubky_testnet::EphemeralTestnet;
@@ -41,8 +68,6 @@ use pubky_testnet::EphemeralTestnet;
 async fn my_test() {
     // Note: both attributes are required — #[tokio::test] provides the async
     // runtime, #[pubky_testnet::test] registers a cleanup hook for test DBs.
-    // Run a new testnet. This creates a test DHT and homeserver.
-    // By default, uses minimal_test_config() (admin/metrics disabled, no HTTP relay).
     let testnet = EphemeralTestnet::builder().build().await.unwrap();
 
     // Create a Pubky Http Client from the testnet.
@@ -53,9 +78,38 @@ async fn my_test() {
 }
 ```
 
-### Docker PostgreSQL
+### Postgres for tests
 
-For testing without a separate Postgres installation, enable the `docker-postgres` feature:
+You need a running PostgreSQL instance (see [Quick start](#quick-start) for a Docker one-liner). By default, `EphemeralTestnet` reads the `TEST_PUBKY_CONNECTION_STRING` environment variable. The `?pubky-test=true` parameter tells the homeserver to create an ephemeral `pubky_test_*` database. The `#[pubky_testnet::test]` macro ensures the database is cleaned up after the test completes or panics.
+
+```bash
+TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres?pubky-test=true' \
+  cargo test -p my-crate
+```
+
+You can also pass the connection string programmatically:
+
+```rust,no_run
+use pubky_testnet::{EphemeralTestnet, pubky_homeserver::ConnectionString};
+
+#[tokio::test]
+#[pubky_testnet::test]
+async fn my_test() {
+    let connection_string = ConnectionString::new(
+        "postgres://postgres:postgres@localhost:5432/postgres?pubky-test=true"
+    ).unwrap();
+
+    let testnet = EphemeralTestnet::builder()
+        .postgres(connection_string)
+        .build()
+        .await
+        .unwrap();
+}
+```
+
+### Docker Postgres
+
+To avoid managing Postgres yourself, enable the `docker-postgres` feature. This uses [testcontainers](https://docs.rs/testcontainers) to run PostgreSQL in a Docker container that is automatically cleaned up on drop and on Ctrl+C/SIGTERM. Docker must be running on the host.
 
 ```toml
 [dev-dependencies]
@@ -79,17 +133,7 @@ async fn main() {
 }
 ```
 
-This uses [testcontainers](https://docs.rs/testcontainers) to run PostgreSQL in a Docker container.
-Docker must be running on the host. The container is automatically cleaned up on drop and on Ctrl+C/SIGTERM.
-
-> **Important**: If you have multiple tests, see [Sharing Docker Postgres Across Tests](#sharing-docker-postgres-across-tests) below.
-
-### Sharing Docker Postgres Across Tests
-
-When using `docker-postgres`, each call to `.with_docker_postgres()` starts a **separate** PostgreSQL container.
-
-Use `DockerPostgres::shared()` to start **one** container and share its connection string across all tests.
-Docker handles cleanup automatically when the process exits.
+Each call to `.with_docker_postgres()` starts a **separate** container. To share **one** container across all tests, use `DockerPostgres::shared()`:
 
 ```rust
 # #[cfg(feature = "docker-postgres")]
@@ -123,38 +167,7 @@ async fn test_two() {
 
 Each testnet still gets its own ephemeral database within the shared PostgreSQL instance, so tests remain isolated.
 
-### External PostgreSQL
-
-If you prefer to use an external Postgres instance, set the `TEST_PUBKY_CONNECTION_STRING` environment variable:
-
-```bash
-TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres?pubky-test=true' \
-  cargo test -p my-crate
-```
-
-Or pass the connection string programmatically:
-
-```rust,no_run
-use pubky_testnet::{EphemeralTestnet, pubky_homeserver::ConnectionString};
-
-#[tokio::test]
-#[pubky_testnet::test]
-async fn my_test() {
-    let connection_string = ConnectionString::new(
-        "postgres://postgres:postgres@localhost:5432/postgres?pubky-test=true"
-    ).unwrap();
-
-    let testnet = EphemeralTestnet::builder()
-        .postgres(connection_string)
-        .build()
-        .await
-        .unwrap();
-}
-```
-
-The `?pubky-test=true` parameter tells the homeserver to create an ephemeral `pubky_test_*` database. The `#[pubky_testnet::test]` macro ensures the database is cleaned up after the test completes or panics.
-
-### Custom Configuration
+### Custom configuration
 
 ```rust,no_run
 use pubky_testnet::{EphemeralTestnet, pubky_homeserver::ConfigToml, pubky::Keypair};
@@ -183,52 +196,4 @@ async fn main() {
         .unwrap();
     let http_relay = testnet.http_relay();
 }
-```
-
-## StaticTestnet (CLI / Interactive)
-
-A long-running testnet with fixed, well-known ports. Use this when external processes need to connect (browser tests, mobile apps, manual debugging).
-
-### Fixed Ports
-
-| Component | Port |
-|-----------|------|
-| DHT bootstrap node | `6881` |
-| Pkarr relay | `15411` |
-| HTTP relay | `15412` |
-| Homeserver ICANN HTTP | `6286` |
-| Homeserver Pubky HTTPS | `6287` |
-| Homeserver admin | `6288` |
-
-Homeserver address: `8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo`
-
-### In-Memory Mode
-
-State is lost on shutdown. Use `?pubky-test=true` to auto-create and clean up an ephemeral database:
-
-```bash
-TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres?pubky-test=true' \
-  cargo run -p pubky-testnet
-```
-
-### Persistent Mode
-
-State survives restarts. The data directory is auto-initialized on first run with a `config.toml` and server keypair. On subsequent runs, the existing state is picked up and the homeserver keeps the same identity.
-
-```bash
-TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres' \
-  cargo run -p pubky-testnet -- persist ./my-testnet-data
-```
-
-The `TEST_PUBKY_CONNECTION_STRING` environment variable is read on every startup and overrides the `database_url` in the on-disk config.
-
-> **Note**: For persistent mode, ensure `?pubky-test=true` is omitted so that the database is not cleaned up on shutdown.
-
-### Custom Homeserver Config
-
-Seed a custom config on first run (errors if `config.toml` already exists in the data directory):
-
-```bash
-TEST_PUBKY_CONNECTION_STRING='postgres://postgres:postgres@localhost:5432/postgres' \
-  cargo run -p pubky-testnet -- --homeserver-config my-config.toml persist ./my-testnet-data
 ```


### PR DESCRIPTION
The readme for testnet felt a bit scattered and not friendly for new users. 

I decided that the most common use case for reading this file is likely a dev wanting to spin up a local static persisted testnet. Therefore i created a quick start section at the top showing how to do this, with notes on modifying configs and persistence. 

Notes on `EphemeralTestnet` are still present but come later. 