### PR TITLE
docs(sdk): Make in-code documentation more user friendly

### DIFF
--- a/pubky-sdk/src/actors/auth/grant/manager.rs
+++ b/pubky-sdk/src/actors/auth/grant/manager.rs
@@ -16,8 +16,31 @@ use crate::util::check_http_status;
 use crate::{PubkyHttpClient, PubkySession};
 
 /// Account-level grant management for a signed-in user.
-/// Requires a session with the root capability; non-root sessions get `403
-/// Forbidden` from the homeserver.
+///
+/// Use this to list and revoke grants (app permissions) for your account.
+/// Requires a session with the **root capability**; non-root sessions get
+/// `403 Forbidden` from the homeserver.
+///
+/// # Example
+///
+/// ```no_run
+/// use pubky::GrantManager;
+///
+/// # async fn example(session: pubky::PubkySession) -> pubky::Result<()> {
+/// let manager = GrantManager::new(&session);
+///
+/// // List all active grants
+/// let grants = manager.list().await?;
+/// for grant in &grants {
+///     println!("grant {} from client {}", grant.grant_id, grant.client_id);
+/// }
+///
+/// // Revoke a specific grant
+/// if let Some(grant) = grants.first() {
+///     manager.revoke(&grant.grant_id).await?;
+/// }
+/// # Ok(()) }
+/// ```
 #[derive(Debug, Clone)]
 pub struct GrantManager {
     client: PubkyHttpClient,

--- a/pubky-sdk/src/actors/auth/kind.rs
+++ b/pubky-sdk/src/actors/auth/kind.rs
@@ -1,31 +1,43 @@
 use crate::PublicKey;
 
 /// The kind of authentication flow to perform.
+///
+/// Used when starting a [`PubkyGrantAuthFlow`](crate::PubkyGrantAuthFlow) or
+/// legacy cookie auth flow to tell the SDK whether the user already has an
+/// account (`SignIn`) or needs to create one (`SignUp`).
+///
+/// # When to use which
+///
+/// - **`SignIn`** — the user already signed up on a homeserver. The flow
+///   authenticates against the existing account.
+/// - **`SignUp`** — the user does not yet have an account. The flow creates
+///   the account on the specified homeserver as part of the auth handshake.
+///   Some homeservers require a `signup_token` (invite code).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AuthFlowKind {
     /// Sign in to an existing account.
     SignIn,
-    /// Sign up for a new account.
+    /// Sign up for a new account on a specific homeserver.
     SignUp {
         /// The public key of the homeserver to sign up on.
         homeserver_public_key: Box<PublicKey>,
-        /// The signup token to use for the signup flow.
-        /// This is optional.
+        /// Optional invite token required by some homeservers.
         signup_token: Option<String>,
     },
 }
 
 impl AuthFlowKind {
-    /// Create a sign in flow.
+    /// Create a sign-in flow kind.
     #[must_use]
     pub fn signin() -> Self {
         Self::SignIn
     }
 
-    /// Create a sign up flow.
+    /// Create a sign-up flow kind.
+    ///
     /// # Arguments
-    /// * `homeserver_public_key` - The public key of the homeserver to sign up on.
-    /// * `signup_token` - The signup token to use for the signup flow. This is optional.
+    /// - `homeserver_public_key` — the public key of the homeserver to create the account on.
+    /// - `signup_token` — optional invite token required by some homeservers.
     #[must_use]
     pub fn signup(homeserver_public_key: PublicKey, signup_token: Option<String>) -> Self {
         Self::SignUp {

--- a/pubky-sdk/src/actors/auth/kind.rs
+++ b/pubky-sdk/src/actors/auth/kind.rs
@@ -8,11 +8,11 @@ use crate::PublicKey;
 ///
 /// # When to use which
 ///
-/// - **`SignIn`** — the user already signed up on a homeserver. The flow
-///   authenticates against the existing account.
 /// - **`SignUp`** — the user does not yet have an account. The flow creates
 ///   the account on the specified homeserver as part of the auth handshake.
 ///   Some homeservers require a `signup_token` (invite code).
+/// - **`SignIn`** — the user already signed up on a homeserver. The flow
+///   authenticates against the existing account.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum AuthFlowKind {
     /// Sign in to an existing account.

--- a/pubky-sdk/src/actors/session/core.rs
+++ b/pubky-sdk/src/actors/session/core.rs
@@ -26,9 +26,8 @@ use crate::{PubkyHttpClient, Result, SessionStorage, cross_log};
 ///
 /// # Concurrency
 ///
-/// `PubkySession` is **cheap to clone** and **thread-safe**. It shares the
-/// underlying [`PubkyHttpClient`] and credential state via `Arc`. Pass clones
-/// freely to async tasks or threads.
+/// `PubkySession` is **cheap to clone** and **thread-safe**. Pass clones freely to
+/// async tasks or threads.
 ///
 /// # Persistence
 ///

--- a/pubky-sdk/src/actors/session/core.rs
+++ b/pubky-sdk/src/actors/session/core.rs
@@ -8,36 +8,52 @@ use super::credential::SessionCredential;
 use crate::errors::Error;
 use crate::{PubkyHttpClient, Result, SessionStorage, cross_log};
 
-/// Stateful, per-identity API driver built on a shared [`PubkyHttpClient`].
+/// Your authenticated handle after signing in.
 ///
 /// A `PubkySession` represents one user/identity authenticated to a homeserver.
-/// It hides the choice of credential (legacy cookie vs grant-based) behind
-/// a single API: callers always go through `info()`, `storage()`, `revalidate()`,
-/// `signout()`, etc., and the SDK dispatches to the right wire format internally
-/// via an internal credential trait.
+/// It carries credentials automatically and provides access to
+/// [`SessionStorage`] for reading and writing data as the signed-in user.
 ///
-/// What it does:
+/// # What it does
+///
 /// - Attaches the correct authentication header (`Cookie` or `Authorization: Bearer`)
-///   to requests targeting this user's homeserver.
-/// - Exposes homeserver verbs (`get/put/post/patch/delete/head`) scoped to this identity.
-/// - Implements identity flows: `signup`, `signin`, `signout`, `session`, and pubkyauth.
+///   to every request targeting this user's homeserver.
+/// - Provides [`storage()`](Self::storage) for path-based CRUD operations as this user.
+/// - Supports session lifecycle: [`revalidate()`](Self::revalidate) and
+///   [`signout()`](Self::signout).
+/// - Offers credential-specific views via [`as_grant()`](Self::as_grant) and
+///   [`as_cookie()`](Self::as_cookie) for grant management or secret export.
 ///
-/// To opaque bearer-only or cookie-only operations (grant management, secret
-/// export), use the capability-view accessors [`Self::as_grant`] and
-/// [`Self::as_cookie`].
+/// # Concurrency
 ///
-/// Credential-specific factory functions live alongside each auth flow:
-/// - Cookie: `crate::actors::auth::cookie` — `CookieCredential::from_auth_token`
-///   and the `secret` module for rehydration helpers.
-/// - Grant: `crate::actors::auth::grant::grant_exchange` —
-///   `credential_from_grant_exchange`.
+/// `PubkySession` is **cheap to clone** and **thread-safe**. It shares the
+/// underlying [`PubkyHttpClient`] and credential state via `Arc`. Pass clones
+/// freely to async tasks or threads.
 ///
-/// Thin delegations on `PubkySession` (`export`, `import`, `import_secret`,
-/// `from_secret_file`) preserve the public API surface.
+/// # Persistence
 ///
-/// Concurrency:
-/// - `PubkySession` is cheap to clone and thread-safe; it shares the underlying
-///   [`PubkyHttpClient`] and credential state via `Arc`.
+/// Sessions can survive process restarts. See
+/// [`GrantSessionView::export_local_secret`](crate::GrantSessionView::export_local_secret)
+/// and [`Pubky::restore_session`](crate::Pubky::restore_session).
+///
+/// # Example
+///
+/// ```no_run
+/// # async fn run(session: pubky::PubkySession) -> pubky::Result<()> {
+/// // Write data
+/// session.storage().put("/pub/my.app/greeting.txt", "hello").await?;
+///
+/// // Read it back
+/// let text = session.storage().get("/pub/my.app/greeting.txt").await?.text().await?;
+/// assert_eq!(text, "hello");
+///
+/// // List a directory
+/// let entries = session.storage().list("/pub/my.app/")?.send().await?;
+///
+/// // Sign out when done
+/// session.signout().await.map_err(|(e, _session)| e)?;
+/// # Ok(()) }
+/// ```
 #[derive(Clone)]
 pub struct PubkySession {
     pub(crate) client: PubkyHttpClient,

--- a/pubky-sdk/src/actors/signer/auth.rs
+++ b/pubky-sdk/src/actors/signer/auth.rs
@@ -25,20 +25,20 @@ use crate::{
 use super::PubkySigner;
 
 impl PubkySigner {
-    /// Produces sessions for an app (e.g. Pubky Ring -> App). Sends a signed
-    /// `AuthToken` (legacy flow) or a signed `pubky-grant` JWS (grant
-    /// flow) to the relay channel encoded in a `pubkyauth://` URL.
+    /// Approve an auth request from another app (wallet / signer side).
     ///
-    /// Typical usage:
-    /// - App constructs `PubkyCookieAuthFlow` or `PubkyGrantAuthFlow` and subscribes, shows QR/deeplink.
-    /// - Signer calls `send_auth_token` with that URL.
+    /// Sends a signed `AuthToken` (legacy flow) or a signed `pubky-grant` JWS
+    /// (grant flow) to the relay channel encoded in the `pubkyauth://` URL.
     ///
-    /// Requirements:
-    /// - URL parses as a [`DeepLink::Signin`], [`DeepLink::Signup`],
-    ///   [`DeepLink::SigninGrant`], or [`DeepLink::SignupGrant`].
-    /// - Channel is derived as `<relay>/<base64url(hash(secret))>`.
+    /// # Typical usage
     ///
-    /// Use [`Self::handle_deeplink`] for direct signup links.
+    /// 1. The **requesting app** constructs a [`PubkyGrantAuthFlow`](crate::PubkyGrantAuthFlow)
+    ///    and displays `authorization_url()` as a QR code or deep link.
+    /// 2. The **signer app** (e.g. Pubky Ring) scans the QR and calls `approve_auth`
+    ///    with the scanned URL.
+    /// 3. The requesting app receives the approval and obtains a session.
+    ///
+    /// Use [`Self::handle_deeplink`] instead if the URL might be a `direct_signup` link.
     ///
     /// # Errors
     /// - Returns [`crate::errors::Error::Authentication`] if the `pubkyauth://`

--- a/pubky-sdk/src/actors/signer/core.rs
+++ b/pubky-sdk/src/actors/signer/core.rs
@@ -1,6 +1,35 @@
 use crate::{BuildError, Keypair, PubkyHttpClient, PublicKey};
 
-/// Key holder and signer.
+/// Holds a private key and proves identity.
+///
+/// Use a `PubkySigner` to:
+/// - **Sign up** for a homeserver ([`signup`](crate::PubkySigner::signup)).
+/// - **Sign in** locally to get a [`PubkySession`](crate::PubkySession)
+///   ([`signin`](crate::PubkySigner::signin)).
+/// - **Approve auth** requests from other apps via QR / deep link
+///   ([`approve_auth`](crate::PubkySigner::approve_auth),
+///   [`handle_deeplink`](crate::PubkySigner::handle_deeplink)).
+/// - **Publish PKDNS** records so others can discover your homeserver
+///   ([`pkdns()`](crate::PubkySigner::pkdns)).
+///
+/// # Creating a signer
+///
+/// Prefer [`Pubky::signer`](crate::Pubky::signer) to share the same HTTP
+/// client. Use [`PubkySigner::new`] only when you don't have a [`Pubky`](crate::Pubky) facade.
+///
+/// # Quick start
+///
+/// ```no_run
+/// use pubky::{Pubky, Keypair, ClientId};
+///
+/// # async fn run() -> pubky::Result<()> {
+/// let signer = Pubky::testnet()?.signer(Keypair::random());
+///
+/// // See signup() and signin() for full examples
+/// let session = signer.signin(ClientId::new("my.app").unwrap()).await?;
+/// session.storage().put("/pub/my.app/hello.txt", "world").await?;
+/// # Ok(()) }
+/// ```
 #[derive(Debug, Clone)]
 pub struct PubkySigner {
     pub(crate) client: PubkyHttpClient,
@@ -8,15 +37,15 @@ pub struct PubkySigner {
 }
 
 impl PubkySigner {
-    /// Construct a new `PubkySigner`.
+    /// Construct a standalone `PubkySigner` with its own HTTP client.
     ///
-    /// This is your entry point to keychain managing tooling.
+    /// If you already have a [`Pubky`](crate::Pubky) facade, prefer
+    /// [`Pubky::signer`](crate::Pubky::signer) to share the connection pool.
     ///
     /// # Examples
     /// ```
     /// # use pubky::{PubkySigner, Keypair};
-    /// let keypair = Keypair::random();
-    /// let app  = PubkySigner::new(keypair)?;
+    /// let signer = PubkySigner::new(Keypair::random())?;
     /// # Ok::<_, pubky::BuildError>(())
     /// ```
     ///

--- a/pubky-sdk/src/actors/signer/session.rs
+++ b/pubky-sdk/src/actors/signer/session.rs
@@ -34,11 +34,17 @@ enum PublishMode {
 impl PubkySigner {
     /// Create an account on a homeserver.
     ///
-    /// Side effects:
-    /// - Publishes the `_pubky` pkarr record pointing to `homeserver` (force mode).
+    /// This is a **one-time** operation. After signing up, call
+    /// [`signin`](Self::signin) to obtain a [`PubkySession`] for reading and
+    /// writing data.
     ///
-    /// Notes:
-    /// - Uses a short-lived root grant + `PoP` proof (sufficient for signup).
+    /// Side effects:
+    /// - Publishes the `_pubky` PKARR record pointing to `homeserver` (force mode),
+    ///   so other users can discover this identity.
+    ///
+    /// # Arguments
+    /// - `homeserver` — public key of the homeserver to register on.
+    /// - `signup_token` — optional invite token required by some homeservers.
     ///
     /// # Errors
     /// - Returns [`crate::errors::Error::Parse`] if the homeserver URL cannot be constructed.
@@ -64,14 +70,26 @@ impl PubkySigner {
         Ok(())
     }
 
-    // All of these methods use root capabilities
-
-    /// Sign in to the users homeserver by locally signing a root-capability token.
-    /// This call returns a user session.
+    /// Sign in to the user's homeserver and return a [`PubkySession`].
     ///
-    /// In case the users pkdns records are stale, this call with republish them in the background.
+    /// Locally signs a root-capability grant and exchanges it for a
+    /// session at the homeserver. If the user's PKDNS record is stale,
+    /// it is republished **in the background** so this call returns fast.
     ///
-    /// Prefer this signin for best user experience, it returns fast.
+    /// # Arguments
+    /// - `client_id` — a [`ClientId`] identifying your application (e.g.
+    ///   `ClientId::new("my.app").unwrap()`). The homeserver records which
+    ///   app holds each grant.
+    ///
+    /// # Example
+    /// ```no_run
+    /// # use pubky::{Pubky, Keypair, ClientId};
+    /// # async fn run() -> pubky::Result<()> {
+    /// let signer = Pubky::new()?.signer(Keypair::random());
+    /// let session = signer.signin(ClientId::new("my.app").unwrap()).await?;
+    /// println!("Signed in as {}", session.public_key());
+    /// # Ok(()) }
+    /// ```
     ///
     /// # Errors
     /// - Propagates transport failures during the session exchange.
@@ -81,11 +99,16 @@ impl PubkySigner {
             .await
     }
 
-    /// Sign in by locally signing a root-capability token. Returns a session-bound session.
-    /// Publishes the homeserver record if stale in the background.
+    /// Sign in, **blocking** until the PKDNS record is republished (if stale).
     ///
-    /// Prefer this signin for highest guarantees of discoverability from Dht and pkarr relays,
-    /// it returns slow (~3-5 seconds).
+    /// Unlike [`Self::signin`], this variant waits for the homeserver PKDNS
+    /// record to be fully published before returning. This gives the highest
+    /// guarantee of discoverability from the DHT and Pkarr relays, at the
+    /// cost of being slower (~3–5 seconds).
+    ///
+    /// Use this when the signer's identity must be immediately discoverable
+    /// by other users (e.g. first-time setup). For interactive apps, prefer
+    /// [`Self::signin`] which publishes in the background.
     ///
     /// # Errors
     /// - Propagates transport failures during the session exchange.

--- a/pubky-sdk/src/actors/storage/core.rs
+++ b/pubky-sdk/src/actors/storage/core.rs
@@ -9,12 +9,44 @@ use crate::{
     errors::{RequestError, Result},
 };
 
-/// Storage that acts **as the signed-in user** (authenticated).
+/// Read and write **your own data** with simple path-based operations (authenticated).
 ///
-/// Accepts **absolute paths** (`ResourcePath`) only; the user is implied by the session.
-/// Writes are allowed.
+/// Obtained via [`PubkySession::storage()`]. The user is implied by the session —
+/// you only supply **absolute paths** (e.g. `"/pub/my.app/file.txt"`).
+/// The SDK resolves the homeserver and attaches credentials automatically.
 ///
-/// Returned by [`PubkySession::storage()`].
+/// # Path conventions
+///
+/// - Paths under `/pub/` are **publicly readable** by anyone via [`PublicStorage`].
+/// - Paths under `/priv/` are **private** to the signed-in user.
+///
+/// # Example
+///
+/// ```no_run
+/// # async fn example(session: pubky::PubkySession) -> pubky::Result<()> {
+/// let storage = session.storage();
+///
+/// // Write
+/// storage.put("/pub/my.app/hello.txt", "world").await?;
+///
+/// // Read
+/// let body = storage.get("/pub/my.app/hello.txt").await?.text().await?;
+///
+/// // Check existence
+/// let exists = storage.exists("/pub/my.app/hello.txt").await?;
+///
+/// // Metadata (content-length, content-type, etag, last-modified)
+/// if let Some(stats) = storage.stats("/pub/my.app/hello.txt").await? {
+///     println!("size: {:?}", stats.content_length);
+/// }
+///
+/// // List a directory (path must end with `/`)
+/// let entries = storage.list("/pub/my.app/")?.limit(50).send().await?;
+///
+/// // Delete
+/// storage.delete("/pub/my.app/hello.txt").await?;
+/// # Ok(()) }
+/// ```
 #[derive(Debug, Clone)]
 pub struct SessionStorage {
     pub(crate) client: PubkyHttpClient,
@@ -70,10 +102,44 @@ impl SessionStorage {
     }
 }
 
-/// Storage that reads **public data for any user** (unauthenticated).
+/// Read **anyone's public data** without signing in (unauthenticated).
 ///
-/// Accepts **addressed resources** (`PubkyResource`: user + absolute path).
-/// Writes are not available.
+/// No keys or session needed. Accepts **addressed resources** that pair a user's
+/// public key with an absolute path. Supported address formats:
+/// - `"pubky://<z32-pubkey>/pub/..."` (canonical)
+/// - `"pubky<z32-pubkey>/pub/..."` (compact)
+/// - `(PublicKey, "/pub/...")` tuple
+///
+/// Writes are not available — use [`SessionStorage`] for that.
+///
+/// # Example
+///
+/// ```no_run
+/// use pubky::{Pubky, PublicKey};
+///
+/// # async fn example() -> pubky::Result<()> {
+/// let pubky = Pubky::new()?;
+/// let user: PublicKey = "o1gg96ewuojmopcjbz8895478wdtxtzzuxnfjjz8o8e77csa1ngo"
+///     .parse().unwrap();
+///
+/// let public = pubky.public_storage();
+///
+/// // Read a file
+/// let body = public
+///     .get(format!("pubky://{}/pub/pubky.app/profile.json", user.z32()))
+///     .await?
+///     .text().await?;
+///
+/// // Or use a tuple
+/// let exists = public.exists((&user, "/pub/pubky.app/profile.json")).await?;
+///
+/// // List a directory
+/// let entries = public
+///     .list(format!("pubky://{}/pub/pubky.app/", user.z32()))?
+///     .shallow(true)
+///     .send().await?;
+/// # Ok(()) }
+/// ```
 #[derive(Debug, Clone)]
 pub struct PublicStorage {
     pub(crate) client: PubkyHttpClient,

--- a/pubky-sdk/src/actors/storage/json.rs
+++ b/pubky-sdk/src/actors/storage/json.rs
@@ -14,6 +14,8 @@ impl SessionStorage {
     ///
     /// Sets `Accept: application/json` and returns `T` via `resp.json()`.
     ///
+    /// *Requires the **`json`** crate feature.*
+    ///
     /// # Errors
     /// - Returns [`crate::errors::Error::Parse`] if `path` cannot be converted into a valid resource path.
     /// - Propagates transport failures or JSON deserialization errors from the underlying HTTP request.
@@ -35,6 +37,8 @@ impl SessionStorage {
     /// PUT JSON to an **absolute path** and return the raw `Response`.
     ///
     /// Serializes `body` as JSON.
+    ///
+    /// *Requires the **`json`** crate feature.*
     ///
     /// # Errors
     /// - Returns [`crate::errors::Error::Parse`] if `path` cannot be converted into a valid resource path.
@@ -60,6 +64,8 @@ impl SessionStorage {
 
 impl PublicStorage {
     /// GET and deserialize JSON from an **addressed resource**.
+    ///
+    /// *Requires the **`json`** crate feature.*
     ///
     /// # Errors
     /// - Returns [`crate::errors::Error::Parse`] if `addr` cannot be converted into a valid addressed resource.

--- a/pubky-sdk/src/actors/storage/list.rs
+++ b/pubky-sdk/src/actors/storage/list.rs
@@ -136,7 +136,10 @@ impl<'a> ListBuilder<'a> {
         self
     }
 
-    /// Resume listing from a previous `cursor` token.
+    /// Resume listing from a previous cursor.
+    ///
+    /// The cursor value comes from the last entry's path in a previous
+    /// listing response. Use it to paginate through large directories.
     pub fn cursor(mut self, cursor: &str) -> Self {
         self.cursor = Some(cursor.to_string());
         self

--- a/pubky-sdk/src/actors/storage/list.rs
+++ b/pubky-sdk/src/actors/storage/list.rs
@@ -138,8 +138,9 @@ impl<'a> ListBuilder<'a> {
 
     /// Resume listing from a previous cursor.
     ///
-    /// The cursor value comes from the last entry's path in a previous
-    /// listing response. Use it to paginate through large directories.
+    /// Pass the last entry's [`to_pubky_url()`](crate::PubkyResource::to_pubky_url)
+    /// from a previous listing response. Use it to paginate through large
+    /// directories.
     pub fn cursor(mut self, cursor: &str) -> Self {
         self.cursor = Some(cursor.to_string());
         self

--- a/pubky-sdk/src/actors/storage/stats.rs
+++ b/pubky-sdk/src/actors/storage/stats.rs
@@ -1,7 +1,23 @@
 use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE, ETAG, HeaderMap, LAST_MODIFIED};
 use std::time::SystemTime;
 
-/// Typed metadata for a stored object (from a `HEAD` request).
+/// Typed metadata for a stored resource, extracted from `HEAD` response headers.
+///
+/// Returned by [`SessionStorage::stats`](crate::SessionStorage::stats) and
+/// [`PublicStorage::stats`](crate::PublicStorage::stats).
+///
+/// # Example
+///
+/// ```no_run
+/// # async fn example(session: pubky::PubkySession) -> pubky::Result<()> {
+/// if let Some(stats) = session.storage().stats("/pub/my.app/photo.jpg").await? {
+///     println!("Content-Type: {:?}", stats.content_type);
+///     println!("Size: {:?} bytes", stats.content_length);
+///     println!("ETag: {:?}", stats.etag);
+///     println!("Last-Modified: {:?}", stats.last_modified);
+/// }
+/// # Ok(()) }
+/// ```
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ResourceStats {
     /// `Content-Length` parsed as `u64`.

--- a/pubky-sdk/src/actors/storage/verbs.rs
+++ b/pubky-sdk/src/actors/storage/verbs.rs
@@ -123,14 +123,18 @@ impl SessionStorage {
 //
 
 impl PublicStorage {
-    /// HTTP `GET` for an **addressed resource** (`pubky<pk>/<abs-path>`, `<pk>/<abs-path>`, or `pubky://…`).
+    /// HTTP `GET` for an **addressed resource** (`pubky://<pk>/<path>`, `pubky<pk>/<path>`, or `(PublicKey, path)` tuple).
     ///
     /// # Examples
     /// ```no_run
-    /// # async fn ex() -> pubky::Result<()> {
+    /// # async fn ex(user: pubky::PublicKey) -> pubky::Result<()> {
     /// let storage = pubky::PublicStorage::new()?;
-    /// let resp = storage.get("{other_pk}/pub/my-cool-app/file.txt").await?;
+    /// let addr = format!("pubky://{}/pub/my-cool-app/file.txt", user.z32());
+    /// let resp = storage.get(addr).await?;
     /// let bytes = resp.bytes().await?;
+    ///
+    /// // Or use a tuple:
+    /// let resp2 = storage.get((&user, "/pub/my-cool-app/file.txt")).await?;
     /// # Ok(()) }
     /// ```
     ///

--- a/pubky-sdk/src/pubky.rs
+++ b/pubky-sdk/src/pubky.rs
@@ -73,10 +73,54 @@ use crate::errors::RequestError;
 #[cfg(not(target_arch = "wasm32"))]
 use std::path::Path;
 
-/// High-level facade. Owns a `PubkyHttpClient` and constructs the main actors.
-/// Prefer to instantiate only once and use trough your application a single shared `Pubky`
-/// instead of constructing one per request. This avoids reinitializing transports and keeps
-/// the same client available for repeated usage.
+/// High-level facade — your entry point to the Pubky SDK.
+///
+/// Create one at startup and share it across your app. It holds the HTTP client
+/// and connection pool, and provides access to everything else: signers, sessions,
+/// public storage, event streams, and PKDNS resolution.
+///
+/// Prefer to instantiate only once and reuse a single shared `Pubky` instead of
+/// constructing one per request. This avoids reinitializing transports and keeps
+/// the same connection pool available for repeated usage.
+///
+/// # Actor overview
+///
+/// ```text
+///   Pubky::new()
+///     ├── .signer(keypair)          → PubkySigner        (signup / signin / approve auth)
+///     │     └── .signin(cid)        → PubkySession        (authenticated handle)
+///     │           └── .storage()    → SessionStorage       (put / get / delete / list)
+///     ├── .public_storage()         → PublicStorage        (read anyone's data, no keys)
+///     ├── .pkdns()                  → Pkdns                (resolve / publish homeserver records)
+///     ├── .event_stream_for_user()  → EventStreamBuilder   (real-time SSE subscriptions)
+///     └── .start_grant_auth_flow()  → PubkyGrantAuthFlow   (QR / deeplink auth)
+/// ```
+///
+/// # Examples
+///
+/// **Sign in with a local key and write data:**
+/// ```no_run
+/// use pubky::{ClientId, Pubky, Keypair};
+///
+/// # async fn run() -> pubky::Result<()> {
+/// let pubky = Pubky::new()?;
+/// let signer = pubky.signer(Keypair::random());
+///
+/// let session = signer.signin(ClientId::new("demo.app").unwrap()).await?;
+/// session.storage().put("/pub/demo.app/hello.txt", "hi").await?;
+/// # Ok(()) }
+/// ```
+///
+/// **Read public data (no identity needed):**
+/// ```no_run
+/// use pubky::Pubky;
+///
+/// # async fn run(user: pubky::PublicKey) -> pubky::Result<()> {
+/// let pubky = Pubky::new()?;
+/// let addr = format!("pubky://{}/pub/pubky.app/profile.json", user.z32());
+/// let body = pubky.public_storage().get(addr).await?.text().await?;
+/// # Ok(()) }
+/// ```
 #[derive(Clone, Debug)]
 pub struct Pubky {
     client: PubkyHttpClient,

--- a/pubky-sdk/src/pubky.rs
+++ b/pubky-sdk/src/pubky.rs
@@ -91,7 +91,7 @@ use std::path::Path;
 ///     │     └── .signin(cid)        → PubkySession        (authenticated handle)
 ///     │           └── .storage()    → SessionStorage       (put / get / delete / list)
 ///     ├── .public_storage()         → PublicStorage        (read anyone's data, no keys)
-///     ├── .pkdns()                  → Pkdns                (resolve / publish homeserver records)
+///     ├── .pkdns()                  → Pkdns                (resolve homeserver records)
 ///     ├── .event_stream_for_user()  → EventStreamBuilder   (real-time SSE subscriptions)
 ///     └── .start_grant_auth_flow()  → PubkyGrantAuthFlow   (QR / deeplink auth)
 /// ```


### PR DESCRIPTION
The in-code docs for the SDK are used directly in docs.rs and now also our JS [typedoc page](https://pubky.github.io/pubky-core/js-sdk-typedoc). I aim here to fit them better for this purpose by:
- Provide user-friendly overviews of high level actors
- Add basic usage examples
- Reduce technical details which are not important for most users