### PR TITLE
feat(homeserver): add support to path-addressed storage reads

### DIFF
--- a/e2e/src/tests/private_data.rs
+++ b/e2e/src/tests/private_data.rs
@@ -145,6 +145,26 @@ async fn under_scoped_owner_priv_access_is_forbidden() {
     .await;
     covering.storage().put(SECRET, vec![1, 2, 3]).await.unwrap();
 
+    // Positive control: the covering bearer also authorizes the canonical route.
+    let covering_bearer = covering.as_grant().unwrap().current_bearer().await;
+    let canonical_url = format!(
+        "{}storage/{}/{}",
+        server.icann_http_url(),
+        owner.z32(),
+        SECRET.trim_start_matches('/')
+    );
+    assert_eq!(
+        req_status(
+            pubky.client(),
+            Method::GET,
+            &canonical_url,
+            Some(&covering_bearer),
+            None,
+        )
+        .await,
+        StatusCode::OK
+    );
+
     // Same owner, session scoped to a sibling subtree that does not cover `/priv/app/`.
     let under = grant_session(
         &testnet,

--- a/e2e/src/tests/storage/objects.rs
+++ b/e2e/src/tests/storage/objects.rs
@@ -53,6 +53,36 @@ async fn put_get_delete() {
     let byte_value = response.bytes().await.unwrap();
     assert_eq!(byte_value, bytes::Bytes::from(vec![0, 1, 2, 3, 4]));
 
+    // The canonical HTTP route carries the storage owner in the path. Legacy
+    // tenant headers are ignored even when they point at a different user.
+    let path_addressed_url = format!(
+        "{}storage/{}/pub/foo.txt",
+        server.icann_http_url(),
+        session.public_key().z32()
+    );
+    let unrelated_user = Keypair::random().public_key();
+    let response = session
+        .client()
+        .request(Method::GET, &path_addressed_url)
+        .header("pubky-host", unrelated_user.z32())
+        .send()
+        .await
+        .unwrap()
+        .error_for_status()
+        .unwrap();
+    let varies_on_pubky_host = response
+        .headers()
+        .get("vary")
+        .and_then(|value| value.to_str().ok())
+        .into_iter()
+        .flat_map(|vary| vary.split(','))
+        .any(|name| name.trim().eq_ignore_ascii_case("pubky-host"));
+    assert!(!varies_on_pubky_host);
+    assert_eq!(
+        response.bytes().await.unwrap(),
+        bytes::Bytes::from(vec![0, 1, 2, 3, 4])
+    );
+
     // Use regular web method to get data from homeserver (with query pubky-host)
     let regular_url = format!(
         "{}pub/foo.txt?pubky-host={}",

--- a/pubky-homeserver/openapi-client.yml
+++ b/pubky-homeserver/openapi-client.yml
@@ -8,12 +8,11 @@ info:
 
     ## Tenant Identification
 
-    Per-tenant (user) routes resolve the target user from these sources (highest priority first):
-    1. `pubky-host` header (explicit override; takes precedence over `Host`)
-    2. `Host` header (e.g. from TLS SNI on the Pubky socket)
-    3. `?pubky-host=` query parameter (fallback when no key is found in headers)
+    Canonical reads use `/storage/{user_z32}/{path}`; the path owner is authoritative
+    and `Host` remains the HTTP authority.
 
-    The value must be a z-base-32 encoded Ed25519 public key.
+    Deprecated owner-relative routes resolve the owner from `pubky-host`, then
+    `Host`, then `?pubky-host=`.
 
     ## Authentication
 
@@ -341,6 +340,168 @@ paths:
               description: Cookie removal header
               schema:
                 type: string
+  "/storage/{user_z32}/{path}":
+    parameters:
+    - name: user_z32
+      in: path
+      required: true
+      description: Raw 52-character z-base-32 public key of the storage owner.
+        The human-readable `pubky` prefix is not accepted.
+      schema:
+        type: string
+        minLength: 52
+        maxLength: 52
+        pattern: "^[ybndrfg8ejkmcpqxot1uwisza345h769]{52}$"
+    - name: path
+      in: path
+      required: true
+      description: Owner-relative storage path. Must start with `pub/` or `priv/`
+        and may contain slashes.
+      schema:
+        type: string
+      examples:
+        file:
+          value: pub/documents/notes.txt
+        directory:
+          value: pub/documents/
+    get:
+      tags:
+      - Data
+      summary: Get a path-addressed file or list a directory
+      description: |
+        Canonical storage read route. The owner in the path is authoritative.
+        Any `pubky-host` header or query parameter is accepted for compatibility
+        but ignored.
+
+        A directory path ending in `/` returns a newline-separated list of
+        `pubky://` URLs. Conditional requests are supported for files.
+      operationId: getPathAddressedEntry
+      security:
+      - {}
+      - bearerAuth: []
+      - cookieAuth: []
+      parameters:
+      - name: limit
+        in: query
+        description: Items per page for directory listings.
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 65535
+      - name: cursor
+        in: query
+        description: Directory-listing cursor, as a bare entry path or `pubky://` URL.
+        schema:
+          type: string
+      - name: shallow
+        in: query
+        description: List immediate children instead of a deep recursive listing.
+        schema:
+          type: boolean
+          default: false
+      - name: reverse
+        in: query
+        description: Reverse listing order.
+        schema:
+          type: boolean
+          default: false
+      - name: If-None-Match
+        in: header
+        schema:
+          type: string
+      - name: If-Modified-Since
+        in: header
+        schema:
+          type: string
+      responses:
+        '200':
+          description: File content or directory listing.
+          headers:
+            Content-Type:
+              schema:
+                type: string
+            Content-Length:
+              schema:
+                type: integer
+            ETag:
+              schema:
+                type: string
+            Last-Modified:
+              schema:
+                type: string
+            Cache-Control:
+              description: Files use `private, must-revalidate`; private paths
+                and private directory listings use `no-store`.
+              schema:
+                type: string
+            Vary:
+              description: Public responses do not vary by `pubky-host`. Private
+                responses vary by `Authorization, Cookie`; neither includes the
+                ignored `pubky-host`. Other middleware, such as CORS, may add values.
+              schema:
+                type: string
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+            text/plain:
+              schema:
+                type: string
+                description: Newline-separated `pubky://` URLs for directory listings.
+        '304':
+          description: Not modified.
+        '400':
+          description: Invalid owner public key, storage path, or pagination cursor.
+        '401':
+          description: Authentication is required to read a `/priv/` path.
+        '403':
+          description: The session does not authorize the owner-relative storage path.
+        '404':
+          description: File, directory, or storage owner not found.
+    head:
+      tags:
+      - Data
+      summary: Get path-addressed file metadata
+      description: Returns the same metadata headers as GET without a response body.
+        The path owner is authoritative and `pubky-host` is ignored.
+      operationId: headPathAddressedEntry
+      security:
+      - {}
+      - bearerAuth: []
+      - cookieAuth: []
+      responses:
+        '200':
+          description: File metadata.
+          headers:
+            Content-Type:
+              schema:
+                type: string
+            Content-Length:
+              schema:
+                type: integer
+            ETag:
+              schema:
+                type: string
+            Last-Modified:
+              schema:
+                type: string
+            Cache-Control:
+              schema:
+                type: string
+            Vary:
+              description: Does not include `pubky-host`; private paths include
+                `Authorization, Cookie`. Other middleware may add values.
+              schema:
+                type: string
+        '400':
+          description: Invalid owner public key or storage path.
+        '401':
+          description: Authentication is required to read a `/priv/` path.
+        '403':
+          description: The session does not authorize the owner-relative storage path.
+        '404':
+          description: File or storage owner not found.
   "/{path}":
     parameters:
     - name: path
@@ -362,7 +523,10 @@ paths:
       tags:
       - Data
       summary: Get file or list directory
+      deprecated: true
       description: |
+        Deprecated: use `GET /storage/{user_z32}/{path}`.
+
         If the path points to a file, returns the file content with caching headers.
         If the path points to a directory (trailing `/`), returns a newline-separated
         list of `pubky://` URLs.
@@ -505,7 +669,10 @@ paths:
       tags:
       - Data
       summary: Get file metadata
-      description: Returns the same headers as GET but without the response body.
+      deprecated: true
+      description: >-
+        Deprecated: use `HEAD /storage/{user_z32}/{path}`. Returns the same
+        headers as GET but without the response body.
       operationId: headEntry
       security:
       - {}
@@ -765,8 +932,10 @@ components:
       name: pubky-host
       in: header
       required: false
+      deprecated: true
       description: |
-        Target tenant's z-base-32 encoded public key.
+        Deprecated tenant-addressing override for owner-relative routes.
+        Ignored by canonical `/storage/{user_z32}/...` routes.
         On the Pubky TLS socket, this is derived from the `Host` header / SNI.
       schema:
         type: string
@@ -774,9 +943,11 @@ components:
       name: pubky-host
       in: query
       required: false
+      deprecated: true
       description: |
-        Fallback for tenant identification when the `pubky-host` header and
-        `Host` header do not contain a valid public key.
+        Deprecated fallback for owner-relative routes when the `pubky-host`
+        header and `Host` header do not contain a valid public key. Ignored by
+        canonical `/storage/{user_z32}/...` routes.
       schema:
         type: string
   schemas:

--- a/pubky-homeserver/src/client_server/app.rs
+++ b/pubky-homeserver/src/client_server/app.rs
@@ -27,8 +27,8 @@ use tower_http::cors::CorsLayer;
 use super::auth::{self, AuthenticationLayer};
 use super::cache_policy;
 use super::middleware::{
-    pubky_host::PubkyHostLayer,
     rate_limiter::{BandwidthQuotaLimitLayer, RequestRateLimitLayer},
+    request_tenant::RequestTenantLayer,
     trace::with_trace_layer,
 };
 use super::routes::{events, root, signup_tokens, tenants};
@@ -232,17 +232,16 @@ pub fn create_app(
             .map_err(ClientServerBuildError::RequestRateLimits)?;
 
     let middleware = ServiceBuilder::new()
-        // Request order matters: auth needs PubkyHost and CookieManager, and
-        // bandwidth limits need AuthSession from authentication.
-        .layer(PubkyHostLayer)
+        // Request order matters: auth needs CookieManager, and bandwidth limits
+        // need AuthSession from authentication. RequestTenant runs outside this
+        // stack so tracing and all of these layers see the resolved target.
         .layer(CookieManagerLayer::new())
         .layer(request_rate_limit_layer)
         .layer(AuthenticationLayer::new(auth_state.clone()))
         .layer(BandwidthQuotaLimitLayer::new(
             context.user_service.clone(),
             context.config_toml.default_quotas.clone(),
-        ))
-        .layer(CorsLayer::very_permissive());
+        ));
 
     let app = base()
         .merge(tenants::router())
@@ -251,8 +250,12 @@ pub fn create_app(
         .merge(auth::tenant_router(auth_state))
         .layer(middleware);
 
-    // Apply tracing to the complete router.
-    Ok(with_trace_layer(app))
+    // Resolve the target before tracing and authentication. Valid canonical
+    // storage requests are therefore logged using their logical Pubky URI.
+    // Keep CORS outermost so tenant-resolution errors are usable by browsers.
+    Ok(with_trace_layer(app)
+        .layer(RequestTenantLayer)
+        .layer(CorsLayer::very_permissive()))
 }
 
 #[cfg(test)]

--- a/pubky-homeserver/src/client_server/app.rs
+++ b/pubky-homeserver/src/client_server/app.rs
@@ -251,7 +251,7 @@ pub fn create_app(
         .layer(middleware);
 
     // Resolve the target before tracing and authentication. Valid canonical
-    // storage requests are therefore logged using their logical Pubky URI.
+    // storage requests are therefore logged using their canonical Pubky URL.
     // Keep CORS outermost so tenant-resolution errors are usable by browsers.
     Ok(with_trace_layer(app)
         .layer(axum_middleware::from_fn(RequestTenant::resolve))

--- a/pubky-homeserver/src/client_server/app.rs
+++ b/pubky-homeserver/src/client_server/app.rs
@@ -28,7 +28,7 @@ use super::auth::{self, AuthenticationLayer};
 use super::cache_policy;
 use super::middleware::{
     rate_limiter::{BandwidthQuotaLimitLayer, RequestRateLimitLayer},
-    request_tenant::RequestTenantLayer,
+    request_tenant::RequestTenant,
     trace::with_trace_layer,
 };
 use super::routes::{events, root, signup_tokens, tenants};
@@ -254,7 +254,7 @@ pub fn create_app(
     // storage requests are therefore logged using their logical Pubky URI.
     // Keep CORS outermost so tenant-resolution errors are usable by browsers.
     Ok(with_trace_layer(app)
-        .layer(RequestTenantLayer)
+        .layer(axum_middleware::from_fn(RequestTenant::resolve))
         .layer(CorsLayer::very_permissive()))
 }
 

--- a/pubky-homeserver/src/client_server/auth/cookie/middleware.rs
+++ b/pubky-homeserver/src/client_server/auth/cookie/middleware.rs
@@ -10,7 +10,7 @@
 
 use crate::client_server::auth::AuthSession;
 use crate::client_server::auth::AuthState;
-use crate::client_server::middleware::pubky_host::PubkyHost;
+use crate::client_server::middleware::request_tenant::RequestTenant;
 use axum::{body::Body, http::Request};
 use futures_util::future::BoxFuture;
 use pubky_common::crypto::PublicKey;
@@ -102,18 +102,18 @@ where
                     return inner.call(req).await.map_err(|e| match e {});
                 }
             };
-            let pubky = match req.extensions().get::<PubkyHost>().cloned() {
-                Some(pubky) => pubky,
+            let tenant = match req.extensions().get::<RequestTenant>().cloned() {
+                Some(tenant) => tenant,
                 None => {
                     tracing::trace!(
-                        "No pubky host found in request extensions. Skip cookie authentication."
+                        "No request tenant found in request extensions. Skip cookie authentication."
                     );
                     return inner.call(req).await.map_err(|e| match e {});
                 }
             };
 
             if let Some(session) =
-                extract_session_from_cookie(&state, &cookies, pubky.public_key()).await
+                extract_session_from_cookie(&state, &cookies, tenant.public_key()).await
             {
                 req.extensions_mut().insert(session);
             }
@@ -205,7 +205,8 @@ mod tests {
             .uri("/session")
             .body(Body::empty())
             .unwrap();
-        req.extensions_mut().insert(PubkyHost(pk.clone()));
+        req.extensions_mut()
+            .insert(RequestTenant::legacy(pk.clone()));
         let cookies = tower_cookies::Cookies::default();
         cookies.add(tower_cookies::Cookie::new(
             pk.z32(),

--- a/pubky-homeserver/src/client_server/auth/cookie/routes.rs
+++ b/pubky-homeserver/src/client_server/auth/cookie/routes.rs
@@ -5,7 +5,9 @@
 
 use crate::persistence::sql::signup_code::SignupCode;
 use crate::shared::{HttpError, HttpResult};
-use crate::{client_server::auth::AuthState, client_server::middleware::pubky_host::PubkyHost};
+use crate::{
+    client_server::auth::AuthState, client_server::middleware::request_tenant::RequestTenant,
+};
 use axum::{
     extract::{Query, State},
     http::StatusCode,
@@ -107,11 +109,11 @@ pub async fn signout(
     auth: Option<crate::client_server::auth::AuthSession>,
     cookies: Cookies,
     Host(host): Host,
-    pubky: PubkyHost,
+    tenant: RequestTenant,
 ) -> HttpResult<impl IntoResponse> {
     state.cookie_auth_service.signout(auth).await?;
 
-    let mut removal = Cookie::new(pubky.public_key().z32(), String::new());
+    let mut removal = Cookie::new(tenant.public_key().z32(), String::new());
     removal.make_removal();
     configure_session_cookie(&mut removal, &host);
     cookies.add(removal);

--- a/pubky-homeserver/src/client_server/auth/middleware/authentication.rs
+++ b/pubky-homeserver/src/client_server/auth/middleware/authentication.rs
@@ -58,7 +58,7 @@ mod tests {
     use crate::app_context::AppContext;
     use crate::client_server::auth::cookie::persistence::SessionRepository;
     use crate::client_server::auth::AuthSession;
-    use crate::client_server::middleware::pubky_host::PubkyHost;
+    use crate::client_server::middleware::request_tenant::RequestTenant;
     use crate::persistence::sql::user::UserRepository;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
@@ -141,7 +141,7 @@ mod tests {
             .header("Cookie", format!("{}=fakesecret", pk.z32()))
             .body(Body::empty())
             .unwrap();
-        req.extensions_mut().insert(PubkyHost(pk));
+        req.extensions_mut().insert(RequestTenant::legacy(pk));
 
         let resp = svc.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::OK);
@@ -160,7 +160,8 @@ mod tests {
             .header("Authorization", "Bearer not-a-valid-jws")
             .body(Body::empty())
             .unwrap();
-        req.extensions_mut().insert(PubkyHost(keypair.public_key()));
+        req.extensions_mut()
+            .insert(RequestTenant::legacy(keypair.public_key()));
         let cookies = Cookies::default();
         cookies.add(cookie_for_user(&context, &keypair).await);
         req.extensions_mut().insert(cookies);

--- a/pubky-homeserver/src/client_server/cache_policy.rs
+++ b/pubky-homeserver/src/client_server/cache_policy.rs
@@ -6,18 +6,30 @@ use axum::{
 };
 use percent_encoding::percent_decode_str;
 
+use crate::client_server::middleware::request_tenant::{AddressingMode, RequestTenant};
 use crate::{constants::PRIVATE_ROOT, shared::webdav::StoragePath};
 
 pub(crate) const CACHE_CONTROL_NO_STORE: HeaderValue = HeaderValue::from_static("no-store");
-pub(crate) const VARY_PRIVATE: HeaderValue =
+pub(crate) const VARY_PRIVATE_LEGACY: HeaderValue =
     HeaderValue::from_static("pubky-host, Authorization, Cookie");
+pub(crate) const VARY_PRIVATE_PATH: HeaderValue = HeaderValue::from_static("Authorization, Cookie");
 
 pub(crate) async fn private_cache_policy(request: Request, next: Next) -> Response {
-    let is_private = is_private_tenant_request_path(request.uri().path());
+    let tenant = request.extensions().get::<RequestTenant>().cloned();
+    let request_path = request.uri().path();
+    let logical_path = tenant
+        .as_ref()
+        .map(|tenant| tenant.logical_path(request_path))
+        .unwrap_or(request_path);
+    let is_private = is_private_tenant_request_path(logical_path);
+    let addressing = tenant
+        .as_ref()
+        .map(RequestTenant::addressing)
+        .unwrap_or(AddressingMode::Legacy);
     let mut response = next.run(request).await;
 
     if is_private {
-        apply_private_cache_headers(&mut response);
+        apply_private_cache_headers(&mut response, addressing);
         if response.status().as_u16() >= 400 {
             remove_validators(&mut response);
         }
@@ -28,14 +40,20 @@ pub(crate) async fn private_cache_policy(request: Request, next: Next) -> Respon
 
 pub(crate) async fn sse_cache_policy(request: Request, next: Next) -> Response {
     let mut response = next.run(request).await;
-    apply_private_cache_headers(&mut response);
+    apply_private_cache_headers(&mut response, AddressingMode::Legacy);
     response
 }
 
-fn apply_private_cache_headers(response: &mut Response) {
+fn apply_private_cache_headers(response: &mut Response, addressing: AddressingMode) {
     let headers = response.headers_mut();
     headers.insert(header::CACHE_CONTROL, CACHE_CONTROL_NO_STORE);
-    headers.insert(header::VARY, VARY_PRIVATE);
+    headers.insert(
+        header::VARY,
+        match addressing {
+            AddressingMode::Path => VARY_PRIVATE_PATH,
+            AddressingMode::Legacy => VARY_PRIVATE_LEGACY,
+        },
+    );
 }
 
 fn remove_validators(response: &mut Response) {

--- a/pubky-homeserver/src/client_server/cache_policy.rs
+++ b/pubky-homeserver/src/client_server/cache_policy.rs
@@ -17,11 +17,11 @@ pub(crate) const VARY_PRIVATE_PATH: HeaderValue = HeaderValue::from_static("Auth
 pub(crate) async fn private_cache_policy(request: Request, next: Next) -> Response {
     let tenant = request.extensions().get::<RequestTenant>().cloned();
     let request_path = request.uri().path();
-    let logical_path = tenant
+    let storage_path = tenant
         .as_ref()
-        .map(|tenant| tenant.logical_path(request_path))
-        .unwrap_or(request_path);
-    let is_private = is_private_tenant_request_path(logical_path);
+        .and_then(RequestTenant::storage_path)
+        .map_or(request_path, StoragePath::as_str);
+    let is_private = is_private_tenant_request_path(storage_path);
     let vary_on_pubky_host = tenant
         .as_ref()
         .is_none_or(|tenant| tenant.storage_path().is_none());

--- a/pubky-homeserver/src/client_server/cache_policy.rs
+++ b/pubky-homeserver/src/client_server/cache_policy.rs
@@ -6,7 +6,7 @@ use axum::{
 };
 use percent_encoding::percent_decode_str;
 
-use crate::client_server::middleware::request_tenant::{AddressingMode, RequestTenant};
+use crate::client_server::middleware::request_tenant::RequestTenant;
 use crate::{constants::PRIVATE_ROOT, shared::webdav::StoragePath};
 
 pub(crate) const CACHE_CONTROL_NO_STORE: HeaderValue = HeaderValue::from_static("no-store");
@@ -22,14 +22,13 @@ pub(crate) async fn private_cache_policy(request: Request, next: Next) -> Respon
         .map(|tenant| tenant.logical_path(request_path))
         .unwrap_or(request_path);
     let is_private = is_private_tenant_request_path(logical_path);
-    let addressing = tenant
+    let vary_on_pubky_host = tenant
         .as_ref()
-        .map(RequestTenant::addressing)
-        .unwrap_or(AddressingMode::Legacy);
+        .is_none_or(|tenant| tenant.storage_path().is_none());
     let mut response = next.run(request).await;
 
     if is_private {
-        apply_private_cache_headers(&mut response, addressing);
+        apply_private_cache_headers(&mut response, vary_on_pubky_host);
         if response.status().as_u16() >= 400 {
             remove_validators(&mut response);
         }
@@ -40,18 +39,19 @@ pub(crate) async fn private_cache_policy(request: Request, next: Next) -> Respon
 
 pub(crate) async fn sse_cache_policy(request: Request, next: Next) -> Response {
     let mut response = next.run(request).await;
-    apply_private_cache_headers(&mut response, AddressingMode::Legacy);
+    apply_private_cache_headers(&mut response, true);
     response
 }
 
-fn apply_private_cache_headers(response: &mut Response, addressing: AddressingMode) {
+fn apply_private_cache_headers(response: &mut Response, vary_on_pubky_host: bool) {
     let headers = response.headers_mut();
     headers.insert(header::CACHE_CONTROL, CACHE_CONTROL_NO_STORE);
     headers.insert(
         header::VARY,
-        match addressing {
-            AddressingMode::Path => VARY_PRIVATE_PATH,
-            AddressingMode::Legacy => VARY_PRIVATE_LEGACY,
+        if vary_on_pubky_host {
+            VARY_PRIVATE_LEGACY
+        } else {
+            VARY_PRIVATE_PATH
         },
     );
 }

--- a/pubky-homeserver/src/client_server/middleware/mod.rs
+++ b/pubky-homeserver/src/client_server/middleware/mod.rs
@@ -1,6 +1,7 @@
 //! Request middleware for the client server.
 //!
-//! - [`pubky_host`]: Extracts the tenant public key from the request Host header (TLS SNI).
+//! - [`request_tenant`]: Resolves path-addressed and legacy request tenants.
+//! - [`pubky_host`]: Compatibility resolver for legacy tenant addressing.
 //! - [`rate_limiter`]: Configurable per-path request rate limiting, keyed by IP or user,
 //!   with optional per-user speed overrides resolved from DB.
 //! - [`trace`]: Request/response logging via `tracing`.
@@ -9,4 +10,5 @@
 
 pub mod pubky_host;
 pub mod rate_limiter;
+pub mod request_tenant;
 pub mod trace;

--- a/pubky-homeserver/src/client_server/middleware/pubky_host.rs
+++ b/pubky-homeserver/src/client_server/middleware/pubky_host.rs
@@ -1,141 +1,17 @@
-//! Tenant identification middleware and extractor.
+//! Legacy tenant identification from HTTP headers and query parameters.
 //!
-//! The [`PubkyHostLayer`] extracts the user's public key from the HTTP Host
-//! header (set via TLS SNI on the Pubky socket, or directly on ICANN requests)
-//! and injects it as a [`PubkyHost`] extension so downstream handlers know
-//! which tenant is being addressed.
-//!
-//! The [`PubkyHost`] extractor retrieves it from request extensions.
+//! New storage routes identify the tenant in the URL path. This module keeps
+//! the compatibility resolver isolated for owner-relative legacy routes and
+//! cookie-session endpoints.
 
-use axum::{
-    body::Body,
-    extract::FromRequestParts,
-    http::{request::Parts, Request, StatusCode},
-    response::{IntoResponse, Response},
-};
-use futures_util::future::BoxFuture;
+use axum::{body::Body, http::Request};
 use pubky_common::crypto::PublicKey;
-use std::fmt::Display;
-use std::{convert::Infallible, task::Poll};
-use tower::{Layer, Service};
-
-// ── Extractor ───────────────────────────────────────────────────────────────
-
-/// The tenant's public key extracted from an incoming HTTP request.
-///
-/// [`PubkyHostLayer`] parses the key from the `Host` / `pubky-host` header
-/// (or the `pubky-host` query parameter as fallback) and stores it as a
-/// request extension. Handlers can then pull it out with the standard Axum
-/// extractor syntax:
-///
-/// ```rust,ignore
-/// async fn handler(PubkyHost(pk): PubkyHost) -> impl IntoResponse {
-///     format!("tenant public key: {pk}")
-/// }
-/// ```
-#[derive(Debug, Clone)]
-pub struct PubkyHost(pub(crate) PublicKey);
-
-impl PubkyHost {
-    pub fn public_key(&self) -> &PublicKey {
-        &self.0
-    }
-}
-
-impl Display for PubkyHost {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl<S> FromRequestParts<S> for PubkyHost
-where
-    S: Sync + Send,
-{
-    type Rejection = Response;
-
-    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
-        let pubky_host = parts
-            .extensions
-            .get::<PubkyHost>()
-            .cloned()
-            .ok_or((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                "Can't extract PubkyHost. Is `PubkyHostLayer` enabled?",
-            ))
-            .map_err(|e| e.into_response())?;
-
-        Ok(pubky_host)
-    }
-}
-
-// ── Layer ───────────────────────────────────────────────────────────────────
-
-/// Tower [`Layer`] that extracts the tenant's public key from every incoming
-/// request and injects it as a [`PubkyHost`] extension.
-///
-/// Resolution order:
-/// 1. `Host` header — the z32-encoded key set via TLS SNI on Pubky sockets.
-/// 2. `pubky-host` header — explicit override (takes precedence over `Host`).
-/// 3. `?pubky-host=<z32>` query parameter — fallback when headers are absent.
-///
-/// # Example
-///
-/// ```rust,ignore
-/// use axum::Router;
-/// use tower::ServiceBuilder;
-///
-/// let app = Router::new()
-///     .route("/data", get(handler))
-///     .layer(ServiceBuilder::new().layer(PubkyHostLayer));
-/// ```
-#[derive(Debug, Clone)]
-pub struct PubkyHostLayer;
-
-impl<S> Layer<S> for PubkyHostLayer {
-    type Service = PubkyHostLayerMiddleware<S>;
-
-    fn layer(&self, inner: S) -> Self::Service {
-        PubkyHostLayerMiddleware { inner }
-    }
-}
-
-/// Middleware that extracts the public key from headers or query parameters.
-#[derive(Debug, Clone)]
-pub struct PubkyHostLayerMiddleware<S> {
-    inner: S,
-}
-
-impl<S> Service<Request<Body>> for PubkyHostLayerMiddleware<S>
-where
-    S: Service<Request<Body>, Response = axum::response::Response, Error = Infallible>
-        + Send
-        + Clone
-        + 'static,
-    S::Future: Send + 'static,
-{
-    type Response = S::Response;
-    type Error = Infallible;
-    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx).map_err(|_| unreachable!())
-    }
-
-    fn call(&mut self, mut req: Request<Body>) -> Self::Future {
-        if let Some(public_key) = extract_pubky(&req) {
-            req.extensions_mut().insert(PubkyHost(public_key));
-        }
-        let mut inner = self.inner.clone();
-        Box::pin(async move { inner.call(req).await.map_err(|_| unreachable!()) })
-    }
-}
 
 /// Extracts a PublicKey by checking, in order:
 /// 1. The "host" header.
 /// 2. The "pubky-host" header (which overwrites any previously found key).
 /// 3. The query parameter "pubky-host" if none was found in headers.
-fn extract_pubky(req: &Request<Body>) -> Option<PublicKey> {
+pub(crate) fn extract_legacy_pubky(req: &Request<Body>) -> Option<PublicKey> {
     let mut pubky = None;
     // Check headers in order: "host" then "pubky-host".
     for header in ["host", "pubky-host"].iter() {

--- a/pubky-homeserver/src/client_server/middleware/rate_limiter/bandwidth_rate_limit.rs
+++ b/pubky-homeserver/src/client_server/middleware/rate_limiter/bandwidth_rate_limit.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 use std::{convert::Infallible, task::Poll};
 use tower::{Layer, Service};
 
-use crate::client_server::middleware::pubky_host::PubkyHost;
+use crate::client_server::middleware::request_tenant::RequestTenant;
 use crate::quota_config::LimitKey;
 use crate::services::user_service::UserService;
 use crate::shared::HttpError;
@@ -35,7 +35,7 @@ use super::CLEANUP_INTERVAL_SECS;
 /// - Unauthenticated requests: IP-keyed read rate from
 ///   `unauthenticated_ip_rate_read`.
 ///
-/// Requires a `PubkyHostLayer` to be applied first.
+/// Requires a `RequestTenantLayer` to be applied first.
 #[derive(Debug, Clone)]
 pub struct BandwidthQuotaLimitLayer {
     user_service: UserService,
@@ -106,7 +106,7 @@ impl BandwidthState {
 
     /// Returns `true` when there is something to check for this request.
     fn should_limit(&self, req: &Request<Body>) -> bool {
-        let has_user = req.extensions().get::<PubkyHost>().is_some();
+        let has_user = req.extensions().get::<RequestTenant>().is_some();
         let has_bandwidth = self.unauthenticated_read_limiter.is_some();
         has_user || has_bandwidth
     }
@@ -256,8 +256,7 @@ mod tests {
 
     use crate::client_server::auth::grant::session::GrantSession;
     use crate::client_server::auth::AuthSession;
-    use crate::client_server::middleware::pubky_host::PubkyHost;
-    use crate::client_server::middleware::pubky_host::PubkyHostLayer;
+    use crate::client_server::middleware::request_tenant::{RequestTenant, RequestTenantLayer};
     use crate::data_directory::quota_config::BandwidthQuota;
     use crate::persistence::sql::SqlDb;
     use crate::services::user_service::UserService;
@@ -294,7 +293,7 @@ mod tests {
                 let auth_public_key = auth_public_key.clone();
                 async move {
                     if let (Some(public_key), Some(_)) =
-                        (auth_public_key, req.extensions().get::<PubkyHost>())
+                        (auth_public_key, req.extensions().get::<RequestTenant>())
                     {
                         req.extensions_mut().insert(auth_session(public_key));
                     }
@@ -302,7 +301,7 @@ mod tests {
                 }
             }))
             .layer(CookieManagerLayer::new())
-            .layer(PubkyHostLayer);
+            .layer(RequestTenantLayer);
 
         let listener = tokio::net::TcpListener::bind(SocketAddr::new(
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),

--- a/pubky-homeserver/src/client_server/middleware/rate_limiter/bandwidth_rate_limit.rs
+++ b/pubky-homeserver/src/client_server/middleware/rate_limiter/bandwidth_rate_limit.rs
@@ -35,7 +35,7 @@ use super::CLEANUP_INTERVAL_SECS;
 /// - Unauthenticated requests: IP-keyed read rate from
 ///   `unauthenticated_ip_rate_read`.
 ///
-/// Requires a `RequestTenantLayer` to be applied first.
+/// Requires `RequestTenant::resolve` middleware to run first.
 #[derive(Debug, Clone)]
 pub struct BandwidthQuotaLimitLayer {
     user_service: UserService,
@@ -256,7 +256,7 @@ mod tests {
 
     use crate::client_server::auth::grant::session::GrantSession;
     use crate::client_server::auth::AuthSession;
-    use crate::client_server::middleware::request_tenant::{RequestTenant, RequestTenantLayer};
+    use crate::client_server::middleware::request_tenant::RequestTenant;
     use crate::data_directory::quota_config::BandwidthQuota;
     use crate::persistence::sql::SqlDb;
     use crate::services::user_service::UserService;
@@ -301,7 +301,7 @@ mod tests {
                 }
             }))
             .layer(CookieManagerLayer::new())
-            .layer(RequestTenantLayer);
+            .layer(from_fn(RequestTenant::resolve));
 
         let listener = tokio::net::TcpListener::bind(SocketAddr::new(
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),

--- a/pubky-homeserver/src/client_server/middleware/rate_limiter/limiter_pool.rs
+++ b/pubky-homeserver/src/client_server/middleware/rate_limiter/limiter_pool.rs
@@ -18,7 +18,7 @@ use crate::quota_config::{LimitKey, LimitKeyType, PathLimit};
 
 use super::extract_ip::extract_ip;
 use super::CLEANUP_INTERVAL_SECS;
-use crate::client_server::middleware::pubky_host::PubkyHost;
+use crate::client_server::middleware::request_tenant::RequestTenant;
 use axum::body::Body;
 use axum::http::Request;
 
@@ -121,7 +121,7 @@ impl LimitTuple {
             LimitKeyType::User => {
                 // Extract the user pubkey from the request.
                 req.extensions()
-                    .get::<PubkyHost>()
+                    .get::<RequestTenant>()
                     .map(|pk| LimitKey::User(pk.public_key().clone()))
                     .ok_or(anyhow::anyhow!("Failed to extract user pubkey."))
             }
@@ -130,7 +130,11 @@ impl LimitTuple {
 
     /// Check if the request matches the limit.
     pub fn is_match(&self, req: &Request<Body>) -> bool {
-        let path = req.uri().path();
+        let path = req
+            .extensions()
+            .get::<RequestTenant>()
+            .map(|tenant| tenant.logical_path(req.uri().path()))
+            .unwrap_or_else(|| req.uri().path());
         let glob_match = self.limit.path.is_match(path);
         let method_match = self.limit.method.0 == req.method();
         glob_match && method_match

--- a/pubky-homeserver/src/client_server/middleware/rate_limiter/limiter_pool.rs
+++ b/pubky-homeserver/src/client_server/middleware/rate_limiter/limiter_pool.rs
@@ -133,8 +133,8 @@ impl LimitTuple {
         let path = req
             .extensions()
             .get::<RequestTenant>()
-            .map(|tenant| tenant.logical_path(req.uri().path()))
-            .unwrap_or_else(|| req.uri().path());
+            .and_then(RequestTenant::storage_path)
+            .map_or(req.uri().path(), |path| path.as_str());
         let glob_match = self.limit.path.is_match(path);
         let method_match = self.limit.method.0 == req.method();
         glob_match && method_match

--- a/pubky-homeserver/src/client_server/middleware/rate_limiter/mod.rs
+++ b/pubky-homeserver/src/client_server/middleware/rate_limiter/mod.rs
@@ -19,6 +19,7 @@ mod tests {
 
     use axum::body::Body;
     use axum::http::{Method, StatusCode};
+    use axum::middleware;
     use axum::response::IntoResponse;
     use axum::routing::{get, post};
     use axum::Router;
@@ -28,7 +29,7 @@ mod tests {
     use tokio::time::Instant;
     use tower_cookies::CookieManagerLayer;
 
-    use crate::client_server::middleware::request_tenant::RequestTenantLayer;
+    use crate::client_server::middleware::request_tenant::RequestTenant;
     use crate::data_directory::quota_config::BandwidthQuota;
     use crate::persistence::sql::SqlDb;
     use crate::quota_config::{GlobPattern, HttpMethod, LimitKeyType, PathLimit};
@@ -67,7 +68,7 @@ mod tests {
                     .expect("valid test request-count rate limit"),
             )
             .layer(CookieManagerLayer::new())
-            .layer(RequestTenantLayer);
+            .layer(middleware::from_fn(RequestTenant::resolve));
 
         let listener = tokio::net::TcpListener::bind(SocketAddr::new(
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),

--- a/pubky-homeserver/src/client_server/middleware/rate_limiter/mod.rs
+++ b/pubky-homeserver/src/client_server/middleware/rate_limiter/mod.rs
@@ -28,7 +28,7 @@ mod tests {
     use tokio::time::Instant;
     use tower_cookies::CookieManagerLayer;
 
-    use crate::client_server::middleware::pubky_host::PubkyHostLayer;
+    use crate::client_server::middleware::request_tenant::RequestTenantLayer;
     use crate::data_directory::quota_config::BandwidthQuota;
     use crate::persistence::sql::SqlDb;
     use crate::quota_config::{GlobPattern, HttpMethod, LimitKeyType, PathLimit};
@@ -67,7 +67,7 @@ mod tests {
                     .expect("valid test request-count rate limit"),
             )
             .layer(CookieManagerLayer::new())
-            .layer(PubkyHostLayer);
+            .layer(RequestTenantLayer);
 
         let listener = tokio::net::TcpListener::bind(SocketAddr::new(
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),

--- a/pubky-homeserver/src/client_server/middleware/rate_limiter/request_rate_limit.rs
+++ b/pubky-homeserver/src/client_server/middleware/rate_limiter/request_rate_limit.rs
@@ -279,7 +279,7 @@ mod tests {
 
     #[tokio::test]
     #[pubky_test_utils::test]
-    async fn path_addressed_storage_uses_logical_path_and_owner_for_limits() {
+    async fn path_addressed_storage_uses_storage_path_and_owner_for_limits() {
         let path_limit = PathLimit {
             path: GlobPattern::new("/pub/*"),
             method: HttpMethod(Method::GET),

--- a/pubky-homeserver/src/client_server/middleware/rate_limiter/request_rate_limit.rs
+++ b/pubky-homeserver/src/client_server/middleware/rate_limiter/request_rate_limit.rs
@@ -22,7 +22,7 @@ use super::limiter_pool::LimitTuple;
 /// Matches requests by path and method against configured limits and
 /// returns 429 TOO MANY REQUESTS when a limit is exceeded.
 ///
-/// Returns 400 BAD REQUEST if the rate-limit key (IP or pubky-host)
+/// Returns 400 BAD REQUEST if the rate-limit key (IP or request tenant)
 /// cannot be extracted.
 #[derive(Debug, Clone)]
 pub struct RequestRateLimitLayer {
@@ -152,7 +152,7 @@ mod tests {
     use tokio::task::JoinHandle;
     use tower_cookies::CookieManagerLayer;
 
-    use crate::client_server::middleware::pubky_host::PubkyHostLayer;
+    use crate::client_server::middleware::request_tenant::RequestTenantLayer;
     use crate::quota_config::{GlobPattern, HttpMethod, LimitKeyType};
     use crate::shared::HttpResult;
 
@@ -171,12 +171,13 @@ mod tests {
         let app = Router::new()
             .route("/upload", post(upload_handler))
             .route("/download", get(download_handler))
+            .route("/storage/{user_z32}/{*path}", get(download_handler))
             .layer(
                 RequestRateLimitLayer::from_path_limits(config)
                     .expect("valid test request-count rate limit"),
             )
             .layer(CookieManagerLayer::new())
-            .layer(PubkyHostLayer);
+            .layer(RequestTenantLayer);
 
         let listener = tokio::net::TcpListener::bind(SocketAddr::new(
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
@@ -273,6 +274,40 @@ mod tests {
             "user1 should have exactly one success and one rate-limited response"
         );
         assert_eq!(res3.status(), StatusCode::CREATED);
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn path_addressed_storage_uses_logical_path_and_owner_for_limits() {
+        let path_limit = PathLimit {
+            path: GlobPattern::new("/pub/*"),
+            method: HttpMethod(Method::GET),
+            quota: "1r/m".parse().unwrap(),
+            key: LimitKeyType::User,
+            burst: None,
+            whitelist: Vec::new(),
+        };
+        let socket = start_server(vec![path_limit]).await;
+        let owner = Keypair::random().public_key();
+        let other = Keypair::random().public_key();
+        let url = format!("http://{socket}/storage/{}/pub/file.txt", owner.z32());
+        let client = Client::new();
+
+        let first = client
+            .get(&url)
+            .header("pubky-host", other.z32())
+            .send()
+            .await
+            .unwrap();
+        let second = client
+            .get(&url)
+            .header("pubky-host", other.z32())
+            .send()
+            .await
+            .unwrap();
+
+        assert_eq!(first.status(), StatusCode::OK);
+        assert_eq!(second.status(), StatusCode::TOO_MANY_REQUESTS);
     }
 
     #[test]

--- a/pubky-homeserver/src/client_server/middleware/rate_limiter/request_rate_limit.rs
+++ b/pubky-homeserver/src/client_server/middleware/rate_limiter/request_rate_limit.rs
@@ -143,6 +143,7 @@ mod tests {
 
     use axum::http::Method;
     use axum::{
+        middleware,
         routing::{get, post},
         Router,
     };
@@ -152,7 +153,7 @@ mod tests {
     use tokio::task::JoinHandle;
     use tower_cookies::CookieManagerLayer;
 
-    use crate::client_server::middleware::request_tenant::RequestTenantLayer;
+    use crate::client_server::middleware::request_tenant::RequestTenant;
     use crate::quota_config::{GlobPattern, HttpMethod, LimitKeyType};
     use crate::shared::HttpResult;
 
@@ -177,7 +178,7 @@ mod tests {
                     .expect("valid test request-count rate limit"),
             )
             .layer(CookieManagerLayer::new())
-            .layer(RequestTenantLayer);
+            .layer(middleware::from_fn(RequestTenant::resolve));
 
         let listener = tokio::net::TcpListener::bind(SocketAddr::new(
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),

--- a/pubky-homeserver/src/client_server/middleware/request_tenant.rs
+++ b/pubky-homeserver/src/client_server/middleware/request_tenant.rs
@@ -17,7 +17,6 @@ use crate::shared::webdav::StoragePath;
 use super::pubky_host::extract_legacy_pubky;
 
 const STORAGE_ROUTE_PREFIX: &str = "/storage/";
-const RAW_PUBLIC_KEY_LENGTH: usize = 52;
 
 /// Tenant and optional owner-relative storage path resolved before auth runs.
 #[derive(Debug, Clone)]
@@ -35,25 +34,17 @@ impl RequestTenant {
         self.storage_path.as_ref()
     }
 
-    /// The path used for storage policy, independent of its HTTP route shape.
-    pub fn logical_path<'a>(&'a self, request_path: &'a str) -> &'a str {
-        self.storage_path
+    pub fn pubky_url(&self, request_uri: &Uri) -> String {
+        let storage_path = self
+            .storage_path
             .as_ref()
-            .map(StoragePath::as_str)
-            .unwrap_or(request_path)
-    }
-
-    pub fn logical_uri(&self, uri: &Uri) -> String {
-        let mut logical = format!(
-            "pubky://{}{}",
-            self.public_key.z32(),
-            self.logical_path(uri.path())
-        );
-        if let Some(query) = uri.query() {
-            logical.push('?');
-            logical.push_str(query);
+            .map_or(request_uri.path(), StoragePath::as_str);
+        let mut pubky_url = format!("pubky://{}{}", self.public_key.z32(), storage_path);
+        if let Some(query) = request_uri.query() {
+            pubky_url.push('?');
+            pubky_url.push_str(query);
         }
-        logical
+        pubky_url
     }
 
     fn from_request(req: &Request) -> Result<Option<Self>, String> {
@@ -61,10 +52,7 @@ impl RequestTenant {
             return Ok(Some(tenant));
         }
 
-        Ok(extract_legacy_pubky(req).map(|public_key| Self {
-            public_key,
-            storage_path: None,
-        }))
+        Ok(extract_legacy_pubky(req).map(Self::legacy))
     }
 
     /// Returns `Ok(None)` when the URL is not in the `/storage` namespace.
@@ -81,13 +69,6 @@ impl RequestTenant {
             .ok_or_else(|| "Missing storage path".to_string())?;
         if raw_storage_path.is_empty() {
             return Err("Missing storage path".to_string());
-        }
-
-        if PublicKey::is_pubky_prefixed(raw_public_key) {
-            return Err("Storage owner must be a raw z32 public key".to_string());
-        }
-        if raw_public_key.len() != RAW_PUBLIC_KEY_LENGTH {
-            return Err("Storage owner must be a 52-character z32 public key".to_string());
         }
 
         let public_key = PublicKey::try_from_z32(raw_public_key)
@@ -112,6 +93,8 @@ impl RequestTenant {
             }
             Ok(None) => next.run(request).await,
             Err(message) => {
+                // Tenant-aware limits require a resolved owner; malformed requests are
+                // rejected before authentication and storage access.
                 tracing::warn!(
                     method = %request.method(),
                     path = request.uri().path(),
@@ -123,7 +106,6 @@ impl RequestTenant {
         }
     }
 
-    #[cfg(test)]
     pub(crate) fn legacy(public_key: PublicKey) -> Self {
         Self {
             public_key,
@@ -164,7 +146,7 @@ mod tests {
         assert_eq!(tenant.public_key(), &owner);
         assert_eq!(tenant.storage_path().unwrap().as_str(), "/pub/example.txt");
         assert_eq!(
-            tenant.logical_uri(&format!("{path}?limit=10").parse().unwrap()),
+            tenant.pubky_url(&format!("{path}?limit=10").parse().unwrap()),
             format!("pubky://{}/pub/example.txt?limit=10", owner.z32())
         );
     }
@@ -181,7 +163,7 @@ mod tests {
         assert!(RequestTenant::from_storage_route(&format!("/storage/{}/", owner.z32())).is_err());
         assert!(RequestTenant::from_storage_route(&format!(
             "/storage/{}/pub/example.txt",
-            "0".repeat(RAW_PUBLIC_KEY_LENGTH)
+            "0".repeat(52)
         ))
         .is_err());
     }

--- a/pubky-homeserver/src/client_server/middleware/request_tenant.rs
+++ b/pubky-homeserver/src/client_server/middleware/request_tenant.rs
@@ -3,18 +3,14 @@
 //! Canonical storage requests carry their owner in `/storage/{owner}/...`.
 //! Other requests retain the legacy Host / `pubky-host` compatibility lookup.
 
-use std::{convert::Infallible, task::Poll};
-
 use axum::{
-    body::Body,
-    extract::FromRequestParts,
-    http::{request::Parts, Request, StatusCode, Uri},
+    extract::{FromRequestParts, Request},
+    http::{request::Parts, StatusCode, Uri},
+    middleware::Next,
     response::{IntoResponse, Response},
 };
-use futures_util::future::BoxFuture;
 use percent_encoding::percent_decode_str;
 use pubky_common::crypto::PublicKey;
-use tower::{Layer, Service};
 
 use crate::shared::webdav::StoragePath;
 
@@ -23,29 +19,16 @@ use super::pubky_host::extract_legacy_pubky;
 const STORAGE_ROUTE_PREFIX: &str = "/storage/";
 const RAW_PUBLIC_KEY_LENGTH: usize = 52;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum AddressingMode {
-    /// Canonical `/storage/{owner}/...` addressing.
-    Path,
-    /// Compatibility addressing through Host, `pubky-host`, or its query fallback.
-    Legacy,
-}
-
 /// Tenant and optional owner-relative storage path resolved before auth runs.
 #[derive(Debug, Clone)]
 pub struct RequestTenant {
     public_key: PublicKey,
-    addressing: AddressingMode,
     storage_path: Option<StoragePath>,
 }
 
 impl RequestTenant {
     pub fn public_key(&self) -> &PublicKey {
         &self.public_key
-    }
-
-    pub fn addressing(&self) -> AddressingMode {
-        self.addressing
     }
 
     pub fn storage_path(&self) -> Option<&StoragePath> {
@@ -73,14 +56,13 @@ impl RequestTenant {
         logical
     }
 
-    fn resolve(req: &Request<Body>) -> Result<Option<Self>, String> {
+    fn from_request(req: &Request) -> Result<Option<Self>, String> {
         if let Some(tenant) = Self::from_storage_route(req.uri().path())? {
             return Ok(Some(tenant));
         }
 
         Ok(extract_legacy_pubky(req).map(|public_key| Self {
             public_key,
-            addressing: AddressingMode::Legacy,
             storage_path: None,
         }))
     }
@@ -97,6 +79,9 @@ impl RequestTenant {
         let (raw_public_key, raw_storage_path) = remainder
             .split_once('/')
             .ok_or_else(|| "Missing storage path".to_string())?;
+        if raw_storage_path.is_empty() {
+            return Err("Missing storage path".to_string());
+        }
 
         if PublicKey::is_pubky_prefixed(raw_public_key) {
             return Err("Storage owner must be a raw z32 public key".to_string());
@@ -115,16 +100,33 @@ impl RequestTenant {
 
         Ok(Some(Self {
             public_key,
-            addressing: AddressingMode::Path,
             storage_path: Some(storage_path),
         }))
+    }
+
+    pub(crate) async fn resolve(mut request: Request, next: Next) -> Response {
+        match Self::from_request(&request) {
+            Ok(Some(tenant)) => {
+                request.extensions_mut().insert(tenant);
+                next.run(request).await
+            }
+            Ok(None) => next.run(request).await,
+            Err(message) => {
+                tracing::warn!(
+                    method = %request.method(),
+                    path = request.uri().path(),
+                    error = %message,
+                    "Failed to resolve request tenant"
+                );
+                (StatusCode::BAD_REQUEST, message).into_response()
+            }
+        }
     }
 
     #[cfg(test)]
     pub(crate) fn legacy(public_key: PublicKey) -> Self {
         Self {
             public_key,
-            addressing: AddressingMode::Legacy,
             storage_path: None,
         }
     }
@@ -146,52 +148,6 @@ where
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct RequestTenantLayer;
-
-impl<S> Layer<S> for RequestTenantLayer {
-    type Service = RequestTenantMiddleware<S>;
-
-    fn layer(&self, inner: S) -> Self::Service {
-        RequestTenantMiddleware { inner }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct RequestTenantMiddleware<S> {
-    inner: S,
-}
-
-impl<S> Service<Request<Body>> for RequestTenantMiddleware<S>
-where
-    S: Service<Request<Body>, Response = Response, Error = Infallible> + Send + Clone + 'static,
-    S::Future: Send + 'static,
-{
-    type Response = S::Response;
-    type Error = Infallible;
-    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
-
-    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
-        self.inner.poll_ready(cx).map_err(|_| unreachable!())
-    }
-
-    fn call(&mut self, mut req: Request<Body>) -> Self::Future {
-        let resolved = RequestTenant::resolve(&req);
-        let mut inner = self.inner.clone();
-
-        Box::pin(async move {
-            match resolved {
-                Ok(Some(tenant)) => {
-                    req.extensions_mut().insert(tenant);
-                    inner.call(req).await.map_err(|_| unreachable!())
-                }
-                Ok(None) => inner.call(req).await.map_err(|_| unreachable!()),
-                Err(message) => Ok((StatusCode::BAD_REQUEST, message).into_response()),
-            }
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use axum::{body::Body, http::Request};
@@ -206,7 +162,6 @@ mod tests {
         let tenant = RequestTenant::from_storage_route(&path).unwrap().unwrap();
 
         assert_eq!(tenant.public_key(), &owner);
-        assert_eq!(tenant.addressing(), AddressingMode::Path);
         assert_eq!(tenant.storage_path().unwrap().as_str(), "/pub/example.txt");
         assert_eq!(
             tenant.logical_uri(&format!("{path}?limit=10").parse().unwrap()),
@@ -223,6 +178,7 @@ mod tests {
         ))
         .is_err());
         assert!(RequestTenant::from_storage_route("/storage/short/pub/example.txt").is_err());
+        assert!(RequestTenant::from_storage_route(&format!("/storage/{}/", owner.z32())).is_err());
         assert!(RequestTenant::from_storage_route(&format!(
             "/storage/{}/pub/example.txt",
             "0".repeat(RAW_PUBLIC_KEY_LENGTH)
@@ -245,9 +201,9 @@ mod tests {
             .body(Body::empty())
             .unwrap();
 
-        let tenant = RequestTenant::resolve(&req).unwrap().unwrap();
+        let tenant = RequestTenant::from_request(&req).unwrap().unwrap();
         assert_eq!(tenant.public_key(), &path_owner);
-        assert_eq!(tenant.addressing(), AddressingMode::Path);
+        assert!(tenant.storage_path().is_some());
     }
 
     #[test]
@@ -259,9 +215,8 @@ mod tests {
             .body(Body::empty())
             .unwrap();
 
-        let tenant = RequestTenant::resolve(&req).unwrap().unwrap();
+        let tenant = RequestTenant::from_request(&req).unwrap().unwrap();
         assert_eq!(tenant.public_key(), &owner);
-        assert_eq!(tenant.addressing(), AddressingMode::Legacy);
         assert!(tenant.storage_path().is_none());
     }
 }

--- a/pubky-homeserver/src/client_server/middleware/request_tenant.rs
+++ b/pubky-homeserver/src/client_server/middleware/request_tenant.rs
@@ -1,0 +1,267 @@
+//! Resolve the tenant targeted by a client-server request.
+//!
+//! Canonical storage requests carry their owner in `/storage/{owner}/...`.
+//! Other requests retain the legacy Host / `pubky-host` compatibility lookup.
+
+use std::{convert::Infallible, task::Poll};
+
+use axum::{
+    body::Body,
+    extract::FromRequestParts,
+    http::{request::Parts, Request, StatusCode, Uri},
+    response::{IntoResponse, Response},
+};
+use futures_util::future::BoxFuture;
+use percent_encoding::percent_decode_str;
+use pubky_common::crypto::PublicKey;
+use tower::{Layer, Service};
+
+use crate::shared::webdav::StoragePath;
+
+use super::pubky_host::extract_legacy_pubky;
+
+const STORAGE_ROUTE_PREFIX: &str = "/storage/";
+const RAW_PUBLIC_KEY_LENGTH: usize = 52;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AddressingMode {
+    /// Canonical `/storage/{owner}/...` addressing.
+    Path,
+    /// Compatibility addressing through Host, `pubky-host`, or its query fallback.
+    Legacy,
+}
+
+/// Tenant and optional owner-relative storage path resolved before auth runs.
+#[derive(Debug, Clone)]
+pub struct RequestTenant {
+    public_key: PublicKey,
+    addressing: AddressingMode,
+    storage_path: Option<StoragePath>,
+}
+
+impl RequestTenant {
+    pub fn public_key(&self) -> &PublicKey {
+        &self.public_key
+    }
+
+    pub fn addressing(&self) -> AddressingMode {
+        self.addressing
+    }
+
+    pub fn storage_path(&self) -> Option<&StoragePath> {
+        self.storage_path.as_ref()
+    }
+
+    /// The path used for storage policy, independent of its HTTP route shape.
+    pub fn logical_path<'a>(&'a self, request_path: &'a str) -> &'a str {
+        self.storage_path
+            .as_ref()
+            .map(StoragePath::as_str)
+            .unwrap_or(request_path)
+    }
+
+    pub fn logical_uri(&self, uri: &Uri) -> String {
+        let mut logical = format!(
+            "pubky://{}{}",
+            self.public_key.z32(),
+            self.logical_path(uri.path())
+        );
+        if let Some(query) = uri.query() {
+            logical.push('?');
+            logical.push_str(query);
+        }
+        logical
+    }
+
+    fn resolve(req: &Request<Body>) -> Result<Option<Self>, String> {
+        if let Some(tenant) = Self::from_storage_route(req.uri().path())? {
+            return Ok(Some(tenant));
+        }
+
+        Ok(extract_legacy_pubky(req).map(|public_key| Self {
+            public_key,
+            addressing: AddressingMode::Legacy,
+            storage_path: None,
+        }))
+    }
+
+    /// Returns `Ok(None)` when the URL is not in the `/storage` namespace.
+    fn from_storage_route(raw_path: &str) -> Result<Option<Self>, String> {
+        if raw_path == "/storage" || raw_path == "/storage/" {
+            return Err("Missing storage owner or path".to_string());
+        }
+
+        let Some(remainder) = raw_path.strip_prefix(STORAGE_ROUTE_PREFIX) else {
+            return Ok(None);
+        };
+        let (raw_public_key, raw_storage_path) = remainder
+            .split_once('/')
+            .ok_or_else(|| "Missing storage path".to_string())?;
+
+        if PublicKey::is_pubky_prefixed(raw_public_key) {
+            return Err("Storage owner must be a raw z32 public key".to_string());
+        }
+        if raw_public_key.len() != RAW_PUBLIC_KEY_LENGTH {
+            return Err("Storage owner must be a 52-character z32 public key".to_string());
+        }
+
+        let public_key = PublicKey::try_from_z32(raw_public_key)
+            .map_err(|_| "Invalid storage owner public key".to_string())?;
+        let decoded_path = percent_decode_str(raw_storage_path)
+            .decode_utf8()
+            .map_err(|_| "Storage path is not valid UTF-8".to_string())?;
+        let storage_path = StoragePath::normalize(&format!("/{decoded_path}"))
+            .map_err(|error| format!("Invalid storage path: {error}"))?;
+
+        Ok(Some(Self {
+            public_key,
+            addressing: AddressingMode::Path,
+            storage_path: Some(storage_path),
+        }))
+    }
+
+    #[cfg(test)]
+    pub(crate) fn legacy(public_key: PublicKey) -> Self {
+        Self {
+            public_key,
+            addressing: AddressingMode::Legacy,
+            storage_path: None,
+        }
+    }
+}
+
+impl<S> FromRequestParts<S> for RequestTenant
+where
+    S: Sync + Send,
+{
+    type Rejection = Response;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        parts
+            .extensions
+            .get::<RequestTenant>()
+            .cloned()
+            .ok_or((StatusCode::BAD_REQUEST, "Missing request tenant"))
+            .map_err(IntoResponse::into_response)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RequestTenantLayer;
+
+impl<S> Layer<S> for RequestTenantLayer {
+    type Service = RequestTenantMiddleware<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        RequestTenantMiddleware { inner }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RequestTenantMiddleware<S> {
+    inner: S,
+}
+
+impl<S> Service<Request<Body>> for RequestTenantMiddleware<S>
+where
+    S: Service<Request<Body>, Response = Response, Error = Infallible> + Send + Clone + 'static,
+    S::Future: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = Infallible;
+    type Future = BoxFuture<'static, Result<Self::Response, Self::Error>>;
+
+    fn poll_ready(&mut self, cx: &mut std::task::Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx).map_err(|_| unreachable!())
+    }
+
+    fn call(&mut self, mut req: Request<Body>) -> Self::Future {
+        let resolved = RequestTenant::resolve(&req);
+        let mut inner = self.inner.clone();
+
+        Box::pin(async move {
+            match resolved {
+                Ok(Some(tenant)) => {
+                    req.extensions_mut().insert(tenant);
+                    inner.call(req).await.map_err(|_| unreachable!())
+                }
+                Ok(None) => inner.call(req).await.map_err(|_| unreachable!()),
+                Err(message) => Ok((StatusCode::BAD_REQUEST, message).into_response()),
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{body::Body, http::Request};
+    use pubky_common::crypto::Keypair;
+
+    use super::*;
+
+    #[test]
+    fn path_addressing_extracts_owner_and_storage_path() {
+        let owner = Keypair::random().public_key();
+        let path = format!("/storage/{}/pub/example.txt", owner.z32());
+        let tenant = RequestTenant::from_storage_route(&path).unwrap().unwrap();
+
+        assert_eq!(tenant.public_key(), &owner);
+        assert_eq!(tenant.addressing(), AddressingMode::Path);
+        assert_eq!(tenant.storage_path().unwrap().as_str(), "/pub/example.txt");
+        assert_eq!(
+            tenant.logical_uri(&format!("{path}?limit=10").parse().unwrap()),
+            format!("pubky://{}/pub/example.txt?limit=10", owner.z32())
+        );
+    }
+
+    #[test]
+    fn path_addressing_rejects_display_and_invalid_keys() {
+        let owner = Keypair::random().public_key();
+        assert!(RequestTenant::from_storage_route(&format!(
+            "/storage/pubky{}/pub/example.txt",
+            owner.z32()
+        ))
+        .is_err());
+        assert!(RequestTenant::from_storage_route("/storage/short/pub/example.txt").is_err());
+        assert!(RequestTenant::from_storage_route(&format!(
+            "/storage/{}/pub/example.txt",
+            "0".repeat(RAW_PUBLIC_KEY_LENGTH)
+        ))
+        .is_err());
+    }
+
+    #[test]
+    fn canonical_path_ignores_legacy_tenant_inputs() {
+        let path_owner = Keypair::random().public_key();
+        let header_owner = Keypair::random().public_key();
+        let req = Request::builder()
+            .uri(format!(
+                "/storage/{}/pub/example.txt?pubky-host={}",
+                path_owner.z32(),
+                header_owner.z32()
+            ))
+            .header("host", header_owner.z32())
+            .header("pubky-host", "invalid")
+            .body(Body::empty())
+            .unwrap();
+
+        let tenant = RequestTenant::resolve(&req).unwrap().unwrap();
+        assert_eq!(tenant.public_key(), &path_owner);
+        assert_eq!(tenant.addressing(), AddressingMode::Path);
+    }
+
+    #[test]
+    fn non_storage_routes_keep_legacy_resolution() {
+        let owner = Keypair::random().public_key();
+        let req = Request::builder()
+            .uri("/pub/example.txt")
+            .header("pubky-host", owner.z32())
+            .body(Body::empty())
+            .unwrap();
+
+        let tenant = RequestTenant::resolve(&req).unwrap().unwrap();
+        assert_eq!(tenant.public_key(), &owner);
+        assert_eq!(tenant.addressing(), AddressingMode::Legacy);
+        assert!(tenant.storage_path().is_none());
+    }
+}

--- a/pubky-homeserver/src/client_server/middleware/trace.rs
+++ b/pubky-homeserver/src/client_server/middleware/trace.rs
@@ -24,7 +24,7 @@ pub fn with_trace_layer(router: Router) -> Router {
         TraceLayer::new_for_http()
             .make_span_with(move |request: &Request| {
                 let uri = if let Some(tenant) = request.extensions().get::<RequestTenant>() {
-                    tenant.logical_uri(request.uri())
+                    tenant.pubky_url(request.uri())
                 } else {
                     request.uri().to_string()
                 };

--- a/pubky-homeserver/src/client_server/middleware/trace.rs
+++ b/pubky-homeserver/src/client_server/middleware/trace.rs
@@ -7,7 +7,7 @@ use tower_http::trace::{
 };
 use tracing::{Level, Span};
 
-use super::pubky_host::PubkyHost;
+use super::request_tenant::RequestTenant;
 
 // Silence events path from logs to avoid noisy logs. Only log when there is an error.
 const TRACING_EXCLUDED_PATHS: [&str; 1] = ["/events/"];
@@ -23,8 +23,8 @@ pub fn with_trace_layer(router: Router) -> Router {
     router.layer(
         TraceLayer::new_for_http()
             .make_span_with(move |request: &Request| {
-                let uri = if let Some(pubky_host) = request.extensions().get::<PubkyHost>() {
-                    format!("pubky://{}{}", pubky_host.public_key().z32(), request.uri())
+                let uri = if let Some(tenant) = request.extensions().get::<RequestTenant>() {
+                    tenant.logical_uri(request.uri())
                 } else {
                     request.uri().to_string()
                 };

--- a/pubky-homeserver/src/client_server/routes/tenants/mod.rs
+++ b/pubky-homeserver/src/client_server/routes/tenants/mod.rs
@@ -17,14 +17,15 @@ pub mod read;
 pub mod write;
 
 pub fn router() -> Router<AppState> {
-    // Data routes — `/pub/` reads need no auth; `/priv/` reads gate on
-    // `has_read_permission` and writes gate on `has_write_permission`, each
-    // after extracting the session.
     Router::new()
         .route(
+            "/storage/{user_z32}/{*path}",
+            get(read::path_get).head(read::path_head),
+        )
+        .route(
             "/{*path}",
-            get(read::get)
-                .head(read::head)
+            get(read::legacy_get)
+                .head(read::legacy_head)
                 .put(write::put)
                 .delete(write::delete),
         )

--- a/pubky-homeserver/src/client_server/routes/tenants/read.rs
+++ b/pubky-homeserver/src/client_server/routes/tenants/read.rs
@@ -1099,6 +1099,7 @@ mod tests {
             "/storage/".to_string(),
             "/storage/short/pub/file.txt".to_string(),
             format!("/storage/pubky{}/pub/file.txt", public_key.z32()),
+            format!("/storage/{}/", public_key.z32()),
         ];
         for path in malformed {
             let response = server

--- a/pubky-homeserver/src/client_server/routes/tenants/read.rs
+++ b/pubky-homeserver/src/client_server/routes/tenants/read.rs
@@ -3,7 +3,7 @@ use crate::shared::{HttpError, HttpResult};
 use crate::{
     client_server::{
         auth::{has_read_permission, AuthSession},
-        middleware::pubky_host::PubkyHost,
+        middleware::request_tenant::RequestTenant,
         query_params::ListQueryParams,
         AppState,
     },
@@ -20,20 +20,51 @@ use sqlx::types::chrono::{DateTime, Utc};
 use std::str::FromStr;
 use std::time::SystemTime;
 
-pub async fn head(
+fn path_entry_path(tenant: &RequestTenant) -> HttpResult<EntryPath> {
+    let path = tenant
+        .storage_path()
+        .cloned()
+        .ok_or_else(|| HttpError::bad_request("Missing path-addressed storage target"))?;
+    Ok(EntryPath::new(tenant.public_key().clone(), path))
+}
+
+pub async fn legacy_head(
     State(state): State<AppState>,
     session: Option<AuthSession>,
-    pubky: PubkyHost,
+    tenant: RequestTenant,
     Path(path): Path<WebDavPathAxum>,
 ) -> HttpResult<impl IntoResponse> {
-    has_read_permission(session.as_ref(), Some(pubky.public_key()), path.inner())?;
+    let entry_path = EntryPath::new(tenant.public_key().clone(), path.inner().clone());
+    let mut response = head(state, session, entry_path).await?;
+    response
+        .headers_mut()
+        .insert(header::VARY, HeaderValue::from_static("pubky-host"));
+    Ok(response)
+}
+
+pub async fn path_head(
+    State(state): State<AppState>,
+    session: Option<AuthSession>,
+    tenant: RequestTenant,
+) -> HttpResult<impl IntoResponse> {
+    head(state, session, path_entry_path(&tenant)?).await
+}
+
+async fn head(
+    state: AppState,
+    session: Option<AuthSession>,
+    entry_path: EntryPath,
+) -> HttpResult<Response<Body>> {
+    has_read_permission(
+        session.as_ref(),
+        Some(entry_path.pubkey()),
+        entry_path.path(),
+    )?;
 
     state
         .user_service
-        .get_or_http_error(pubky.public_key(), false)
+        .get_or_http_error(entry_path.pubkey(), false)
         .await?;
-
-    let entry_path = EntryPath::new(pubky.public_key().clone(), path.inner().clone());
 
     let entry = state
         .file_service
@@ -44,18 +75,46 @@ pub async fn head(
 }
 
 #[axum::debug_handler]
-pub async fn get(
+pub async fn legacy_get(
     State(state): State<AppState>,
     headers: HeaderMap,
     session: Option<AuthSession>,
-    pubky: PubkyHost,
+    tenant: RequestTenant,
     Path(path): Path<WebDavPathAxum>,
     params: ListQueryParams,
 ) -> HttpResult<impl IntoResponse> {
-    has_read_permission(session.as_ref(), Some(pubky.public_key()), path.inner())?;
+    let entry_path = EntryPath::new(tenant.public_key().clone(), path.inner().clone());
+    let mut response = get(state, headers, session, entry_path, params).await?;
+    response
+        .headers_mut()
+        .insert(header::VARY, HeaderValue::from_static("pubky-host"));
+    Ok(response)
+}
 
-    let public_key = pubky.public_key().clone();
-    let entry_path = EntryPath::new(public_key.clone(), path.inner().clone());
+#[axum::debug_handler]
+pub async fn path_get(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    session: Option<AuthSession>,
+    tenant: RequestTenant,
+    params: ListQueryParams,
+) -> HttpResult<impl IntoResponse> {
+    get(state, headers, session, path_entry_path(&tenant)?, params).await
+}
+
+async fn get(
+    state: AppState,
+    headers: HeaderMap,
+    session: Option<AuthSession>,
+    entry_path: EntryPath,
+    params: ListQueryParams,
+) -> HttpResult<Response<Body>> {
+    has_read_permission(
+        session.as_ref(),
+        Some(entry_path.pubkey()),
+        entry_path.path(),
+    )?;
+
     if entry_path.path().is_directory() {
         return list(state, &entry_path, params).await;
     }
@@ -189,7 +248,6 @@ fn not_modified_response(entry: &EntryEntity) -> HttpResult<Response<Body>> {
             header::LAST_MODIFIED,
             to_http_date(&entry.modified_at).to_string().as_str(),
         )
-        .header(header::VARY, "pubky-host")
         .header(header::CACHE_CONTROL, "private, must-revalidate")
         .body(Body::empty())?)
 }
@@ -229,8 +287,6 @@ impl EntryEntity {
             .try_into()
             .expect("base64 string is valid"),
         );
-        // tenant-aware caching
-        headers.insert(header::VARY, HeaderValue::from_static("pubky-host"));
         headers.insert(
             header::CACHE_CONTROL,
             HeaderValue::from_static("private, must-revalidate"),
@@ -328,6 +384,17 @@ mod tests {
 
     fn header_value(headers: &HeaderMap, name: header::HeaderName) -> Option<&str> {
         headers.get(name).and_then(|value| value.to_str().ok())
+    }
+
+    fn assert_does_not_vary_on(headers: &HeaderMap, ignored_header: &str) {
+        let varies_on_ignored_header = header_value(headers, header::VARY)
+            .into_iter()
+            .flat_map(|vary| vary.split(','))
+            .any(|name| name.trim().eq_ignore_ascii_case(ignored_header));
+        assert!(
+            !varies_on_ignored_header,
+            "response must not vary on {ignored_header}"
+        );
     }
 
     fn assert_private_cache_policy(headers: &HeaderMap) {
@@ -912,5 +979,141 @@ mod tests {
             .expect_success()
             .await;
         assert!(header_value(listing.headers(), header::CACHE_CONTROL).is_none());
+        assert_eq!(
+            header_value(listing.headers(), header::VARY),
+            Some("pubky-host")
+        );
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn path_addressed_get_and_head_ignore_legacy_tenant_headers() {
+        let (_, _, server, public_key, cookie) = create_environment().await.unwrap();
+        let other = Keypair::random().public_key();
+
+        server
+            .put("/pub/file.txt")
+            .add_header("host", public_key.z32())
+            .add_header(header::COOKIE, cookie)
+            .text("path addressed")
+            .expect_success()
+            .await;
+
+        let url = format!(
+            "/storage/{}/pub/file.txt?pubky-host={}",
+            public_key.z32(),
+            other.z32()
+        );
+        let response = server
+            .get(&url)
+            .add_header("pubky-host", other.z32())
+            .expect_success()
+            .await;
+        assert_eq!(response.text(), "path addressed");
+        assert_does_not_vary_on(response.headers(), "pubky-host");
+
+        let head = server
+            .method(Method::HEAD, &url)
+            .add_header("pubky-host", "invalid")
+            .await;
+        head.assert_status(StatusCode::OK);
+        assert_does_not_vary_on(head.headers(), "pubky-host");
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn path_addressed_listing_preserves_pagination() {
+        let (_, _, server, public_key, cookie) = create_environment().await.unwrap();
+
+        for name in ["a.txt", "b.txt"] {
+            server
+                .put(&format!("/pub/app/{name}"))
+                .add_header("host", public_key.z32())
+                .add_header(header::COOKIE, cookie.clone())
+                .text(name)
+                .expect_success()
+                .await;
+        }
+
+        let base = format!("/storage/{}/pub/app/", public_key.z32());
+        let first = server
+            .get(&format!("{base}?limit=1"))
+            .expect_success()
+            .await;
+        let first_entry = first.text();
+        assert_eq!(first_entry.lines().count(), 1);
+        assert_does_not_vary_on(first.headers(), "pubky-host");
+
+        let cursor = first_entry.trim_start_matches("pubky://");
+        let second = server
+            .get(&format!("{base}?limit=1&cursor={cursor}"))
+            .expect_success()
+            .await;
+        let second_entry = second.text();
+        assert_eq!(second_entry.lines().count(), 1);
+        assert_ne!(first_entry, second_entry);
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn path_addressed_private_reads_use_path_owner_cookie_and_cache_policy() {
+        let (_, _, server, public_key, cookie) = create_environment().await.unwrap();
+
+        server
+            .put("/priv/secret.txt")
+            .add_header("host", public_key.z32())
+            .add_header(header::COOKIE, cookie.clone())
+            .text("private")
+            .expect_success()
+            .await;
+
+        let url = format!("/storage/{}/priv/secret.txt", public_key.z32());
+        server
+            .get(&url)
+            .await
+            .assert_status(StatusCode::UNAUTHORIZED);
+
+        let response = server
+            .get(&url)
+            .add_header(header::COOKIE, cookie)
+            .expect_success()
+            .await;
+        assert_eq!(response.text(), "private");
+        assert_eq!(
+            header_value(response.headers(), header::CACHE_CONTROL),
+            Some("no-store")
+        );
+        assert_eq!(
+            header_value(response.headers(), header::VARY),
+            Some("Authorization, Cookie")
+        );
+    }
+
+    #[tokio::test]
+    #[pubky_test_utils::test]
+    async fn malformed_path_addressing_is_a_client_error_and_writes_are_not_enabled() {
+        let (_, _, server, public_key, _) = create_environment().await.unwrap();
+
+        let malformed = [
+            "/storage".to_string(),
+            "/storage/".to_string(),
+            "/storage/short/pub/file.txt".to_string(),
+            format!("/storage/pubky{}/pub/file.txt", public_key.z32()),
+        ];
+        for path in malformed {
+            let response = server
+                .get(&path)
+                .add_header(header::ORIGIN, "https://app.example")
+                .await;
+            response.assert_status(StatusCode::BAD_REQUEST);
+            assert!(response
+                .headers()
+                .contains_key(header::ACCESS_CONTROL_ALLOW_ORIGIN));
+        }
+
+        server
+            .put(&format!("/storage/{}/pub/file.txt", public_key.z32()))
+            .await
+            .assert_status(StatusCode::METHOD_NOT_ALLOWED);
     }
 }

--- a/pubky-homeserver/src/client_server/routes/tenants/write.rs
+++ b/pubky-homeserver/src/client_server/routes/tenants/write.rs
@@ -10,7 +10,7 @@ use futures_util::stream::StreamExt;
 use crate::{
     client_server::{
         auth::{has_write_permission, AuthSession},
-        middleware::pubky_host::PubkyHost,
+        middleware::request_tenant::RequestTenant,
         AppState,
     },
     persistence::{
@@ -30,12 +30,12 @@ use crate::{
 pub async fn delete(
     State(state): State<AppState>,
     session: AuthSession,
-    pubky: PubkyHost,
+    tenant: RequestTenant,
     Path(path): Path<WebDavFilePathAxum>,
 ) -> HttpResult<impl IntoResponse> {
-    has_write_permission(&session, pubky.public_key(), path.inner())?;
+    has_write_permission(&session, tenant.public_key(), path.inner())?;
 
-    let public_key = pubky.public_key();
+    let public_key = tenant.public_key();
     state
         .user_service
         .get_or_http_error(public_key, false)
@@ -49,14 +49,14 @@ pub async fn delete(
 pub async fn put(
     State(state): State<AppState>,
     session: AuthSession,
-    pubky: PubkyHost,
+    tenant: RequestTenant,
     Path(path): Path<WebDavFilePathAxum>,
     headers: HeaderMap,
     body: Body,
 ) -> HttpResult<impl IntoResponse> {
-    has_write_permission(&session, pubky.public_key(), path.inner())?;
+    has_write_permission(&session, tenant.public_key(), path.inner())?;
 
-    let public_key = pubky.public_key();
+    let public_key = tenant.public_key();
     let user = state
         .user_service
         .get_or_http_error(public_key, true)

--- a/pubky-homeserver/src/shared/webdav/entry_path.rs
+++ b/pubky-homeserver/src/shared/webdav/entry_path.rs
@@ -34,7 +34,6 @@ impl EntryPath {
         Self { pubkey, path, key }
     }
 
-    #[allow(dead_code)]
     pub fn pubkey(&self) -> &PublicKey {
         &self.pubkey
     }


### PR DESCRIPTION
Closes #524.

### Summary

Adds new APIs for storage reads:

- `GET /storage/{user_z32}/{path}`
- `HEAD /storage/{user_z32}/{path}`

The path owner is authoritative. `Host` remains the HTTP authority, while legacy `pubky-host` headers and query parameters are ignored by canonical routes. Legacy owner-relative routes remain supported for compatibility.

| | New path-addressed route | Legacy owner-relative route |
|---|---|---|
| Example | `GET /storage/{user_z32}/pub/file.txt` | `GET /pub/file.txt` |
| Storage owner | `{user_z32}` path segment | `pubky-host`, `Host`, or query fallback |
| `pubky-host` | Accepted but ignored | Used for owner resolution |
| Read methods | GET and HEAD | GET and HEAD |

Both route forms create the same internal `EntryPath` and use the existing persistence and OpenDAL implementation. No database or physical-storage migration is introduced.

### Acceptance criteria

- [x] GET, HEAD, and paginated directory listings work through `/storage/{user_z32}/...`.
- [x] The path owner cannot be overridden by legacy tenant inputs.
- [x] Legacy read and write routes continue working.
- [x] Legacy and canonical reads share the same storage handlers and `EntryPath`.
- [x] Data written through a legacy route can be read through the canonical route.
- [x] Authorization, caching, tracing, and rate-limit behavior is preserved.
- [x] Malformed canonical routes return `4xx`.
- [x] No database, OpenDAL, or physical-storage migration is required.
- [x] Legacy routes and parameters are documented as deprecated.