### PR TITLE
feat(sdk): add support to callback params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4003,6 +4003,7 @@ dependencies = [
  "httpdate",
  "httpmock",
  "log",
+ "percent-encoding",
  "pkarr",
  "pubky-common",
  "pubky-testnet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ js-sys = "0.3"
 log = "0.4"
 pkarr = { version = "7", default-features = false }
 pkarr-relay = { version = "1" }
+percent-encoding = "2"
 pubky = { path = "pubky-sdk", version = "0.9", default-features = false }
 pubky-common = { path = "pubky-common", version = "0.9" }
 pubky-homeserver = { path = "pubky-homeserver", version = "0.9", default-features = false }

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -62,6 +62,22 @@ pubkyauth:///
   &secret=mAa8kGmlrynGzQLteDVW6-WeUGnfvHTpEmbNerbWfPI
  ```
  and finally show that URL as a QR code to the user.
+
+The request may also carry x-callback-url metadata used by an authenticator to
+return control to the requesting application:
+
+| Parameter | Meaning |
+| --- | --- |
+| `x-source` | Human-readable name of the requesting application. |
+| `x-success` | Destination after successful handling. |
+| `x-error` | Destination after an error. |
+| `x-cancel` | Destination after cancellation or timeout. |
+
+Values are percent-encoded once as URI components. Authenticators should
+decode them exactly once; in particular, nested percent escapes must remain
+escaped for the destination URL. For compatibility, `callback` may be parsed
+as a fallback for `x-success`, but new requests should emit `x-success`.
+
 1. The `Authenticator` app scans that QR code, parses the URL and shows a consent form for the user.
 1. The user decides whether or not to grant these capabilities to the `3rd Party App`.
 1. If the user approves, the `Authenticator` uses their Keypair to sign an [`AuthToken`](#authtoken-encoding), then encrypts that token with the `client_secret`. The `channel_id` is then calculated by hashing that secret and the encrypted token is sent to the callback url, which is the `relay` + `channel_id`.

--- a/pubky-sdk/Cargo.toml
+++ b/pubky-sdk/Cargo.toml
@@ -32,6 +32,7 @@ eventsource-stream.workspace = true
 url.workspace = true
 base64.workspace = true
 pkarr = { workspace = true, features = ["full"] }
+percent-encoding.workspace = true
 cookie = "0.18"
 flume = { version = "0.11", default-features = false, features = ["async"] }
 futures-util.workspace = true

--- a/pubky-sdk/README.md
+++ b/pubky-sdk/README.md
@@ -228,6 +228,36 @@ let session = flow.await_approval().await?;
 # Ok(()) }
 ```
 
+Optional x-callback parameters let the authenticator return control to the
+requesting app after it has handled the deep link. They work with both cookie
+and grant flows:
+
+```rust
+# use pubky::{AuthFlowKind, Capabilities, ClientId, PubkyGrantAuthFlow};
+# use pubky::deep_links::XCallbackParams;
+# fn callback_flow() -> pubky::Result<()> {
+let caps = Capabilities::builder()
+    .read_write("/pub/example.com/")
+    .expect("static scope is canonical")
+    .finish();
+let callbacks = XCallbackParams {
+    x_source: Some("Example App".into()),
+    x_success: Some("example://auth/success?nonce=unique".into()),
+    x_error: Some("example://auth/error?nonce=unique".into()),
+    x_cancel: Some("example://auth/cancel?nonce=unique".into()),
+};
+
+let flow = PubkyGrantAuthFlow::builder(
+    &caps,
+    AuthFlowKind::signin(),
+    ClientId::new("example.com").expect("static client id is valid"),
+)
+.x_callback(callbacks)
+.start()?;
+# drop(flow);
+# Ok(()) }
+```
+
 Approve an auth request
 
 ```rust ignore

--- a/pubky-sdk/bindings/js/pkg/README.md
+++ b/pubky-sdk/bindings/js/pkg/README.md
@@ -255,7 +255,16 @@ const relay = "https://httprelay.pubky.app/inbox/"; // optional (defaults to thi
 const flow = await pubky.startGrantAuthFlow(
   caps,
   AuthFlowKind.signin(),
-  { clientId: "my-cool-app.example", relay },
+  {
+    clientId: "my-cool-app.example",
+    relay,
+    xCallback: {
+      xSource: "My Cool App",
+      xSuccess: "my-cool-app://auth/success?nonce=unique",
+      xError: "my-cool-app://auth/error?nonce=unique",
+      xCancel: "my-cool-app://auth/cancel?nonce=unique",
+    },
+  },
 );
 
 renderQr(flow.authorizationUrl); // show to user
@@ -263,6 +272,12 @@ renderQr(flow.authorizationUrl); // show to user
 // Blocks until the signer approves; returns a ready Session
 const session = await flow.awaitApproval();
 ```
+
+The same callback object can be passed as the fourth argument to legacy cookie
+auth: `startCookieAuthFlow(caps, kind, relay, xCallback)`. The SDK emits
+`x-source`, `x-success`, `x-error`, and `x-cancel` using the encoding expected
+by Pubky Ring. Parsed deep-link objects expose them through `xCallback`; the
+legacy `callback` parameter is accepted as an `xSuccess` fallback.
 
 #### Resume an auth flow after page refresh
 

--- a/pubky-sdk/bindings/js/pkg/tests/auth.ts
+++ b/pubky-sdk/bindings/js/pkg/tests/auth.ts
@@ -1,5 +1,6 @@
 import test from "tape";
 import {
+  SigninDeepLink,
   SigninGrantDeepLink,
   SignupGrantDeepLink,
   GrantAuthFlow,
@@ -241,6 +242,41 @@ test("startCookieAuthFlow validates capabilities", (t) => {
   const emptyUrl = new URL(emptyFlow.authorizationUrl);
   t.equal(emptyUrl.searchParams.get("caps"), "", "allows empty capabilities");
 
+  t.end();
+});
+
+test("auth flow builders add Ring-compatible x-callback parameters", async (t) => {
+  const sdk = Pubky.testnet();
+  const xCallback = {
+    xSource: "Bitkit Wallet",
+    xSuccess: "bitkit://auth/success?nonce=builder&state=ready",
+    xError: "bitkit://auth/error?nonce=builder",
+    xCancel: "bitkit://auth/cancel?nonce=builder",
+  };
+
+  const cookieFlow = sdk.startCookieAuthFlow(
+    "/pub/example/:rw",
+    AuthFlowKind.signin(),
+    TESTNET_HTTP_RELAY,
+    xCallback,
+  );
+  const cookieLink = SigninDeepLink.parse(cookieFlow.authorizationUrl);
+  t.deepEqual(cookieLink.xCallback, xCallback, "cookie flow carries callbacks");
+
+  const grantFlow = await sdk.startGrantAuthFlow(
+    "/pub/example/:rw",
+    AuthFlowKind.signin(),
+    {
+      clientId: "grant-x-callback-js.test",
+      relay: TESTNET_HTTP_RELAY,
+      xCallback,
+    },
+  );
+  const grantLink = SigninGrantDeepLink.parse(grantFlow.authorizationUrl);
+  t.deepEqual(grantLink.xCallback, xCallback, "grant flow carries callbacks");
+
+  cookieFlow.free();
+  grantFlow.free();
   t.end();
 });
 

--- a/pubky-sdk/bindings/js/pkg/tests/deep_links.ts
+++ b/pubky-sdk/bindings/js/pkg/tests/deep_links.ts
@@ -25,17 +25,43 @@ const CLIENT_PUBLICKEY = PublicKey.from(
 const TESTNET_HTTP_RELAY = "http://localhost:15412/inbox";
 
 test("signin deep link valid", async (t) => {
-  let url = "pubkyauth://signin?caps=/pub/pubky.app/:rw&relay=http://localhost:15412/inbox&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8";
+  const xSuccess = "bitkit://auth/success?nonce=abc%2F123&state=ready";
+  const xError = "bitkit://auth/error?nonce=abc&reason=denied";
+  const xCancel = "bitkit://auth/cancel?nonce=abc";
+  const url = "pubkyauth://signin?caps=/pub/pubky.app/:rw&relay=http://localhost:15412/inbox&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8" +
+    `&x-source=${encodeURIComponent("Bitkit Wallet")}` +
+    `&x-success=${encodeURIComponent(xSuccess)}` +
+    `&x-error=${encodeURIComponent(xError)}` +
+    `&x-cancel=${encodeURIComponent(xCancel)}`;
   const deepLink = SigninDeepLink.parse(url);
   t.equal(deepLink.capabilities, "/pub/pubky.app/:rw");
   t.equal(deepLink.baseRelayUrl, TESTNET_HTTP_RELAY);
   t.deepEqual(deepLink.secret, new Uint8Array([146, 169, 220, 120, 67, 32, 172, 212, 12, 255, 24, 180, 234, 132, 23, 140, 13, 220, 36, 117, 255, 69, 9, 176, 212, 22, 58, 36, 77, 91, 177, 239]));
+  t.deepEqual(deepLink.xCallback, {
+    xSource: "Bitkit Wallet",
+    xSuccess,
+    xError,
+    xCancel,
+  });
 
   t.equal(SigninDeepLink.parse(deepLink.toString()).toString(), deepLink.toString());
 
   t.end();
 });
 
+test("signin deep link accepts legacy callback and emits canonical x-success", (t) => {
+  const callback = "bitkit://auth/success?nonce=legacy";
+  const url = "pubkyauth://signin?caps=&relay=http://localhost:15412/inbox" +
+    "&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8" +
+    `&callback=${encodeURIComponent(callback)}`;
+
+  const deepLink = SigninDeepLink.parse(url);
+
+  t.equal(deepLink.xCallback.xSuccess, callback);
+  t.ok(deepLink.toString().includes("x-success="));
+  t.notOk(deepLink.toString().includes("callback="));
+  t.end();
+});
 
 test("signup deep link valid", async (t) => {
   let url = "pubkyauth://signup?caps=/pub/pubky.app/:rw&relay=http://localhost:15412/inbox&secret=kqnceEMgrNQM_xi06oQXjA3cJHX_RQmw1BY6JE1bse8&hs=8pinxxgqs41n4aididenw5apqp1urfmzdztr8jt4abrkdn435ewo&st=1234567890";

--- a/pubky-sdk/bindings/js/src/actors/auth_flow.rs
+++ b/pubky-sdk/bindings/js/src/actors/auth_flow.rs
@@ -11,6 +11,7 @@ use wasm_bindgen::JsValue;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
+use super::deep_links::XCallbackParams;
 use super::{in_flight::InFlightGuard, session::Session};
 use crate::{
     js_error::{JsResult, PubkyError, PubkyErrorName},
@@ -55,6 +56,9 @@ impl AuthFlow {
     /// Optional HTTP relay base, e.g. `"https://demo.httprelay.io/inbox/"`.
     /// Defaults to the default Synonym-hosted relay when omitted.
     ///
+    /// @param {XCallbackParams} [xCallback]
+    /// Optional return destinations for success, error, and cancellation.
+    ///
     /// @returns {AuthFlow}
     /// A running auth flow. Call `authorizationUrl()` to show the deep link,
     /// then `awaitApproval()` to receive a `Session`.
@@ -72,8 +76,9 @@ impl AuthFlow {
         #[wasm_bindgen(unchecked_param_type = "Capabilities")] capabilities: String,
         kind: AuthFlowKind,
         relay: Option<String>,
+        x_callback: Option<XCallbackParams>,
     ) -> JsResult<AuthFlow> {
-        Self::start_with_client(capabilities, kind, relay, None)
+        Self::start_with_client(capabilities, kind, relay, x_callback, None)
     }
 
     /// Internal helper that threads an explicit transport.
@@ -81,6 +86,7 @@ impl AuthFlow {
         capabilities: String,
         kind: AuthFlowKind,
         relay: Option<String>,
+        x_callback: Option<XCallbackParams>,
         client: Option<pubky::PubkyHttpClient>,
     ) -> JsResult<AuthFlow> {
         let caps = parse_capabilities(&capabilities)?;
@@ -92,6 +98,10 @@ impl AuthFlow {
 
         if let Some(r) = relay {
             builder = builder.relay(Url::parse(&r)?);
+        }
+
+        if let Some(x_callback) = x_callback {
+            builder = builder.x_callback(x_callback.into());
         }
 
         let flow = builder.start()?;

--- a/pubky-sdk/bindings/js/src/actors/deep_links/direct_signup.rs
+++ b/pubky-sdk/bindings/js/src/actors/deep_links/direct_signup.rs
@@ -7,6 +7,8 @@ use crate::{
     wrappers::keys::PublicKey,
 };
 
+use super::XCallbackParams;
+
 /// Parsed direct signup deeplink.
 #[wasm_bindgen]
 pub struct DirectSignupDeepLink(pubky::deep_links::DirectSignupDeepLink);
@@ -36,6 +38,12 @@ impl DirectSignupDeepLink {
     #[wasm_bindgen(js_name = "signupToken", getter)]
     pub fn signup_token(&self) -> Option<String> {
         self.0.params().signup_token.clone()
+    }
+
+    /// Optional x-callback-url metadata carried by this deep link.
+    #[wasm_bindgen(js_name = "xCallback", getter)]
+    pub fn x_callback(&self) -> XCallbackParams {
+        self.0.x_callback().into()
     }
 
     #[allow(

--- a/pubky-sdk/bindings/js/src/actors/deep_links/mod.rs
+++ b/pubky-sdk/bindings/js/src/actors/deep_links/mod.rs
@@ -4,6 +4,7 @@ mod signin;
 mod signin_grant;
 mod signup;
 mod signup_grant;
+mod x_callback;
 
 pub use direct_signup::DirectSignupDeepLink;
 pub use seed_export::SeedExportDeepLink;
@@ -11,3 +12,4 @@ pub use signin::SigninDeepLink;
 pub use signin_grant::SigninGrantDeepLink;
 pub use signup::SignupDeepLink;
 pub use signup_grant::SignupGrantDeepLink;
+pub use x_callback::XCallbackParams;

--- a/pubky-sdk/bindings/js/src/actors/deep_links/seed_export.rs
+++ b/pubky-sdk/bindings/js/src/actors/deep_links/seed_export.rs
@@ -5,6 +5,8 @@ use wasm_bindgen::prelude::*;
 
 use crate::js_error::{JsResult, PubkyError, PubkyErrorName};
 
+use super::XCallbackParams;
+
 #[wasm_bindgen]
 pub struct SeedExportDeepLink(pubky::deep_links::SeedExportDeepLink);
 
@@ -25,6 +27,12 @@ impl SeedExportDeepLink {
     #[wasm_bindgen(getter)]
     pub fn secret(&self) -> Uint8Array {
         Uint8Array::from(self.0.params().secret.as_ref())
+    }
+
+    /// Optional x-callback-url metadata carried by this deep link.
+    #[wasm_bindgen(js_name = "xCallback", getter)]
+    pub fn x_callback(&self) -> XCallbackParams {
+        self.0.x_callback().into()
     }
 
     #[allow(

--- a/pubky-sdk/bindings/js/src/actors/deep_links/signin.rs
+++ b/pubky-sdk/bindings/js/src/actors/deep_links/signin.rs
@@ -5,6 +5,8 @@ use wasm_bindgen::prelude::*;
 
 use crate::js_error::{JsResult, PubkyError, PubkyErrorName};
 
+use super::XCallbackParams;
+
 #[wasm_bindgen]
 pub struct SigninDeepLink(pubky::deep_links::SigninDeepLink);
 
@@ -35,6 +37,12 @@ impl SigninDeepLink {
     #[wasm_bindgen(getter)]
     pub fn secret(&self) -> Uint8Array {
         Uint8Array::from(self.0.params().secret.as_ref())
+    }
+
+    /// Optional x-callback-url metadata carried by this deep link.
+    #[wasm_bindgen(js_name = "xCallback", getter)]
+    pub fn x_callback(&self) -> XCallbackParams {
+        self.0.x_callback().into()
     }
 
     #[allow(

--- a/pubky-sdk/bindings/js/src/actors/deep_links/signin_grant.rs
+++ b/pubky-sdk/bindings/js/src/actors/deep_links/signin_grant.rs
@@ -8,6 +8,8 @@ use crate::{
     wrappers::keys::PublicKey,
 };
 
+use super::XCallbackParams;
+
 /// Parsed grant-based signin deeplink.
 ///
 /// This is useful for tools, tests, and signer UIs that need to inspect a
@@ -74,6 +76,12 @@ impl SigninGrantDeepLink {
     #[wasm_bindgen(js_name = "clientPublicKey", getter)]
     pub fn client_public_key(&self) -> PublicKey {
         PublicKey(self.0.params().client_pk.clone())
+    }
+
+    /// Optional x-callback-url metadata carried by this deep link.
+    #[wasm_bindgen(js_name = "xCallback", getter)]
+    pub fn x_callback(&self) -> XCallbackParams {
+        self.0.x_callback().into()
     }
 
     #[allow(

--- a/pubky-sdk/bindings/js/src/actors/deep_links/signup.rs
+++ b/pubky-sdk/bindings/js/src/actors/deep_links/signup.rs
@@ -8,6 +8,8 @@ use crate::{
     wrappers::keys::PublicKey,
 };
 
+use super::XCallbackParams;
+
 #[wasm_bindgen]
 pub struct SignupDeepLink(pubky::deep_links::SignupDeepLink);
 
@@ -48,6 +50,12 @@ impl SignupDeepLink {
     #[wasm_bindgen(js_name = "signupToken", getter)]
     pub fn signup_token(&self) -> Option<String> {
         self.0.params().signup_token.clone()
+    }
+
+    /// Optional x-callback-url metadata carried by this deep link.
+    #[wasm_bindgen(js_name = "xCallback", getter)]
+    pub fn x_callback(&self) -> XCallbackParams {
+        self.0.x_callback().into()
     }
 
     #[allow(

--- a/pubky-sdk/bindings/js/src/actors/deep_links/signup_grant.rs
+++ b/pubky-sdk/bindings/js/src/actors/deep_links/signup_grant.rs
@@ -8,6 +8,8 @@ use crate::{
     wrappers::keys::PublicKey,
 };
 
+use super::XCallbackParams;
+
 /// Parsed grant-based signup deeplink.
 ///
 /// This is useful for tools, tests, and signer UIs that need to inspect a
@@ -90,6 +92,12 @@ impl SignupGrantDeepLink {
     #[wasm_bindgen(js_name = "clientPublicKey", getter)]
     pub fn client_public_key(&self) -> PublicKey {
         PublicKey(self.0.params().client_pk.clone())
+    }
+
+    /// Optional x-callback-url metadata carried by this deep link.
+    #[wasm_bindgen(js_name = "xCallback", getter)]
+    pub fn x_callback(&self) -> XCallbackParams {
+        self.0.x_callback().into()
     }
 
     #[allow(

--- a/pubky-sdk/bindings/js/src/actors/deep_links/x_callback.rs
+++ b/pubky-sdk/bindings/js/src/actors/deep_links/x_callback.rs
@@ -1,0 +1,50 @@
+use serde::{Deserialize, Serialize};
+use tsify::Tsify;
+
+/// Optional x-callback-url metadata carried by a Pubky deep link.
+///
+/// Callback destinations are untrusted navigation hints. Authentication still
+/// completes through the encrypted relay.
+#[derive(Tsify, Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+#[tsify(into_wasm_abi, from_wasm_abi)]
+#[serde(rename_all = "camelCase")]
+pub struct XCallbackParams {
+    /// Human-readable name of the requesting application.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[tsify(optional, type = "string | null")]
+    pub(crate) x_source: Option<String>,
+    /// Destination to open after successful completion.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[tsify(optional, type = "string | null")]
+    pub(crate) x_success: Option<String>,
+    /// Destination to open after an error.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[tsify(optional, type = "string | null")]
+    pub(crate) x_error: Option<String>,
+    /// Destination to open after user cancellation or timeout.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[tsify(optional, type = "string | null")]
+    pub(crate) x_cancel: Option<String>,
+}
+
+impl From<XCallbackParams> for pubky::deep_links::XCallbackParams {
+    fn from(value: XCallbackParams) -> Self {
+        Self {
+            x_source: value.x_source,
+            x_success: value.x_success,
+            x_error: value.x_error,
+            x_cancel: value.x_cancel,
+        }
+    }
+}
+
+impl From<&pubky::deep_links::XCallbackParams> for XCallbackParams {
+    fn from(value: &pubky::deep_links::XCallbackParams) -> Self {
+        Self {
+            x_source: value.x_source.clone(),
+            x_success: value.x_success.clone(),
+            x_error: value.x_error.clone(),
+            x_cancel: value.x_cancel.clone(),
+        }
+    }
+}

--- a/pubky-sdk/bindings/js/src/actors/grant_auth_flow.rs
+++ b/pubky-sdk/bindings/js/src/actors/grant_auth_flow.rs
@@ -11,7 +11,7 @@ use wasm_bindgen_futures::JsFuture;
 
 use super::{
     auth_flow::AuthFlowKind, browser_grant_key_store::BrowserGrantKeyStore,
-    in_flight::InFlightGuard, session::Session,
+    deep_links::XCallbackParams, in_flight::InFlightGuard, session::Session,
 };
 use crate::{
     js_error::{JsResult, PubkyError, PubkyErrorName},
@@ -29,6 +29,9 @@ pub struct GrantAuthFlowOptions {
     /// Defaults to the default Synonym-hosted relay when omitted.
     #[tsify(optional, type = "string | null")]
     pub(crate) relay: Option<String>,
+    /// Optional return destinations for success, error, and cancellation.
+    #[tsify(optional, type = "XCallbackParams | null")]
+    pub(crate) x_callback: Option<XCallbackParams>,
 }
 
 /// Start and control a grant-backed pubkyauth authorization flow.
@@ -67,7 +70,7 @@ impl GrantAuthFlow {
     /// The kind of authentication flow to perform.
     ///
     /// @param {GrantAuthFlowOptions} options
-    /// Options for the grant flow: `{ clientId, relay? }`.
+    /// Options for the grant flow: `{ clientId, relay?, xCallback? }`.
     ///
     /// @returns {GrantAuthFlow}
     /// A running grant auth flow. Call `authorizationUrl()` to show the deep link,
@@ -89,7 +92,12 @@ impl GrantAuthFlow {
         client: Option<pubky::PubkyHttpClient>,
     ) -> JsResult<GrantAuthFlow> {
         let caps = parse_capabilities(&capabilities)?;
-        let client_id = ClientId::new(&options.client_id).map_err(|e| {
+        let GrantAuthFlowOptions {
+            client_id,
+            relay,
+            x_callback,
+        } = options;
+        let client_id = ClientId::new(&client_id).map_err(|e| {
             pubky::Error::Authentication(pubky::errors::AuthError::Validation(e.to_string()))
         })?;
 
@@ -98,8 +106,12 @@ impl GrantAuthFlow {
             builder = builder.client(c);
         }
 
-        if let Some(r) = options.relay {
+        if let Some(r) = relay {
             builder = builder.relay(Url::parse(&r)?);
+        }
+
+        if let Some(x_callback) = x_callback {
+            builder = builder.x_callback(x_callback.into());
         }
 
         let flow = builder.start()?;
@@ -130,7 +142,12 @@ impl GrantAuthFlow {
         client: Option<pubky::PubkyHttpClient>,
     ) -> JsResult<GrantAuthFlow> {
         let caps = parse_capabilities(&capabilities)?;
-        let client_id = ClientId::new(&options.client_id).map_err(|e| {
+        let GrantAuthFlowOptions {
+            client_id,
+            relay,
+            x_callback,
+        } = options;
+        let client_id = ClientId::new(&client_id).map_err(|e| {
             pubky::Error::Authentication(pubky::errors::AuthError::Validation(e.to_string()))
         })?;
         let (key_id, public_key) = BrowserGrantKeyStore::ensure_key(None).await?;
@@ -142,8 +159,12 @@ impl GrantAuthFlow {
             builder = builder.client(c);
         }
 
-        if let Some(r) = options.relay {
+        if let Some(r) = relay {
             builder = builder.relay(Url::parse(&r)?);
+        }
+
+        if let Some(x_callback) = x_callback {
+            builder = builder.x_callback(x_callback.into());
         }
 
         let flow = builder.start()?;

--- a/pubky-sdk/bindings/js/src/pubky.rs
+++ b/pubky-sdk/bindings/js/src/pubky.rs
@@ -3,6 +3,7 @@ use wasm_bindgen::prelude::*;
 use crate::actors::{
     auth_flow::{AuthFlow, AuthFlowKind},
     browser_grant_key_store::BrowserGrantKeyStore,
+    deep_links::XCallbackParams,
     event_stream::EventStreamBuilder,
     grant_auth_flow::{GrantAuthFlow, GrantAuthFlowOptions},
     session::Session,
@@ -86,6 +87,7 @@ impl Pubky {
     /// - `AuthFlowKind.signin()` - Sign in to an existing account.
     /// - `AuthFlowKind.signup(homeserverPublicKey, signupToken)` - Sign up for a new account.
     /// @param {string=} relay Optional HTTP relay base (e.g. `"https://…/inbox/"`).
+    /// @param {XCallbackParams=} xCallback Optional app return destinations.
     /// @returns {AuthFlow}
     /// A running auth flow. Show `authorizationUrl` as QR/deeplink,
     /// then `awaitApproval()` to obtain a `Session`.
@@ -105,9 +107,15 @@ impl Pubky {
         #[wasm_bindgen(unchecked_param_type = "Capabilities")] capabilities: String,
         kind: AuthFlowKind,
         relay: Option<String>,
+        x_callback: Option<XCallbackParams>,
     ) -> JsResult<AuthFlow> {
-        let flow =
-            AuthFlow::start_with_client(capabilities, kind, relay, Some(self.0.client().clone()))?;
+        let flow = AuthFlow::start_with_client(
+            capabilities,
+            kind,
+            relay,
+            x_callback,
+            Some(self.0.client().clone()),
+        )?;
         Ok(flow)
     }
 
@@ -118,7 +126,8 @@ impl Pubky {
     ///
     /// @param {string} capabilities Comma-separated caps, e.g. `"/pub/app/:rw,/pub/foo/file:r"`.
     /// @param {AuthFlowKind} kind The kind of authentication flow to perform.
-    /// @param {GrantAuthFlowOptions} options Options for the grant flow: `{ clientId, relay? }`.
+    /// @param {GrantAuthFlowOptions} options Options for the grant flow:
+    /// `{ clientId, relay?, xCallback? }`.
     /// @returns {Promise<GrantAuthFlow>}
     /// A running grant auth flow. Show `authorizationUrl` as QR/deeplink,
     /// then `awaitApproval()` to obtain a grant-backed `Session`.

--- a/pubky-sdk/src/actors/auth/cookie/builder.rs
+++ b/pubky-sdk/src/actors/auth/cookie/builder.rs
@@ -7,6 +7,7 @@ use crate::actors::DEFAULT_HTTP_RELAY_INBOX;
 use crate::actors::auth::cookie::flow::PubkyCookieAuthFlow;
 use crate::actors::auth::deep_links::{
     DeepLink, DeepLinkScheme, SigninDeepLink, SigninParams, SignupDeepLink, SignupParams,
+    XCallbackParams,
 };
 use crate::actors::auth::kind::AuthFlowKind;
 use crate::actors::auth::relay::auth_relay_listener::AuthRelayListener;
@@ -25,6 +26,7 @@ pub struct CookieAuthFlowBuilder {
     client: Option<PubkyHttpClient>,
     auth_kind: AuthFlowKind,
     client_secret: [u8; 32],
+    x_callback: XCallbackParams,
 }
 
 impl CookieAuthFlowBuilder {
@@ -36,6 +38,7 @@ impl CookieAuthFlowBuilder {
             client: None,
             auth_kind,
             client_secret: random_bytes::<32>(),
+            x_callback: XCallbackParams::default(),
         }
     }
 
@@ -60,6 +63,13 @@ impl CookieAuthFlowBuilder {
         self
     }
 
+    /// Attach optional x-callback-url metadata to the authorization deep link.
+    #[must_use]
+    pub fn x_callback(mut self, x_callback: XCallbackParams) -> Self {
+        self.x_callback = x_callback;
+        self
+    }
+
     /// Finalize: derive channel, compute the `pubkyauth://` deep link, spawn
     /// the background poller, and return the flow handle.
     ///
@@ -74,6 +84,7 @@ impl CookieAuthFlowBuilder {
             client,
             auth_kind,
             client_secret,
+            x_callback,
         } = self;
 
         let client = match client {
@@ -103,7 +114,8 @@ impl CookieAuthFlowBuilder {
                     signup_token,
                 },
             )),
-        };
+        }
+        .with_x_callback(x_callback);
 
         let relay_listener = AuthRelayListener::builder(client_secret)
             .relay_base_url(base_relay)

--- a/pubky-sdk/src/actors/auth/cookie/flow.rs
+++ b/pubky-sdk/src/actors/auth/cookie/flow.rs
@@ -270,7 +270,7 @@ impl PubkyCookieAuthFlow {
 mod tests {
     use super::*;
     use crate::actors::auth::relay::http_relay_inbox_channel::EncryptedHttpRelayInboxChannel;
-    use crate::{Keypair, Pubky};
+    use crate::{Keypair, Pubky, deep_links::XCallbackParams};
     use std::str::FromStr;
 
     async fn build_flow(auth_kind: AuthFlowKind) -> PubkyCookieAuthFlow {
@@ -298,15 +298,21 @@ mod tests {
         let pubky = Pubky::with_client(client.clone());
 
         let caps = Capabilities::default();
+        let x_callback = XCallbackParams {
+            x_success: Some("bitkit://auth/success?nonce=resume-cookie".into()),
+            ..XCallbackParams::default()
+        };
         let flow = PubkyCookieAuthFlow::builder(&caps, auth_kind)
             .client(client.clone())
             .relay(inbox_base)
+            .x_callback(x_callback.clone())
             .start()
             .unwrap();
 
         let auth_url_str = flow.authorization_url().as_str().to_string();
 
         let deep_link = DeepLink::from_str(&auth_url_str).unwrap();
+        assert_eq!(deep_link.x_callback(), &x_callback);
         let secret = match &deep_link {
             DeepLink::Signin(s) => s.params().secret,
             DeepLink::Signup(s) => s.params().secret,
@@ -335,6 +341,13 @@ mod tests {
             resumed.authorization_url().as_str(),
             auth_url_str,
             "resumed flow produces the same authorization URL"
+        );
+        assert_eq!(
+            DeepLink::from_str(resumed.authorization_url().as_str())
+                .unwrap()
+                .x_callback(),
+            &x_callback,
+            "resumed flow preserves x-callback metadata"
         );
 
         let received_token = resumed.await_token().await.unwrap();

--- a/pubky-sdk/src/actors/auth/deep_links/deep_link.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/deep_link.rs
@@ -5,7 +5,7 @@ use url::Url;
 use crate::actors::auth::deep_links::{
     DEEP_LINK_SCHEMES, direct_signup::DirectSignupDeepLink, error::DeepLinkParseError,
     seed_export::SeedExportDeepLink, signin::SigninDeepLink, signin_grant::SigninGrantDeepLink,
-    signup::SignupDeepLink, signup_grant::SignupGrantDeepLink,
+    signup::SignupDeepLink, signup_grant::SignupGrantDeepLink, x_callback::XCallbackParams,
 };
 
 /// A parsed Pubky deep link.
@@ -30,6 +30,32 @@ pub enum DeepLink {
 }
 
 impl DeepLink {
+    /// Return the optional x-callback-url metadata carried by this deep link.
+    #[must_use]
+    pub const fn x_callback(&self) -> &XCallbackParams {
+        match self {
+            DeepLink::Signin(link) => link.x_callback(),
+            DeepLink::Signup(link) => link.x_callback(),
+            DeepLink::DirectSignup(link) => link.x_callback(),
+            DeepLink::SigninGrant(link) => link.x_callback(),
+            DeepLink::SignupGrant(link) => link.x_callback(),
+            DeepLink::SeedExport(link) => link.x_callback(),
+        }
+    }
+
+    /// Attach x-callback-url metadata to this deep link.
+    #[must_use]
+    pub(crate) fn with_x_callback(self, x_callback: XCallbackParams) -> Self {
+        match self {
+            Self::Signin(link) => Self::Signin(link.with_x_callback(x_callback)),
+            Self::Signup(link) => Self::Signup(link.with_x_callback(x_callback)),
+            Self::DirectSignup(link) => Self::DirectSignup(link.with_x_callback(x_callback)),
+            Self::SigninGrant(link) => Self::SigninGrant(link.with_x_callback(x_callback)),
+            Self::SignupGrant(link) => Self::SignupGrant(link.with_x_callback(x_callback)),
+            Self::SeedExport(link) => Self::SeedExport(link.with_x_callback(x_callback)),
+        }
+    }
+
     /// Convert the deep link to a simple URL.
     #[must_use]
     pub fn to_url(self) -> Url {

--- a/pubky-sdk/src/actors/auth/deep_links/mod.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/mod.rs
@@ -24,6 +24,7 @@ mod signin_grant;
 mod signup;
 mod signup_grant;
 mod typed_deep_link;
+mod x_callback;
 
 /// Supported deep link schemes.
 pub const DEEP_LINK_SCHEMES: [&str; 2] = ["pubkyauth", "pubkyring"];
@@ -38,3 +39,4 @@ pub use signin_grant::{SigninGrantDeepLink, SigninGrantIntent, SigninGrantParams
 pub use signup::{SignupDeepLink, SignupIntent, SignupParams};
 pub use signup_grant::{SignupGrantDeepLink, SignupGrantIntent, SignupGrantParams};
 pub use typed_deep_link::{DeepLinkIntent, DeepLinkParams, TypedDeepLink};
+pub use x_callback::XCallbackParams;

--- a/pubky-sdk/src/actors/auth/deep_links/typed_deep_link.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/typed_deep_link.rs
@@ -88,7 +88,6 @@ where
     }
 
     /// Return the optional x-callback-url metadata carried by this deep link.
-    #[must_use]
     pub const fn x_callback(&self) -> &XCallbackParams {
         &self.x_callback
     }

--- a/pubky-sdk/src/actors/auth/deep_links/typed_deep_link.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/typed_deep_link.rs
@@ -6,7 +6,7 @@ use std::{
 
 use url::Url;
 
-use super::{DeepLinkParseError, schemes::DeepLinkScheme};
+use super::{DeepLinkParseError, XCallbackParams, schemes::DeepLinkScheme};
 
 /// Intent marker for typed Pubky deep links.
 pub trait DeepLinkIntent {
@@ -32,6 +32,7 @@ pub trait DeepLinkParams: Sized {
 pub struct TypedDeepLink<I, P> {
     scheme: DeepLinkScheme,
     params: P,
+    x_callback: XCallbackParams,
     _intent: PhantomData<I>,
 }
 
@@ -41,6 +42,7 @@ impl<I, P> TypedDeepLink<I, P> {
         Self {
             scheme,
             params,
+            x_callback: XCallbackParams::default(),
             _intent: PhantomData,
         }
     }
@@ -65,6 +67,7 @@ where
         Ok(Self {
             scheme,
             params: P::parse(url)?,
+            x_callback: XCallbackParams::from_url(url),
             _intent: PhantomData,
         })
     }
@@ -84,6 +87,19 @@ where
         &self.params
     }
 
+    /// Return the optional x-callback-url metadata carried by this deep link.
+    #[must_use]
+    pub const fn x_callback(&self) -> &XCallbackParams {
+        &self.x_callback
+    }
+
+    /// Attach x-callback-url metadata to this deep link.
+    #[must_use]
+    pub fn with_x_callback(mut self, x_callback: XCallbackParams) -> Self {
+        self.x_callback = x_callback;
+        self
+    }
+
     /// Convert this typed deep link into a URL.
     ///
     /// # Panics
@@ -93,6 +109,7 @@ where
         let mut url = Url::parse(&format!("{}://{}", self.scheme.as_str(), I::NAME))
             .expect("invariant: deep-link scheme and intent form a valid URL");
         self.params.append_query_pairs(&mut url);
+        self.x_callback.append_to_url(&mut url);
         url
     }
 }
@@ -222,6 +239,46 @@ mod tests {
         let url: Url = deep_link.into();
 
         assert_eq!(url.as_str(), "pubkyauth://test?value=hello");
+    }
+
+    #[test]
+    fn parses_and_serializes_x_callback_metadata() {
+        let deep_link: TestDeepLink = "pubkyauth://test?value=hello&x-source=Bitkit%20Wallet&x-success=bitkit%3A%2F%2Fcallback%3Fnonce%3Dabc%26state%3Dready"
+            .parse()
+            .unwrap();
+
+        assert_eq!(
+            deep_link.x_callback(),
+            &XCallbackParams {
+                x_source: Some("Bitkit Wallet".into()),
+                x_success: Some("bitkit://callback?nonce=abc&state=ready".into()),
+                ..XCallbackParams::default()
+            }
+        );
+        assert_eq!(
+            deep_link.to_string(),
+            "pubkyauth://test?value=hello&x-source=Bitkit%20Wallet&x-success=bitkit%3A%2F%2Fcallback%3Fnonce%3Dabc%26state%3Dready"
+        );
+    }
+
+    #[test]
+    fn attaches_x_callback_metadata_without_changing_params() {
+        let deep_link = TestDeepLink::new(
+            DeepLinkScheme::PubkyAuth,
+            TestParams {
+                value: "hello".into(),
+            },
+        )
+        .with_x_callback(XCallbackParams {
+            x_cancel: Some("bitkit://cancel".into()),
+            ..XCallbackParams::default()
+        });
+
+        assert_eq!(deep_link.params().value, "hello");
+        assert_eq!(
+            deep_link.to_string(),
+            "pubkyauth://test?value=hello&x-cancel=bitkit%3A%2F%2Fcancel"
+        );
     }
 
     #[test]

--- a/pubky-sdk/src/actors/auth/deep_links/x_callback.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/x_callback.rs
@@ -1,0 +1,242 @@
+use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, percent_decode_str, utf8_percent_encode};
+use url::Url;
+
+/// Percent-encode callback values like JavaScript's `encodeURIComponent`.
+///
+/// Ring decodes callback parameters exactly once with `decodeURIComponent`, so
+/// spaces must be emitted as `%20` rather than the form-encoded `+`.
+const X_CALLBACK_ENCODE_SET: &AsciiSet = &NON_ALPHANUMERIC
+    .remove(b'-')
+    .remove(b'_')
+    .remove(b'.')
+    .remove(b'!')
+    .remove(b'~')
+    .remove(b'*')
+    .remove(b'\'')
+    .remove(b'(')
+    .remove(b')');
+
+/// Optional x-callback-url metadata carried by a Pubky deep link.
+///
+/// Callback destinations are kept as strings rather than parsed [`Url`]s so
+/// custom schemes and percent-encoded content round-trip exactly. They are
+/// untrusted navigation hints; applications must decide whether and how to
+/// open them. Authentication still completes through the encrypted relay.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct XCallbackParams {
+    /// Human-readable name of the application requesting authorization.
+    pub x_source: Option<String>,
+    /// Destination to open after successful completion.
+    pub x_success: Option<String>,
+    /// Destination to open after an error.
+    pub x_error: Option<String>,
+    /// Destination to open after user cancellation or timeout.
+    pub x_cancel: Option<String>,
+}
+
+impl XCallbackParams {
+    /// Parse x-callback-url parameters from a URL's still-encoded query.
+    ///
+    /// Values are decoded exactly once. A literal `+` remains `+`, matching
+    /// Pubky Ring's `decodeURIComponent` behavior. Legacy `callback` is used as
+    /// a fallback only when `x-success` is absent.
+    #[must_use]
+    pub fn from_url(url: &Url) -> Self {
+        let Some(query) = url.query() else {
+            return Self::default();
+        };
+
+        let x_success = Self::raw_query_value(query, "x-success")
+            .or_else(|| Self::raw_query_value(query, "callback"))
+            .map(Self::decode_once);
+
+        Self {
+            x_source: Self::raw_query_value(query, "x-source").map(Self::decode_once),
+            x_success,
+            x_error: Self::raw_query_value(query, "x-error").map(Self::decode_once),
+            x_cancel: Self::raw_query_value(query, "x-cancel").map(Self::decode_once),
+        }
+    }
+
+    /// Return true when no callback parameters are present.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.x_source.is_none()
+            && self.x_success.is_none()
+            && self.x_error.is_none()
+            && self.x_cancel.is_none()
+    }
+
+    /// Append canonical x-callback-url parameters to a URL.
+    ///
+    /// Existing query parameters are preserved. The legacy `callback` key is
+    /// never emitted; parsed legacy values are canonicalized to `x-success`.
+    pub fn append_to_url(&self, url: &mut Url) {
+        if self.is_empty() {
+            return;
+        }
+
+        let mut query = url.query().unwrap_or_default().to_owned();
+        for (key, value) in [
+            ("x-source", self.x_source.as_deref()),
+            ("x-success", self.x_success.as_deref()),
+            ("x-error", self.x_error.as_deref()),
+            ("x-cancel", self.x_cancel.as_deref()),
+        ] {
+            let Some(value) = value else {
+                continue;
+            };
+
+            if !query.is_empty() {
+                query.push('&');
+            }
+            query.push_str(key);
+            query.push('=');
+            query.push_str(&utf8_percent_encode(value, X_CALLBACK_ENCODE_SET).to_string());
+        }
+        url.set_query(Some(&query));
+    }
+
+    fn raw_query_value<'a>(query: &'a str, key: &str) -> Option<&'a str> {
+        query.split('&').find_map(|pair| {
+            let (pair_key, value) = pair.split_once('=').unwrap_or((pair, ""));
+            (pair_key == key).then_some(value)
+        })
+    }
+
+    fn decode_once(value: &str) -> String {
+        if !Self::has_valid_percent_triplets(value) {
+            return value.to_owned();
+        }
+
+        percent_decode_str(value)
+            .decode_utf8()
+            .map_or_else(|_| value.to_owned(), std::borrow::Cow::into_owned)
+    }
+
+    fn has_valid_percent_triplets(value: &str) -> bool {
+        let bytes = value.as_bytes();
+        let mut index = 0;
+
+        while index < bytes.len() {
+            if bytes[index] == b'%' {
+                let Some(first) = bytes.get(index + 1) else {
+                    return false;
+                };
+                let Some(second) = bytes.get(index + 2) else {
+                    return false;
+                };
+                if !first.is_ascii_hexdigit() || !second.is_ascii_hexdigit() {
+                    return false;
+                }
+                index += 3;
+            } else {
+                index += 1;
+            }
+        }
+
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_all_callback_params_exactly_once() {
+        let url = Url::parse(
+            "pubkyauth://signin?caps=%2F%3Arw&x-source=Bitkit%20Wallet&x-success=bitkit%3A%2F%2Fwallet%2Fcallback%3Fnonce%3Dabc%252F123%26state%3Dready&x-error=bitkit%3A%2F%2Fwallet%2Ferror%3Fnonce%3Dabc%26reason%3Ddenied&x-cancel=bitkit%3A%2F%2Fwallet%2Fcancel%3Fnonce%3Dabc",
+        )
+        .unwrap();
+
+        assert_eq!(
+            XCallbackParams::from_url(&url),
+            XCallbackParams {
+                x_source: Some("Bitkit Wallet".into()),
+                x_success: Some("bitkit://wallet/callback?nonce=abc%2F123&state=ready".into()),
+                x_error: Some("bitkit://wallet/error?nonce=abc&reason=denied".into()),
+                x_cancel: Some("bitkit://wallet/cancel?nonce=abc".into()),
+            }
+        );
+    }
+
+    #[test]
+    fn preserves_literal_plus_and_decodes_percent_encoded_space() {
+        let url = Url::parse(
+            "pubkyauth://signin?x-source=Bitkit+Wallet%20Mobile&x-success=bitkit%3A%2F%2Fcallback%3Fnonce%3Da%2Bb",
+        )
+        .unwrap();
+
+        let callbacks = XCallbackParams::from_url(&url);
+        assert_eq!(callbacks.x_source.as_deref(), Some("Bitkit+Wallet Mobile"));
+        assert_eq!(
+            callbacks.x_success.as_deref(),
+            Some("bitkit://callback?nonce=a+b")
+        );
+    }
+
+    #[test]
+    fn x_success_takes_precedence_over_legacy_callback_even_when_empty() {
+        let url =
+            Url::parse("pubkyauth://signin?x-success=&callback=bitkit%3A%2F%2Flegacy").unwrap();
+
+        assert_eq!(
+            XCallbackParams::from_url(&url).x_success.as_deref(),
+            Some("")
+        );
+    }
+
+    #[test]
+    fn uses_legacy_callback_as_success_fallback() {
+        let url = Url::parse("pubkyauth://signin?callback=bitkit%3A%2F%2Flegacy").unwrap();
+
+        assert_eq!(
+            XCallbackParams::from_url(&url).x_success.as_deref(),
+            Some("bitkit://legacy")
+        );
+    }
+
+    #[test]
+    fn appends_callbacks_with_ring_compatible_encoding_and_order() {
+        let mut url = Url::parse("pubkyauth://signin?caps=%2F%3Arw").unwrap();
+        let callbacks = XCallbackParams {
+            x_source: Some("Bitkit Wallet".into()),
+            x_success: Some("bitkit://callback?nonce=a+b&state=ready%20now".into()),
+            x_error: Some("bitkit://error".into()),
+            x_cancel: Some("bitkit://cancel".into()),
+        };
+
+        callbacks.append_to_url(&mut url);
+
+        assert_eq!(
+            url.as_str(),
+            "pubkyauth://signin?caps=%2F%3Arw&x-source=Bitkit%20Wallet&x-success=bitkit%3A%2F%2Fcallback%3Fnonce%3Da%2Bb%26state%3Dready%2520now&x-error=bitkit%3A%2F%2Ferror&x-cancel=bitkit%3A%2F%2Fcancel"
+        );
+        assert_eq!(XCallbackParams::from_url(&url), callbacks);
+    }
+
+    #[test]
+    fn canonicalizes_legacy_callback_when_appending() {
+        let legacy = Url::parse("pubkyauth://signin?callback=bitkit%3A%2F%2Flegacy").unwrap();
+        let callbacks = XCallbackParams::from_url(&legacy);
+        let mut canonical = Url::parse("pubkyauth://signin").unwrap();
+
+        callbacks.append_to_url(&mut canonical);
+
+        assert_eq!(
+            canonical.as_str(),
+            "pubkyauth://signin?x-success=bitkit%3A%2F%2Flegacy"
+        );
+    }
+
+    #[test]
+    fn malformed_percent_encoding_is_left_unchanged() {
+        let url = Url::parse("pubkyauth://signin?x-success=bitkit%3A%2F%2Fcallback%ZZ").unwrap();
+
+        assert_eq!(
+            XCallbackParams::from_url(&url).x_success.as_deref(),
+            Some("bitkit%3A%2F%2Fcallback%ZZ")
+        );
+    }
+}

--- a/pubky-sdk/src/actors/auth/deep_links/x_callback.rs
+++ b/pubky-sdk/src/actors/auth/deep_links/x_callback.rs
@@ -115,27 +115,13 @@ impl XCallbackParams {
     }
 
     fn has_valid_percent_triplets(value: &str) -> bool {
-        let bytes = value.as_bytes();
-        let mut index = 0;
-
-        while index < bytes.len() {
-            if bytes[index] == b'%' {
-                let Some(first) = bytes.get(index + 1) else {
-                    return false;
-                };
-                let Some(second) = bytes.get(index + 2) else {
-                    return false;
-                };
-                if !first.is_ascii_hexdigit() || !second.is_ascii_hexdigit() {
-                    return false;
-                }
-                index += 3;
-            } else {
-                index += 1;
-            }
-        }
-
-        true
+        value.split('%').skip(1).all(|escape| {
+            matches!(
+                escape.as_bytes(),
+                [first, second, ..]
+                    if first.is_ascii_hexdigit() && second.is_ascii_hexdigit()
+            )
+        })
     }
 }
 

--- a/pubky-sdk/src/actors/auth/grant/builder.rs
+++ b/pubky-sdk/src/actors/auth/grant/builder.rs
@@ -8,7 +8,7 @@ use pubky_common::{
 use crate::actors::DEFAULT_HTTP_RELAY_INBOX;
 use crate::actors::auth::deep_links::{
     DeepLink, DeepLinkScheme, SigninGrantDeepLink, SigninGrantParams, SignupGrantDeepLink,
-    SignupGrantParams,
+    SignupGrantParams, XCallbackParams,
 };
 use crate::actors::auth::grant::flow::PubkyGrantAuthFlow;
 use crate::actors::auth::grant::pop_signer::{DelegatedSignFn, GrantPopSigner};
@@ -32,6 +32,7 @@ pub struct GrantAuthFlowBuilder {
     client_secret: [u8; 32],
     client_id: ClientId,
     client_signer: GrantPopSigner,
+    x_callback: XCallbackParams,
 }
 
 impl GrantAuthFlowBuilder {
@@ -45,6 +46,7 @@ impl GrantAuthFlowBuilder {
             client_secret: random_bytes::<32>(),
             client_id,
             client_signer: GrantPopSigner::local(Keypair::random()),
+            x_callback: XCallbackParams::default(),
         }
     }
 
@@ -77,6 +79,13 @@ impl GrantAuthFlowBuilder {
         self
     }
 
+    /// Attach optional x-callback-url metadata to the authorization deep link.
+    #[must_use]
+    pub fn x_callback(mut self, x_callback: XCallbackParams) -> Self {
+        self.x_callback = x_callback;
+        self
+    }
+
     /// Use a delegated PoP signer, for example in a browser environment.
     #[must_use]
     #[doc(hidden)]
@@ -105,6 +114,7 @@ impl GrantAuthFlowBuilder {
             client_secret,
             client_id,
             client_signer,
+            x_callback,
         } = self;
 
         let client = match client {
@@ -143,7 +153,8 @@ impl GrantAuthFlowBuilder {
                     },
                 ))
             }
-        };
+        }
+        .with_x_callback(x_callback);
 
         let relay_listener = AuthRelayListener::builder(client_secret)
             .relay_base_url(base_relay)

--- a/pubky-sdk/src/actors/auth/grant/flow.rs
+++ b/pubky-sdk/src/actors/auth/grant/flow.rs
@@ -422,6 +422,7 @@ mod tests {
     use super::*;
     use crate::actors::auth::deep_links::{
         DeepLinkScheme, SigninDeepLink, SigninGrantDeepLink, SigninGrantParams, SigninParams,
+        XCallbackParams,
     };
 
     #[tokio::test]
@@ -434,6 +435,10 @@ mod tests {
         let relay_url = relay.local_url().join("inbox").unwrap();
         let client = PubkyHttpClient::new().unwrap();
         let client_id = ClientId::new("save-restore.test").unwrap();
+        let x_callback = XCallbackParams {
+            x_success: Some("bitkit://auth/success?nonce=resume-grant".into()),
+            ..XCallbackParams::default()
+        };
         let flow = PubkyGrantAuthFlow::builder(
             &Capabilities::default(),
             AuthFlowKind::signin(),
@@ -441,12 +446,19 @@ mod tests {
         )
         .relay(relay_url)
         .client(client.clone())
+        .x_callback(x_callback.clone())
         .start()
         .unwrap();
 
         let restored = PubkyGrantAuthFlow::restore(flow.save_local().unwrap(), client).unwrap();
 
         assert_eq!(restored.authorization_url(), flow.authorization_url());
+        assert_eq!(
+            DeepLink::from_str(restored.authorization_url().as_str())
+                .unwrap()
+                .x_callback(),
+            &x_callback
+        );
     }
 
     #[tokio::test]
@@ -486,6 +498,75 @@ mod tests {
         );
         assert!(delegated_flow.save_local().is_none());
         assert!(delegated_flow.save_delegated().is_some());
+    }
+
+    #[tokio::test]
+    async fn signup_builder_attaches_x_callback_metadata() {
+        let relay = http_relay::HttpRelay::builder()
+            .http_port(0)
+            .run()
+            .await
+            .unwrap();
+        let x_callback = XCallbackParams {
+            x_success: Some("bitkit://signup/success?nonce=grant-signup".into()),
+            ..XCallbackParams::default()
+        };
+        let flow = PubkyGrantAuthFlow::builder(
+            &Capabilities::default(),
+            AuthFlowKind::signup(Keypair::random().public_key(), Some("signup-token".into())),
+            ClientId::new("grant-signup-callback.test").unwrap(),
+        )
+        .relay(relay.local_url().join("inbox").unwrap())
+        .x_callback(x_callback.clone())
+        .start()
+        .unwrap();
+
+        let deep_link = DeepLink::from_str(flow.authorization_url().as_str()).unwrap();
+        assert!(matches!(&deep_link, DeepLink::SignupGrant(_)));
+        assert_eq!(deep_link.x_callback(), &x_callback);
+    }
+
+    #[tokio::test]
+    async fn delegated_save_restore_preserves_x_callback_metadata() {
+        let relay = http_relay::HttpRelay::builder()
+            .http_port(0)
+            .run()
+            .await
+            .unwrap();
+        let client = PubkyHttpClient::new().unwrap();
+        let keypair = Keypair::random();
+        let sign: DelegatedSignFn =
+            std::sync::Arc::new(|_| Box::pin(async { Ok(vec![0_u8; 64]) }) as _);
+        let x_callback = XCallbackParams {
+            x_success: Some("bitkit://auth/success?nonce=delegated".into()),
+            ..XCallbackParams::default()
+        };
+        let flow = PubkyGrantAuthFlow::builder(
+            &Capabilities::default(),
+            AuthFlowKind::signin(),
+            ClientId::new("delegated-callback.test").unwrap(),
+        )
+        .relay(relay.local_url().join("inbox").unwrap())
+        .delegated_client_signer(
+            "key-1".into(),
+            keypair.public_key(),
+            std::sync::Arc::clone(&sign),
+        )
+        .x_callback(x_callback.clone())
+        .start()
+        .unwrap();
+
+        let restored =
+            PubkyGrantAuthFlow::restore_delegated(flow.save_delegated().unwrap(), client, sign)
+                .unwrap();
+
+        assert_eq!(restored.authorization_url(), flow.authorization_url());
+        assert_eq!(
+            DeepLink::from_str(restored.authorization_url().as_str())
+                .unwrap()
+                .x_callback(),
+            &x_callback
+        );
     }
 
     #[test]

--- a/pubky-sdk/src/pubky.rs
+++ b/pubky-sdk/src/pubky.rs
@@ -62,7 +62,10 @@ use crate::PubkyCookieAuthFlow;
 use crate::{
     Capabilities, ClientId, DelegatedGrantCredentialState, EventCursor, EventStreamBuilder,
     GrantCredential, Pkdns, PubkyGrantAuthFlow, PubkyHttpClient, PubkySession, PubkySigner,
-    PublicStorage, Result, actors::AuthFlowKind, deep_links::DeepLink, errors::AuthError,
+    PublicStorage, Result,
+    actors::AuthFlowKind,
+    deep_links::{DeepLink, XCallbackParams},
+    errors::AuthError,
 };
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -180,11 +183,12 @@ impl Pubky {
         reason = "Cookie flow is intentionally exposed via this facade while deprecated"
     )]
     pub fn resume_cookie_auth_flow(&self, authorization_url: &str) -> Result<PubkyCookieAuthFlow> {
-        let (caps, relay, secret, auth_kind) = parse_auth_deep_link(authorization_url)?;
+        let (caps, relay, secret, auth_kind, x_callback) = parse_auth_deep_link(authorization_url)?;
 
         PubkyCookieAuthFlow::builder(&caps, auth_kind)
             .client_secret(secret)
             .relay(relay)
+            .x_callback(x_callback)
             .client(self.client.clone())
             .start()
     }
@@ -388,7 +392,15 @@ impl Pubky {
 /// Parse a `pubkyauth://` URL into the components needed to rebuild an auth flow.
 ///
 /// Rejects `SeedExport` deep links since they cannot be resumed as auth flows.
-fn parse_auth_deep_link(url: &str) -> Result<(Capabilities, url::Url, [u8; 32], AuthFlowKind)> {
+fn parse_auth_deep_link(
+    url: &str,
+) -> Result<(
+    Capabilities,
+    url::Url,
+    [u8; 32],
+    AuthFlowKind,
+    XCallbackParams,
+)> {
     let deep_link = DeepLink::from_str(url)
         .map_err(|e| AuthError::Validation(format!("Failed to parse authorization URL: {e}")))?;
 
@@ -398,6 +410,7 @@ fn parse_auth_deep_link(url: &str) -> Result<(Capabilities, url::Url, [u8; 32], 
             s.params().relay.clone(),
             s.params().secret,
             AuthFlowKind::signin(),
+            s.x_callback().clone(),
         )),
         DeepLink::Signup(s) => Ok((
             s.params().capabilities.clone(),
@@ -407,6 +420,7 @@ fn parse_auth_deep_link(url: &str) -> Result<(Capabilities, url::Url, [u8; 32], 
                 s.params().homeserver.clone(),
                 s.params().signup_token.clone(),
             ),
+            s.x_callback().clone(),
         )),
         DeepLink::SigninGrant(_) | DeepLink::SignupGrant(_) => Err(AuthError::Validation(
             "grant auth flows cannot be resumed from the authorization URL alone; the PoP client private key is required and is not encoded in the deep link."


### PR DESCRIPTION
Closes #336.

### Summary

Adds first-class support for `x-callback` metadata in Pubky deep links:

- `x-source`
- `x-success`
- `x-error`
- `x-cancel`

The SDK now parses, preserves, and serializes these parameters through the typed deep-link model. Cookie and grant auth builders can attach them directly, and JS/WASM consumers receive them through the typed `xCallback` API instead of manually parsing the authorization URL.

### Behavior

- Callback values are decoded exactly once, matching Pubky Ring behavior.
- Literal `+` characters and nested percent-encoded values round-trip correctly.
- The legacy `callback` parameter is accepted as an `x-success` fallback; serialization emits the canonical `x-success` form.
- Callback metadata survives cookie and grant flow persistence/resume, including delegated grant flows.
- Signin, signup, grant, direct-signup, and seed-export deep-link types expose the parsed metadata.
- Callback-free authorization URLs remain unchanged.

Callbacks remain untrusted navigation hints. Authentication completion is still determined through the encrypted relay, and the client application remains responsible for deciding whether to open a callback destination. No homeserver behavior changes.

### API

Rust auth builders accept `XCallbackParams` through `.x_callback(...)`.

JavaScript supports callbacks through:

- `startCookieAuthFlow(caps, kind, relay, xCallback)`
- `startGrantAuthFlow(caps, kind, { clientId, relay, xCallback })`
- The `xCallback` getter on parsed deep-link objects.

### Acceptance criteria

- [x] Parse and serialize `x-source`, `x-success`, `x-error`, and `x-cancel`.
- [x] Match Ring’s exact-once decoding and literal-plus behavior.
- [x] Accept legacy `callback` as an `x-success` fallback.
- [x] Support both cookie and grant signin/signup flows.
- [x] Preserve callbacks when auth flows are saved and resumed.
- [x] Expose typed callback metadata through the JS/WASM bindings.
- [x] Keep existing callback-free auth flows unchanged.
- [x] Document callback security and relay-authoritative completion behavior.