### PR TITLE
chore: v0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1598,7 +1598,7 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "e2e"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -3990,7 +3990,7 @@ checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "pubky"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4022,7 +4022,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-common"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "argon2",
  "base64 0.22.1",
@@ -4042,7 +4042,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-core-examples"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4061,7 +4061,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-homeserver"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "async-dropper",
@@ -4126,7 +4126,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-testnet"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4164,7 +4164,7 @@ dependencies = [
 
 [[package]]
 name = "pubky-wasm"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "base64 0.22.1",
  "console_log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ default-members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.9.3"
+version = "0.10.0"
 rust-version = "1.89"
 edition = "2021"
 authors = [
@@ -55,10 +55,10 @@ log = "0.4"
 pkarr = { version = "7", default-features = false }
 pkarr-relay = { version = "1" }
 percent-encoding = "2"
-pubky = { path = "pubky-sdk", version = "0.9", default-features = false }
-pubky-common = { path = "pubky-common", version = "0.9" }
-pubky-homeserver = { path = "pubky-homeserver", version = "0.9", default-features = false }
-pubky-testnet = { path = "pubky-testnet", version = "0.9" }
+pubky = { path = "pubky-sdk", version = "0.10", default-features = false }
+pubky-common = { path = "pubky-common", version = "0.10" }
+pubky-homeserver = { path = "pubky-homeserver", version = "0.10", default-features = false }
+pubky-testnet = { path = "pubky-testnet", version = "0.10" }
 pubky_test_utils = { path = "test_utils/pubky_test", version = "0.1" }
 rand = "0.10"
 reqwest = { version = "0.13", default-features = false }

--- a/pubky-sdk/bindings/js/pkg/package-lock.json
+++ b/pubky-sdk/bindings/js/pkg/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@synonymdev/pubky",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@synonymdev/pubky",
-      "version": "0.9.3",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "fetch-cookie": "^3.0.1"

--- a/pubky-sdk/bindings/js/pkg/package.json
+++ b/pubky-sdk/bindings/js/pkg/package.json
@@ -2,7 +2,7 @@
   "name": "@synonymdev/pubky",
   "type": "module",
   "description": "Decentralized identity, auth flows, and user-owned storage",
-  "version": "0.9.3",
+  "version": "0.10.0",
   "license": "MIT",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary

### BREAKING CHANGES
- **hs/sdk/common**: Grant-based auth *(PR [#373](https://github.com/pubky/pubky-core/pull/373) by @SeverinAlexB)*
- **sdk**: deeplink refactor *(PR [#392](https://github.com/pubky/pubky-core/pull/392) by @SeverinAlexB)*
- **js-sdk**: Grant auth for the JS SDK *(PR [#405](https://github.com/pubky/pubky-core/pull/405) by @SeverinAlexB)*
- **sdk**: Rename `startAuthFlow` to `startCookieAuthFlow` *(PR [#460](https://github.com/pubky/pubky-core/pull/460) by @SeverinAlexB)*
- **homeserver|sdk**: Signup deeplink authentication *(PR [#482](https://github.com/pubky/pubky-core/pull/482) by @MCarlomagno)*
- **pkarr**: Adapt to the new client API, replacing `PkarrError::Query` with `PkarrError::Resolve` *(PR [#502](https://github.com/pubky/pubky-core/pull/502) by @andrei-21)*
- **common**: Strict capabilities and shared storage paths *(PR [#514](https://github.com/pubky/pubky-core/pull/514) by @SeverinAlexB)*
- **sdk**: Surface errors from `get_homeserver_of` *(PR [#477](https://github.com/pubky/pubky-core/pull/477) by @MCarlomagno)*

### New Features
- **sdk**: Restore grant sessions *(PR [#400](https://github.com/pubky/pubky-core/pull/400) by @SeverinAlexB)*
- Add Docker build pipeline *(PR [#416](https://github.com/pubky/pubky-core/pull/416) by @SpontaneousOverthrow)*
- Add list signup tokens endpoint *(PR [#420](https://github.com/pubky/pubky-core/pull/420) by @MCarlomagno)*
- Allow writes to `/priv` *(PR [#446](https://github.com/pubky/pubky-core/pull/446) by @MCarlomagno)*
- **homeserver**: Authenticated reads and listing authorization for `/priv` *(PR [#448](https://github.com/pubky/pubky-core/pull/448) by @MCarlomagno)*
- Add OpenAPI specification *(PR [#406](https://github.com/pubky/pubky-core/pull/406) by @86667)*
- **homeserver**: Filter private events from the events endpoint *(PR [#454](https://github.com/pubky/pubky-core/pull/454) by @MCarlomagno)*
- **homeserver**: Add private event-stream reads *(PR [#458](https://github.com/pubky/pubky-core/pull/458) by @MCarlomagno)*
- Add init CLI command for generating configuration and secrets *(PR [#467](https://github.com/pubky/pubky-core/pull/467) by @86667)*
- **sdk**: WebCrypto delegated PoP key and browser session store *(PR [#411](https://github.com/pubky/pubky-core/pull/411) by @SeverinAlexB)*
- **testnet**: Add persistent data-directory mode to `StaticTestnet` *(PR [#472](https://github.com/pubky/pubky-core/pull/472) by @86667)*
- Expose `pool_max_idle_per_host` on `PubkyHttpClientBuilder` *(PR [#480](https://github.com/pubky/pubky-core/pull/480) by @tipogi)*
- **homeserver**: Add events admin endpoint *(PR [#463](https://github.com/pubky/pubky-core/pull/463) by @MCarlomagno)*
- **sdk**: Subscribe to private events *(PR [#470](https://github.com/pubky/pubky-core/pull/470) by @MCarlomagno)*
- **homeserver**: Skip PKARR republishing for migrated users *(PR [#515](https://github.com/pubky/pubky-core/pull/515) by @andrei-21)*
- Set up TypeDoc *(PR [#523](https://github.com/pubky/pubky-core/pull/523) by @86667)*
- **sdk**: Add support for callback parameters *(PR [#533](https://github.com/pubky/pubky-core/pull/533) by @MCarlomagno)*

### Bug Fixes
- **release**: Allow hotfix releases *(PR [#453](https://github.com/pubky/pubky-core/pull/453) by @86667)*
- Handle path collisions *(PR [#424](https://github.com/pubky/pubky-core/pull/424) by @MCarlomagno)*
- **homeserver**: Reject directory paths on writes *(PR [#445](https://github.com/pubky/pubky-core/pull/445) by @andrei-21)*
- Repair Docker build pipeline *(PR [#466](https://github.com/pubky/pubky-core/pull/466) by @SpontaneousOverthrow)*
- Repair build-artifacts script *(PR [#485](https://github.com/pubky/pubky-core/pull/485) by @SpontaneousOverthrow)*
- Correct cache policy for private events *(PR [#494](https://github.com/pubky/pubky-core/pull/494) by @MCarlomagno)*
- **homeserver**: Split OpenAPI specification into client and admin APIs *(PR [#507](https://github.com/pubky/pubky-core/pull/507) by @MCarlomagno)*
- **homeserver**: Republish the latest known PKARR packet *(PR [#509](https://github.com/pubky/pubky-core/pull/509) by @andrei-21)*
- **homeserver**: Close private event streams on session revocation *(PR [#501](https://github.com/pubky/pubky-core/pull/501) by @MCarlomagno)*
- **homeserver**: Consolidate stateful OpenDAL layers *(PR [#510](https://github.com/pubky/pubky-core/pull/510) by @MCarlomagno)*

### Refactors
- **sdk**: Extract grant management into `GrantManager` *(PR [#412](https://github.com/pubky/pubky-core/pull/412) by @SeverinAlexB)*
- **homeserver**: Simplify republisher internals *(PR [#481](https://github.com/pubky/pubky-core/pull/481) by @andrei-21)*
- Resolve workspace Clippy warnings *(PR [#489](https://github.com/pubky/pubky-core/pull/489) by @andrei-21)*
- **homeserver**: Simplify concurrent PKARR republishing *(PR [#488](https://github.com/pubky/pubky-core/pull/488) by @andrei-21)*
- **homeserver**: Move PKARR retries into a dedicated republisher *(PR [#495](https://github.com/pubky/pubky-core/pull/495) by @andrei-21)*
- **homeserver**: Restructure PKARR republishing *(PR [#498](https://github.com/pubky/pubky-core/pull/498) by @andrei-21)*
- **homeserver**: Move auth revocation into `AuthState` *(PR [#518](https://github.com/pubky/pubky-core/pull/518) by @86667)*

### Tests
- **homeserver**: Add E2E coverage for private data *(PR [#474](https://github.com/pubky/pubky-core/pull/474) by @MCarlomagno)*
- **homeserver**: Prevent PKARR clients from using default relays *(PR [#517](https://github.com/pubky/pubky-core/pull/517) by @andrei-21)*

### Build System
- **homeserver**: Set the default run binary to `pubky-homeserver` *(PR [#452](https://github.com/pubky/pubky-core/pull/452) by @andrei-21)*
- Add Context7 refresh workflow *(PR [#462](https://github.com/pubky/pubky-core/pull/462) by @gcomte)*
- Cache npm dependencies *(PR [#499](https://github.com/pubky/pubky-core/pull/499) by @ok300)*
- Change Dependabot’s Rust interval to weekly *(PR [#511](https://github.com/pubky/pubky-core/pull/511) by @ok300)*
- Use Rust cache in the build-artifacts workflow *(PR [#512](https://github.com/pubky/pubky-core/pull/512) by @ok300)*
- **deps-dev**: Update `@xmldom/xmldom` *(PR [#516](https://github.com/pubky/pubky-core/pull/516) by @dependabot[bot])*
- Use `dtolnay/rust-toolchain` for faster Rust setup *(PR [#513](https://github.com/pubky/pubky-core/pull/513) by @ok300)*

### Documentation Changes
- Fix Rustdoc links *(PR [#447](https://github.com/pubky/pubky-core/pull/447) by @andrei-21)*
- Add DeepWiki badge *(PR [#450](https://github.com/pubky/pubky-core/pull/450) by @ok300)*
- **testnet**: Gate Docker Postgres doctest by feature *(PR [#461](https://github.com/pubky/pubky-core/pull/461) by @andrei-21)*
- **homeserver**: Improve developer documentation and READMEs *(PR [#431](https://github.com/pubky/pubky-core/pull/431) by @SeverinAlexB)*
- **examples**: Add grant-auth examples and reorganize existing examples *(PR [#487](https://github.com/pubky/pubky-core/pull/487) by @SeverinAlexB)*
- **homeserver**: Add deployment guide *(PR [#503](https://github.com/pubky/pubky-core/pull/503) by @86667)*
- Remove the legacy mdBook site *(PR [#508](https://github.com/pubky/pubky-core/pull/508) by @andrei-21)*
- **testnet**: Prioritize persisted static-testnet setup instructions *(PR [#521](https://github.com/pubky/pubky-core/pull/521) by @86667)*
- **hs/sdk**: Add private-storage documentation *(PR [#505](https://github.com/pubky/pubky-core/pull/505) by @MCarlomagno)*
- **sdk**: Make in-code documentation more user-friendly *(PR [#537](https://github.com/pubky/pubky-core/pull/537) by @86667)*

### Chores
- Update the Cargo dependency group *(PR [#396](https://github.com/pubky/pubky-core/pull/396) by @dependabot[bot])*
- **deps**: Remove the nested WASM lockfile *(PR [#415](https://github.com/pubky/pubky-core/pull/415) by @andrei-21)*
- **deps**: Separate library dependency ranges *(PR [#414](https://github.com/pubky/pubky-core/pull/414) by @andrei-21)*
- **cargo**: Centralize workspace manifest metadata *(PR [#417](https://github.com/pubky/pubky-core/pull/417) by @andrei-21)*
- **deps**: Remove unused crate dependencies *(PR [#455](https://github.com/pubky/pubky-core/pull/455) by @andrei-21)*
- Make the npm workflow respect prerelease tags *(PR [#465](https://github.com/pubky/pubky-core/pull/465) by @SeverinAlexB)*
- Improve cookie `AuthFlow` documentation *(PR [#367](https://github.com/pubky/pubky-core/pull/367) by @tipogi)*
- **deps**: Update `serde_valid` to 2.0.3 *(PR [#490](https://github.com/pubky/pubky-core/pull/490) by @andrei-21)*
- Bind the testnet HTTP relay to all addresses *(PR [#497](https://github.com/pubky/pubky-core/pull/497) by @ok300)*
- Update the Cargo dependency group *(PR [#491](https://github.com/pubky/pubky-core/pull/491) by @dependabot[bot])*
- **sdk**: Add the v0.10 migration guide *(PR [#493](https://github.com/pubky/pubky-core/pull/493) by @SeverinAlexB)*

**Full Changelog**: https://github.com/pubky/pubky-core/compare/v0.9.3...chore/v0.10.0